### PR TITLE
Add meta["abstract"]

### DIFF
--- a/docs/cstatements.rst
+++ b/docs/cstatements.rst
@@ -324,6 +324,12 @@ These headers may include C++ code.
 
 .. listed in fc_statements as *c_impl_header* and *cxx_impl_header*
 
+destructor_header
+^^^^^^^^^^^^^^^^^
+
+A list of header files which will be added to the C++ utility file.
+These headers may include C++ code.
+
 destructor_name
 ^^^^^^^^^^^^^^^
 

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -79,6 +79,7 @@
                                         "typemap_name": "ArrayWrapper"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -131,6 +132,7 @@
                                         "typemap_name": "ArrayWrapper"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -161,6 +163,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_shadow"
@@ -169,6 +172,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -245,6 +249,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -274,6 +279,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -299,6 +305,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -337,6 +344,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -349,6 +357,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -372,6 +381,7 @@
                                         "value_var": "SHValue_size"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -381,11 +391,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "size": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -471,6 +483,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -521,6 +534,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -544,6 +558,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_native"
@@ -552,6 +567,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -638,6 +654,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -666,6 +683,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "out"
                                     },
                                     "stmt": "c_out_native&"
@@ -690,6 +708,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -727,6 +746,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "out"
                                     },
                                     "stmt": "f_out_native&"
@@ -738,6 +758,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -762,6 +783,7 @@
                                         "value_var": "SHValue_size"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "out"
                                     },
                                     "stmt": "py_out_native&"
@@ -770,11 +792,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "size": {
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "out"
                                     }
                                 }
@@ -841,6 +865,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -864,6 +889,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -875,6 +901,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -883,6 +910,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -996,6 +1024,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1066,6 +1095,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -1104,6 +1134,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1119,6 +1150,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1243,6 +1275,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1313,6 +1346,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -1351,6 +1385,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1366,6 +1401,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1489,6 +1525,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1559,6 +1596,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -1597,6 +1635,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1612,6 +1651,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1737,6 +1777,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1807,6 +1848,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -1845,6 +1887,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1860,6 +1903,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "args": [],
@@ -1986,6 +2030,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -2028,6 +2073,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native**",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2070,6 +2116,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_native*"
@@ -2095,6 +2142,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -2148,6 +2196,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native**",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -2192,6 +2241,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -2204,6 +2254,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -2233,6 +2284,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "native**",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2263,6 +2315,7 @@
                                         "value_var": "SHValue_isize"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -2272,11 +2325,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "native**",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2288,6 +2343,7 @@
                                 },
                                 "isize": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "inout"
                                     }
                                 }
@@ -2406,6 +2462,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -2448,6 +2505,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*&",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2490,6 +2548,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_native&"
@@ -2515,6 +2574,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -2568,6 +2628,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*&",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -2612,6 +2673,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -2624,6 +2686,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -2653,6 +2716,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "native*&",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2683,6 +2747,7 @@
                                         "value_var": "SHValue_isize"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -2692,11 +2757,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "native*&",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2708,6 +2775,7 @@
                                 },
                                 "isize": {
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "inout"
                                     }
                                 }
@@ -2827,6 +2895,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -2869,6 +2938,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native**",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -2911,6 +2981,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_native*"
@@ -2936,6 +3007,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -2989,6 +3061,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native**",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -3033,6 +3106,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -3045,6 +3119,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -3074,6 +3149,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "native**",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -3104,6 +3180,7 @@
                                         "value_var": "SHValue_isize"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -3113,11 +3190,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "native**",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -3129,6 +3208,7 @@
                                 },
                                 "isize": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "inout"
                                     }
                                 }
@@ -3248,6 +3328,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -3290,6 +3371,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*&",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -3332,6 +3414,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_native&"
@@ -3357,6 +3440,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -3410,6 +3494,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native*&",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -3454,6 +3539,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -3466,6 +3552,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -3495,6 +3582,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "native*&",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -3525,6 +3613,7 @@
                                         "value_var": "SHValue_isize"
                                     },
                                     "meta": {
+                                        "abstract": "native&",
                                         "hidden": true,
                                         "intent": "inout"
                                     },
@@ -3534,11 +3623,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "native*&",
                                         "dim_ast": [
                                             {
                                                 "name": "isize"
@@ -3550,6 +3641,7 @@
                                 },
                                 "isize": {
                                     "meta": {
+                                        "abstract": "native&",
                                         "intent": "inout"
                                     }
                                 }
@@ -3639,6 +3731,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -3667,6 +3760,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void**",
                                         "intent": "out"
                                     },
                                     "stmt": "c_out_void**"
@@ -3691,6 +3785,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -3728,6 +3823,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void**",
                                         "intent": "out"
                                     },
                                     "stmt": "f_out_void**"
@@ -3739,6 +3835,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -3763,6 +3860,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "void**",
                                         "intent": "out"
                                     },
                                     "stmt": "py_out_void**"
@@ -3771,11 +3869,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "void**",
                                         "intent": "out"
                                     }
                                 }
@@ -3865,6 +3965,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -3893,6 +3994,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void*&",
                                         "intent": "out"
                                     },
                                     "stmt": "c_out_void*&"
@@ -3917,6 +4019,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -3954,6 +4057,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void*&",
                                         "intent": "out"
                                     },
                                     "stmt": "f_out_void*&"
@@ -3965,6 +4069,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -3989,6 +4094,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "void*&",
                                         "intent": "out"
                                     },
                                     "stmt": "py_out_void*&"
@@ -3997,11 +4103,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "void*&",
                                         "intent": "out"
                                     }
                                 }
@@ -4098,6 +4206,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_bool"
@@ -4127,6 +4236,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void*",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -4176,6 +4286,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_bool"
@@ -4214,6 +4325,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void*",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -4239,6 +4351,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_bool"
@@ -4264,6 +4377,7 @@
                                         "value_var": "SHValue_array"
                                     },
                                     "meta": {
+                                        "abstract": "void*",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -4273,11 +4387,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     }
                                 },
                                 "array": {
                                     "meta": {
+                                        "abstract": "void*",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -4364,6 +4480,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -4413,6 +4530,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -4436,6 +4554,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_native"
@@ -4444,6 +4563,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }

--- a/regression/reference/ccomplex/ccomplex.json
+++ b/regression/reference/ccomplex/ccomplex.json
@@ -72,6 +72,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -109,6 +110,7 @@
                                 "typemap_name": "float_complex"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -117,11 +119,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -194,6 +198,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -231,6 +236,7 @@
                                 "typemap_name": "double_complex"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -242,6 +248,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -269,6 +276,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -277,11 +285,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -374,6 +384,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -411,6 +422,7 @@
                                 "typemap_name": "double_complex"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -422,6 +434,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -448,6 +461,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -456,11 +470,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -555,6 +571,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -582,6 +599,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -606,6 +624,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -614,16 +633,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -735,6 +757,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -772,6 +795,7 @@
                                 "typemap_name": "double_complex"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -809,6 +833,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -820,6 +845,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -846,6 +872,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -870,6 +897,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -878,16 +906,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -80,6 +80,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -121,6 +122,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -147,6 +149,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -195,6 +198,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "intent": "in",
                                 "rank": 2
@@ -205,11 +209,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
@@ -427,6 +433,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -464,6 +471,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -503,6 +511,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "rank": 0,
                                 "value": true
@@ -513,16 +522,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "rank": 0,
                                 "value": true
@@ -660,6 +672,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -702,6 +715,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -748,6 +762,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 0
@@ -758,16 +773,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out",
                                 "rank": 0
                             }
@@ -908,6 +926,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -950,6 +969,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -996,6 +1016,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 0
@@ -1006,16 +1027,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out",
                                 "rank": 0
                             }
@@ -1092,6 +1116,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "function"
                             }
                         }
@@ -1190,6 +1215,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1238,6 +1264,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1246,6 +1273,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1353,6 +1381,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1401,6 +1430,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1409,6 +1439,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1599,16 +1630,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "out",
                                 "value": true
                             }
@@ -1730,6 +1764,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1772,6 +1807,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -1810,6 +1846,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -1818,16 +1855,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1953,6 +1993,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1995,6 +2036,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -2033,6 +2075,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2041,16 +2084,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -171,6 +171,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -223,6 +224,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -240,6 +242,7 @@
                                         "stmt": "lua_ctor"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -268,6 +271,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_shadow"
@@ -276,6 +280,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -405,6 +410,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -443,6 +449,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -496,6 +503,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -535,6 +543,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -552,6 +561,7 @@
                                         "stmt": "lua_ctor"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 },
@@ -570,6 +580,7 @@
                                         "stmt": "lua_in_native"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -599,6 +610,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_shadow"
@@ -622,6 +634,7 @@
                                         "value_var": "SHValue_flag"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -631,11 +644,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -713,6 +728,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "c_dtor"
@@ -736,6 +752,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "f_dtor"
@@ -747,6 +764,7 @@
                                         "stmt": "lua_dtor"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -754,6 +772,7 @@
                             "py": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -761,6 +780,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -848,6 +868,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -897,6 +918,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -914,6 +936,7 @@
                                         "stmt": "lua_function_native"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -936,6 +959,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_native"
@@ -944,6 +968,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -1058,6 +1083,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_bool"
@@ -1087,6 +1113,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "in"
                                     },
                                     "stmt": "c_in_shadow&"
@@ -1136,6 +1163,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_bool"
@@ -1177,6 +1205,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "in"
                                     },
                                     "stmt": "f_in_shadow&"
@@ -1185,11 +1214,13 @@
                             "lua": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     }
                                 },
                                 "obj2": {
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "in"
                                     }
                                 }
@@ -1213,6 +1244,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_bool"
@@ -1241,6 +1273,7 @@
                                         "value_var": "SHValue_obj2"
                                     },
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "in"
                                     },
                                     "stmt": "py_in_shadow&"
@@ -1249,11 +1282,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "function"
                                     }
                                 },
                                 "obj2": {
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "in"
                                     }
                                 }
@@ -1351,6 +1386,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -1402,6 +1438,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -1411,6 +1448,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 }
@@ -1541,6 +1579,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "capptr",
                                         "intent": "function"
                                     },
@@ -1577,6 +1616,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1615,6 +1655,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "in"
                                     },
                                     "stmt": "c_in_string&"
@@ -1670,6 +1711,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "capsule",
                                         "intent": "function"
                                     },
@@ -1708,6 +1750,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1751,6 +1794,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "api": "buf",
                                         "intent": "in"
                                     },
@@ -1760,17 +1804,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "in"
                                     }
                                 }
@@ -1867,6 +1914,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "capptr",
                                         "intent": "function"
                                     },
@@ -1922,6 +1970,7 @@
                                         "typemap_name": "classes::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "capsule",
                                         "intent": "function"
                                     },
@@ -1931,6 +1980,7 @@
                             "lua": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 }
@@ -1957,6 +2007,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_shadow*"
@@ -1965,6 +2016,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 }
@@ -2080,6 +2132,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_string&"
@@ -2142,6 +2195,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "api": "cdesc",
                                         "deref": "allocatable",
                                         "intent": "function"
@@ -2162,6 +2216,7 @@
                                         "stmt": "lua_function_string&"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     }
                                 }
@@ -2185,6 +2240,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_string&"
@@ -2193,6 +2249,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     }
                                 }
@@ -2312,6 +2369,7 @@
                                         "typemap_name": "classes::Class1::DIRECTION"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_enum"
@@ -2350,6 +2408,7 @@
                                         "typemap_name": "classes::Class1::DIRECTION"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2405,6 +2464,7 @@
                                         "typemap_name": "classes::Class1::DIRECTION"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_enum"
@@ -2444,6 +2504,7 @@
                                         "typemap_name": "classes::Class1::DIRECTION"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2463,6 +2524,7 @@
                                         "stmt": "lua_function_enum"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "function"
                                     }
                                 },
@@ -2482,6 +2544,7 @@
                                         "stmt": "lua_in_enum"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2505,6 +2568,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_enum"
@@ -2529,6 +2593,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2538,11 +2603,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "function"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "enum",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2666,6 +2733,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -2674,6 +2742,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2770,6 +2839,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -2778,6 +2848,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2865,6 +2936,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -2903,6 +2975,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -2912,11 +2985,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -3012,6 +3087,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_bool"
@@ -3020,6 +3096,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "getter"
                                     }
                                 }
@@ -3107,6 +3184,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -3144,6 +3222,7 @@
                                         "typemap_name": "bool"
                                     },
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -3153,11 +3232,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "bool",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -3273,6 +3354,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string",
                                         "api": "cdesc",
                                         "deref": "allocatable",
                                         "intent": "getter"
@@ -3283,6 +3365,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "string",
                                         "intent": "getter"
                                     }
                                 }
@@ -3370,6 +3453,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -3409,6 +3493,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string",
                                         "api": "buf",
                                         "intent": "setter"
                                     },
@@ -3418,11 +3503,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "string",
                                         "intent": "setter"
                                     }
                                 }
@@ -3717,6 +3804,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_string&"
@@ -3779,6 +3867,7 @@
                                         "typemap_name": "std::string"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "api": "cdesc",
                                         "deref": "allocatable",
                                         "intent": "function"
@@ -3799,6 +3888,7 @@
                                         "stmt": "lua_function_string&"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     }
                                 }
@@ -3822,6 +3912,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_string&"
@@ -3830,6 +3921,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "string&",
                                         "intent": "function"
                                     }
                                 }
@@ -3997,6 +4089,7 @@
                                         "typemap_name": "classes::Singleton"
                                     },
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "api": "capptr",
                                         "intent": "function"
                                     },
@@ -4052,6 +4145,7 @@
                                         "typemap_name": "classes::Singleton"
                                     },
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "api": "capsule",
                                         "intent": "function"
                                     },
@@ -4061,6 +4155,7 @@
                             "lua": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "function"
                                     }
                                 }
@@ -4087,6 +4182,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_shadow&"
@@ -4095,6 +4191,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow&",
                                         "intent": "function"
                                     }
                                 }
@@ -4251,6 +4348,7 @@
                                         "typemap_name": "classes::Shape"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -4303,6 +4401,7 @@
                                         "typemap_name": "classes::Shape"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -4320,6 +4419,7 @@
                                         "stmt": "lua_ctor"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -4348,6 +4448,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_shadow"
@@ -4356,6 +4457,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -4445,6 +4547,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -4495,6 +4598,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -4512,6 +4616,7 @@
                                         "stmt": "lua_function_native"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -4534,6 +4639,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_native"
@@ -4542,6 +4648,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -4712,6 +4819,7 @@
                                         "typemap_name": "classes::Circle"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -4764,6 +4872,7 @@
                                         "typemap_name": "classes::Circle"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -4781,6 +4890,7 @@
                                         "stmt": "lua_ctor"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -4809,6 +4919,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_shadow"
@@ -4817,6 +4928,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -4954,6 +5066,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -4983,6 +5096,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -5008,6 +5122,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -5046,6 +5161,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -5055,11 +5171,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "n": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -5113,6 +5231,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -5136,6 +5255,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -5144,6 +5264,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -5231,6 +5352,7 @@
                                         "typemap_name": "classes::Data"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -5283,6 +5405,7 @@
                                         "typemap_name": "classes::Data"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -5292,6 +5415,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -5342,6 +5466,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "c_dtor"
@@ -5365,6 +5490,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "f_dtor"
@@ -5373,6 +5499,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -5466,6 +5593,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -5474,6 +5602,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -5561,6 +5690,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -5599,6 +5729,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -5608,11 +5739,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -5739,6 +5872,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -5755,6 +5889,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -5854,6 +5989,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -5896,6 +6032,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "setter",
                                         "rank": 1
                                     },
@@ -5905,11 +6042,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "setter",
                                         "rank": 1
                                     }
@@ -6137,6 +6276,7 @@
                                 "typemap_name": "classes::Class1::DIRECTION"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -6175,6 +6315,7 @@
                                 "typemap_name": "classes::Class1::DIRECTION"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6230,6 +6371,7 @@
                                 "typemap_name": "classes::Class1::DIRECTION"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -6269,6 +6411,7 @@
                                 "typemap_name": "classes::Class1::DIRECTION"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6288,6 +6431,7 @@
                                 "stmt": "lua_function_enum"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
@@ -6307,6 +6451,7 @@
                                 "stmt": "lua_in_enum"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6330,6 +6475,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -6354,6 +6500,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6363,11 +6510,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6462,6 +6611,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6492,6 +6642,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6517,6 +6668,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6559,6 +6711,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6568,11 +6721,13 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6584,6 +6739,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -6611,6 +6767,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "shadow",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6620,11 +6777,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6724,6 +6883,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -6753,6 +6913,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_shadow*"
@@ -6803,6 +6964,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6844,6 +7006,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_shadow*"
@@ -6852,11 +7015,13 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -6879,6 +7044,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -6907,6 +7073,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_shadow*"
@@ -6915,11 +7082,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -7029,6 +7198,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -7084,6 +7254,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7093,6 +7264,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -7184,6 +7356,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -7239,6 +7412,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7248,6 +7422,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -7274,6 +7449,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_shadow*"
@@ -7282,6 +7458,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -7371,6 +7548,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7425,6 +7603,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7434,6 +7613,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -7509,6 +7689,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7563,6 +7744,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7572,6 +7754,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -7661,6 +7844,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow&",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -7716,6 +7900,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow&",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7725,6 +7910,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow&",
                                 "intent": "function"
                             }
                         }
@@ -7813,6 +7999,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow&",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -7868,6 +8055,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow&",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7877,6 +8065,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow&",
                                 "intent": "function"
                             }
                         }
@@ -7903,6 +8092,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "shadow&",
                                 "intent": "function"
                             },
                             "stmt": "py_function_shadow&"
@@ -7911,6 +8101,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow&",
                                 "intent": "function"
                             }
                         }
@@ -8022,6 +8213,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -8060,6 +8252,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8116,6 +8309,7 @@
                                 "typemap_name": "classes::Class1"
                             },
                             "meta": {
+                                "abstract": "shadow",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -8155,6 +8349,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8164,11 +8359,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8232,6 +8429,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8261,6 +8459,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8286,6 +8485,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8324,6 +8524,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8336,6 +8537,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -8354,6 +8556,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8365,6 +8568,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -8388,6 +8592,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8397,11 +8602,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8490,6 +8697,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -8538,6 +8746,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -8555,6 +8764,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -8577,6 +8787,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -8585,6 +8796,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -8699,6 +8911,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -8755,6 +8968,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -8776,6 +8990,7 @@
                                 "stmt": "lua_function_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }
@@ -8800,6 +9015,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -8809,6 +9025,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -128,6 +128,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -139,6 +140,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -147,6 +149,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -262,6 +265,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -300,6 +304,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -339,6 +344,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -363,6 +369,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -386,6 +393,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -410,6 +418,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -419,17 +428,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -542,6 +554,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -579,6 +592,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -616,6 +630,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -627,6 +642,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -651,6 +667,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_native*"
@@ -675,6 +692,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -683,16 +701,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -808,6 +829,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -846,6 +868,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -870,6 +893,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -893,6 +917,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -902,11 +927,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1033,6 +1060,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1070,6 +1098,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1107,6 +1136,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_bool*"
@@ -1143,6 +1173,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_bool*"
@@ -1154,6 +1185,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1179,6 +1211,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1205,6 +1238,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "bool*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_bool*"
@@ -1231,6 +1265,7 @@
                                 "value_var": "SHValue_arg3"
                             },
                             "meta": {
+                                "abstract": "bool*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_bool*"
@@ -1239,22 +1274,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "bool*",
                                 "intent": "out"
                             }
                         },
                         "arg3": {
                             "meta": {
+                                "abstract": "bool*",
                                 "intent": "inout"
                             }
                         }
@@ -1406,6 +1445,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -1445,6 +1485,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1482,6 +1523,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1507,6 +1549,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -1532,6 +1575,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -1556,6 +1600,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -1564,17 +1609,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1666,6 +1714,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1702,6 +1751,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1714,6 +1764,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1738,6 +1789,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -1746,11 +1798,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1853,6 +1907,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1897,6 +1952,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -1909,6 +1965,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1933,6 +1990,7 @@
                                 "value_var": "SHValue_s"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_char*"
@@ -1941,11 +1999,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "s": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             }
                         }
@@ -2072,6 +2132,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2108,6 +2169,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "inout"
                             },
@@ -2147,6 +2209,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2184,6 +2247,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "out"
                             },
@@ -2193,22 +2257,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             }
                         },
                         "n": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         }
@@ -2296,6 +2364,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2336,6 +2405,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -2348,6 +2418,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2373,6 +2444,7 @@
                                 "value_var": "SHValue_name1"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2381,11 +2453,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name1": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "MAXNAME",
                                 "intent": "out"
                             }
@@ -2503,6 +2577,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2543,6 +2618,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -2584,6 +2660,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -2596,6 +2673,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2621,6 +2699,7 @@
                                 "value_var": "SHValue_name1"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2646,6 +2725,7 @@
                                 "value_var": "SHValue_name2"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2654,17 +2734,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name1": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "MAXNAME",
                                 "intent": "out"
                             }
                         },
                         "name2": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "MAXNAME",
                                 "intent": "out"
                             }
@@ -2778,6 +2861,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2817,6 +2901,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2858,6 +2943,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -2870,6 +2956,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2894,6 +2981,7 @@
                                 "value_var": "SHValue_ltext"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "len(text)",
                                 "intent": "in",
                                 "value": true
@@ -2921,6 +3009,7 @@
                                 "value_var": "SHValue_text"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2929,17 +3018,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "ltext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "text": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "MAXNAME",
                                 "intent": "out"
                             }
@@ -3084,6 +3176,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3122,6 +3215,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3162,6 +3256,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3199,6 +3294,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "in"
                             },
@@ -3223,6 +3319,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3248,6 +3345,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "implied": "false",
                                 "intent": "in",
                                 "value": true
@@ -3274,6 +3372,7 @@
                                 "value_var": "SHValue_ltext"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "len(text)",
                                 "intent": "in",
                                 "value": true
@@ -3300,6 +3399,7 @@
                                 "value_var": "SHValue_text"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -3308,23 +3408,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ltext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "text": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -3473,6 +3577,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3511,6 +3616,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3551,6 +3657,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3588,6 +3695,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "in"
                             },
@@ -3612,6 +3720,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3637,6 +3746,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "implied": "true",
                                 "intent": "in",
                                 "value": true
@@ -3663,6 +3773,7 @@
                                 "value_var": "SHValue_ltext"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "len_trim(text)",
                                 "intent": "in",
                                 "value": true
@@ -3689,6 +3800,7 @@
                                 "value_var": "SHValue_text"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -3697,23 +3809,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ltext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "text": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -3827,6 +3943,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -3865,6 +3982,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3890,6 +4008,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "py_function_bool"
@@ -3915,6 +4034,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "implied": "true",
                                 "intent": "in",
                                 "value": true
@@ -3925,11 +4045,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4040,6 +4162,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -4078,6 +4201,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4103,6 +4227,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "py_function_bool"
@@ -4128,6 +4253,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "implied": "false",
                                 "intent": "in",
                                 "value": true
@@ -4138,11 +4264,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4219,6 +4347,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4227,6 +4356,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -4316,6 +4446,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4356,6 +4487,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -4365,11 +4497,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         }
@@ -4471,6 +4605,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4509,6 +4644,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4547,6 +4683,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -4555,17 +4692,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -4672,6 +4812,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4709,6 +4850,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             },
@@ -4718,11 +4860,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             }
@@ -4804,6 +4948,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4846,6 +4991,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in",
                                 "rank": 1
@@ -4856,11 +5002,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in",
                                 "rank": 1
@@ -4992,6 +5140,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5029,6 +5178,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             },
@@ -5070,6 +5220,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -5079,17 +5230,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         }
@@ -5231,6 +5385,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5270,6 +5425,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "alloc  None ****************************************",
                                     "ast": {
@@ -5328,6 +5484,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5351,6 +5508,7 @@
                                                     "typemap_name": "array_info"
                                                 },
                                                 "meta": {
+                                                    "abstract": "struct*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_struct*"
@@ -5374,6 +5532,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -5383,16 +5542,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "struct*",
                                                     "intent": "inout"
                                                 }
                                             },
                                             "tc": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -5444,6 +5606,7 @@
                                 "typemap_name": "array_info"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -5482,6 +5645,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5491,11 +5655,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "alloc": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "alloc  None ****************************************",
                                     "ast": {
@@ -5554,6 +5720,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5577,6 +5744,7 @@
                                                     "typemap_name": "array_info"
                                                 },
                                                 "meta": {
+                                                    "abstract": "struct*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_struct*"
@@ -5600,6 +5768,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -5609,16 +5778,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "struct*",
                                                     "intent": "inout"
                                                 }
                                             },
                                             "tc": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -5637,11 +5809,13 @@
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "tc": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -91,6 +91,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -116,6 +117,7 @@
                                         "value_var": "SHValue_dfield"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -142,6 +144,7 @@
                                         "value_var": "SHValue_ifield"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -151,17 +154,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dfield": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -631,6 +637,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -683,6 +690,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -692,6 +700,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -762,6 +771,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -811,6 +821,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -819,6 +830,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -958,6 +970,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -995,6 +1008,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1004,11 +1018,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 },
                                 "length": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1118,6 +1134,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -1155,6 +1172,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1164,11 +1182,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 },
                                 "length": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1281,6 +1301,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -1318,6 +1339,7 @@
                                         "typemap_name": "long"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1327,11 +1349,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 },
                                 "length": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1424,6 +1448,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -1454,6 +1479,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1506,6 +1532,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -1545,6 +1572,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1554,11 +1582,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1734,6 +1764,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -1772,6 +1803,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1810,6 +1842,7 @@
                                         "typemap_name": "LengthType"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1819,17 +1852,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "length": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1944,6 +1980,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -1982,6 +2019,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2020,6 +2058,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2029,17 +2068,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "length": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2157,6 +2199,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "api": "this",
                                         "intent": "function"
                                     },
@@ -2195,6 +2238,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2233,6 +2277,7 @@
                                         "typemap_name": "long"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2242,17 +2287,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "function"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "length": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2348,6 +2396,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -2356,6 +2405,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2509,6 +2559,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2538,6 +2589,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct&_class"
@@ -2546,11 +2598,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "inout"
                             }
                         }
@@ -2639,6 +2693,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2668,6 +2723,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct&_class"
@@ -2676,11 +2732,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "in"
                             }
                         }
@@ -2755,6 +2813,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2784,6 +2843,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct&_class"
@@ -2792,11 +2852,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "inout"
                             }
                         }
@@ -2871,6 +2933,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2899,6 +2962,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_struct&_class"
@@ -2907,11 +2971,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct&",
                                 "intent": "out"
                             }
                         }
@@ -2988,6 +3054,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "c_function_bool"
@@ -3034,6 +3101,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -3042,6 +3110,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         }
@@ -3136,6 +3205,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "c_function_bool"
@@ -3164,6 +3234,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3213,6 +3284,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -3255,6 +3327,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3280,6 +3353,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "py_function_bool"
@@ -3305,6 +3379,7 @@
                                 "value_var": "SHValue_data"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3314,11 +3389,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "data": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -3441,6 +3518,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3470,6 +3548,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3499,6 +3578,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3527,6 +3607,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3551,6 +3632,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3589,6 +3671,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3627,6 +3710,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -3664,6 +3748,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -3672,22 +3757,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "out1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "out2": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3806,6 +3895,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3835,6 +3925,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3865,6 +3956,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3894,6 +3986,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3922,6 +4015,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3946,6 +4040,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3983,6 +4078,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4022,6 +4118,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4060,6 +4157,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -4097,6 +4195,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -4108,6 +4207,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4133,6 +4233,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4157,6 +4258,7 @@
                                 "value_var": "SHValue_in1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4182,6 +4284,7 @@
                                 "value_var": "SHValue_out1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -4206,6 +4309,7 @@
                                 "value_var": "SHValue_out2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -4214,28 +4318,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "in1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "out1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "out2": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4396,6 +4505,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -4434,6 +4544,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4443,12 +4554,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }
                         },
                         "idx": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4571,6 +4684,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -4612,6 +4726,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4621,12 +4736,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }
                         },
                         "idx": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4753,6 +4870,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -4794,6 +4912,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4803,12 +4922,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }
                         },
                         "idx": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4940,6 +5061,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "getter"
@@ -4980,6 +5102,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -4988,11 +5111,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "getter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -5096,6 +5221,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -5134,6 +5260,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -5172,6 +5299,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter_struct*"
@@ -5180,16 +5308,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "setter"
                             }
                         }
@@ -5336,6 +5467,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct**",
                                 "api": "cdesc",
                                 "deref": "raw",
                                 "dim_ast": [
@@ -5382,6 +5514,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -5390,6 +5523,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct**",
                                 "dim_ast": [
                                     {
                                         "name": "sublevels"
@@ -5401,6 +5535,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -5508,6 +5643,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -5546,6 +5682,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -5589,6 +5726,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct**",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -5598,16 +5736,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "struct**",
                                 "intent": "setter",
                                 "rank": 1
                             }
@@ -5752,6 +5893,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5798,6 +5940,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -5806,6 +5949,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "name": "sublevels"
@@ -5817,6 +5961,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -5921,6 +6066,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -5959,6 +6105,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -6002,6 +6149,7 @@
                                 "typemap_name": "nested"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -6011,16 +6159,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "setter",
                                 "rank": 1
                             }
@@ -6229,6 +6380,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -6257,6 +6409,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_struct&"
@@ -6307,6 +6460,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -6345,6 +6499,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     },
                                     "stmt": "f_inout_struct&"
@@ -6368,6 +6523,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_native"
@@ -6397,6 +6553,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     },
                                     "stmt": "py_inout_struct&_numpy"
@@ -6405,11 +6562,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     }
                                 }
@@ -6511,6 +6670,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -6539,6 +6699,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "in"
                                     },
                                     "stmt": "c_in_struct&"
@@ -6589,6 +6750,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -6627,6 +6789,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "in"
                                     },
                                     "stmt": "f_in_struct&"
@@ -6650,6 +6813,7 @@
                                         "value_var": "SHValue_rv"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "py_function_native"
@@ -6679,6 +6843,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "in"
                                     },
                                     "stmt": "py_in_struct&_numpy"
@@ -6687,11 +6852,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "in"
                                     }
                                 }
@@ -6778,6 +6945,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -6806,6 +6974,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_struct&"
@@ -6830,6 +6999,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -6868,6 +7038,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     },
                                     "stmt": "f_inout_struct&"
@@ -6879,6 +7050,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -6908,6 +7080,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     },
                                     "stmt": "py_inout_struct&_numpy"
@@ -6916,11 +7089,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "inout"
                                     }
                                 }
@@ -7007,6 +7182,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -7035,6 +7211,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "out"
                                     },
                                     "stmt": "c_out_struct&"
@@ -7059,6 +7236,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -7097,6 +7275,7 @@
                                         "typemap_name": "structns::Cstruct1"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "out"
                                     },
                                     "stmt": "f_out_struct&"
@@ -7108,6 +7287,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -7136,6 +7316,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "out"
                                     },
                                     "stmt": "py_out_struct&_numpy"
@@ -7144,11 +7325,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "struct&",
                                         "intent": "out"
                                     }
                                 }

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -119,6 +119,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -141,6 +142,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -152,6 +154,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -162,6 +165,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -170,6 +174,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -273,6 +278,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -302,6 +308,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -332,6 +339,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -383,6 +391,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -421,6 +430,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -460,6 +470,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -478,6 +489,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -496,6 +508,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -515,6 +528,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -538,6 +552,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -561,6 +576,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -585,6 +601,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -594,17 +611,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -761,6 +781,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -798,6 +819,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -835,6 +857,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -900,6 +923,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -944,6 +968,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -987,6 +1012,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -1006,6 +1032,7 @@
                                 "stmt": "lua_function_string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         },
@@ -1024,6 +1051,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
@@ -1042,6 +1070,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -1064,6 +1093,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string"
@@ -1089,6 +1119,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -1114,6 +1145,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -1122,16 +1154,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -1233,6 +1268,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1281,6 +1317,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1289,6 +1326,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1377,6 +1415,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1406,6 +1445,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1457,6 +1497,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1495,6 +1536,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1504,11 +1546,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1615,6 +1659,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1644,6 +1689,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1674,6 +1720,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1725,6 +1772,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1763,6 +1811,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1801,6 +1850,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1819,6 +1869,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -1837,6 +1888,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1856,6 +1908,7 @@
                                 "stmt": "lua_in_bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1879,6 +1932,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1902,6 +1956,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1928,6 +1983,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1937,17 +1993,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2059,6 +2118,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2096,6 +2156,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -2121,6 +2182,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2163,6 +2225,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -2175,6 +2238,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -2193,6 +2257,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -2203,6 +2268,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2228,6 +2294,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -2236,11 +2303,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -2335,6 +2404,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2364,6 +2434,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2389,6 +2460,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2427,6 +2499,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2439,6 +2512,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -2457,6 +2531,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2468,6 +2543,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2491,6 +2567,7 @@
                                 "value_var": "SHValue_indx"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2500,11 +2577,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "indx": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2605,11 +2684,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2705,6 +2786,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2734,6 +2816,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2759,6 +2842,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2797,6 +2881,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2809,6 +2894,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -2827,6 +2913,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2838,6 +2925,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2861,6 +2949,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2870,11 +2959,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3006,6 +3097,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3035,6 +3127,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3060,6 +3153,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3098,6 +3192,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3110,6 +3205,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -3128,6 +3224,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3139,6 +3236,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3162,6 +3260,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3171,11 +3270,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3269,6 +3370,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "function"
                             }
                         }
@@ -3366,6 +3468,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3414,6 +3517,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3422,6 +3526,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3528,6 +3633,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3576,6 +3682,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3584,6 +3691,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3637,6 +3745,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3659,6 +3768,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3670,6 +3780,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -3680,6 +3791,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3688,6 +3800,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -3864,6 +3977,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3901,6 +4015,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3939,6 +4054,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -3950,6 +4066,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -3968,6 +4085,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3987,6 +4105,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -3997,6 +4116,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4020,6 +4140,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4046,6 +4167,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -4054,17 +4176,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4176,6 +4301,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4214,6 +4340,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4257,6 +4384,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -4266,17 +4394,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4375,6 +4506,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4413,6 +4545,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4456,6 +4589,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -4465,17 +4599,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4561,6 +4698,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4590,6 +4728,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4641,6 +4780,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4679,6 +4819,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4688,11 +4829,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4790,6 +4933,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4819,6 +4963,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4849,6 +4994,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4900,6 +5046,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4938,6 +5085,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4977,6 +5125,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4986,17 +5135,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5111,6 +5263,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5140,6 +5293,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5170,6 +5324,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5200,6 +5355,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5251,6 +5407,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5289,6 +5446,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5328,6 +5486,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5367,6 +5526,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5385,6 +5545,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -5403,6 +5564,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5422,6 +5584,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5441,6 +5604,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5464,6 +5628,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -5487,6 +5652,7 @@
                                 "value_var": "SHValue_num"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5511,6 +5677,7 @@
                                 "value_var": "SHValue_offset"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5535,6 +5702,7 @@
                                 "value_var": "SHValue_stride"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5544,23 +5712,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5683,6 +5855,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5712,6 +5885,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5742,6 +5916,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5793,6 +5968,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5831,6 +6007,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5870,6 +6047,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5879,17 +6057,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5992,6 +6173,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -6021,6 +6203,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6051,6 +6234,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6081,6 +6265,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6132,6 +6317,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6170,6 +6356,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6209,6 +6396,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6248,6 +6436,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6257,23 +6446,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6393,6 +6586,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -6422,6 +6616,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6452,6 +6647,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6482,6 +6678,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6512,6 +6709,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6563,6 +6761,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6601,6 +6800,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6640,6 +6840,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6679,6 +6880,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6718,6 +6920,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6736,6 +6939,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -6754,6 +6958,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6773,6 +6978,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6792,6 +6998,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6811,6 +7018,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6834,6 +7042,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -6857,6 +7066,7 @@
                                 "value_var": "SHValue_num"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6881,6 +7091,7 @@
                                 "value_var": "SHValue_offset"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6905,6 +7116,7 @@
                                 "value_var": "SHValue_stride"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6929,6 +7141,7 @@
                                 "value_var": "SHValue_type"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6938,29 +7151,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7056,6 +7274,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -7085,6 +7304,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7136,6 +7356,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -7174,6 +7395,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7192,6 +7414,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -7210,6 +7433,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7233,6 +7457,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -7256,6 +7481,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7265,11 +7491,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7389,6 +7617,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -7427,6 +7656,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7482,6 +7712,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -7521,6 +7752,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7540,6 +7772,7 @@
                                 "stmt": "lua_function_enum"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
@@ -7559,6 +7792,7 @@
                                 "stmt": "lua_in_enum"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7582,6 +7816,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -7606,6 +7841,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7615,11 +7851,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7741,6 +7979,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7769,6 +8008,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native&"
@@ -7797,6 +8037,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native&"
@@ -7821,6 +8062,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7858,6 +8100,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native&"
@@ -7895,6 +8138,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native&"
@@ -7903,16 +8147,19 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "max": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         },
                         "min": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         }
@@ -7923,6 +8170,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -7947,6 +8195,7 @@
                                 "value_var": "SHValue_max"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native&"
@@ -7971,6 +8220,7 @@
                                 "value_var": "SHValue_min"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native&"
@@ -7979,16 +8229,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "max": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         },
                         "min": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         }
@@ -8112,6 +8365,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -8141,6 +8395,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8171,6 +8426,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -8220,6 +8476,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -8241,6 +8498,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -8250,11 +8508,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -8318,6 +8578,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -8356,6 +8617,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8396,6 +8658,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -8445,6 +8708,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -8466,6 +8730,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -8475,11 +8740,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -8501,17 +8768,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -8561,6 +8831,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -8582,6 +8853,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -8591,11 +8863,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -8701,6 +8975,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -8757,6 +9032,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -8778,6 +9054,7 @@
                                 "stmt": "lua_function_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }
@@ -8802,6 +9079,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -8811,6 +9089,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -101,6 +101,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -139,6 +140,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -192,6 +194,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -231,6 +234,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -240,11 +244,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -364,6 +370,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -402,6 +409,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -440,6 +448,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -493,6 +502,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -532,6 +542,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -571,6 +582,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -580,17 +592,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -725,6 +740,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -763,6 +779,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -801,6 +818,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -839,6 +857,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -892,6 +911,7 @@
                                         "typemap_name": "Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -931,6 +951,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -970,6 +991,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1009,6 +1031,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1018,23 +1041,27 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg3": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1090,6 +1117,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "c_dtor"
@@ -1113,6 +1141,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "f_dtor"
@@ -1121,6 +1150,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -1194,6 +1224,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -1223,6 +1254,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1248,6 +1280,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -1286,6 +1319,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1295,11 +1329,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1386,6 +1422,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -1415,6 +1452,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1445,6 +1483,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1470,6 +1509,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -1508,6 +1548,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1547,6 +1588,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1556,17 +1598,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1668,6 +1713,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -1697,6 +1743,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1727,6 +1774,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1757,6 +1805,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1782,6 +1831,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -1820,6 +1870,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1859,6 +1910,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1898,6 +1950,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1907,23 +1960,27 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg3": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2019,6 +2076,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -2027,6 +2085,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2123,6 +2182,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -2131,6 +2191,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2227,6 +2288,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -2235,6 +2297,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2454,6 +2517,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2483,6 +2547,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2508,6 +2573,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2546,6 +2612,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2555,11 +2622,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2646,6 +2715,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2675,6 +2745,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2705,6 +2776,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2730,6 +2802,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2768,6 +2841,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2807,6 +2881,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2816,17 +2891,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2928,6 +3006,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2957,6 +3036,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2987,6 +3067,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3017,6 +3098,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3042,6 +3124,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3080,6 +3163,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3119,6 +3203,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3158,6 +3243,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3167,23 +3253,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3269,6 +3359,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3298,6 +3389,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3330,6 +3422,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3355,6 +3448,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3393,6 +3487,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3434,6 +3529,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3443,17 +3539,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3550,6 +3649,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3579,6 +3679,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3609,6 +3710,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3641,6 +3743,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3666,6 +3769,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3704,6 +3808,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3743,6 +3848,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3784,6 +3890,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3793,23 +3900,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3921,6 +4032,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3950,6 +4062,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3980,6 +4093,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4010,6 +4124,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4042,6 +4157,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4067,6 +4183,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4105,6 +4222,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4144,6 +4262,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4183,6 +4302,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4224,6 +4344,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4233,29 +4354,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4347,6 +4473,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4376,6 +4503,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4406,6 +4534,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4436,6 +4565,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4461,6 +4591,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4499,6 +4630,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4538,6 +4670,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4577,6 +4710,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4586,23 +4720,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4704,6 +4842,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4733,6 +4872,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4763,6 +4903,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4793,6 +4934,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4825,6 +4967,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4850,6 +4993,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4888,6 +5032,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4927,6 +5072,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4966,6 +5112,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5007,6 +5154,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5016,29 +5164,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5130,6 +5283,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5159,6 +5313,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5190,6 +5345,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5222,6 +5378,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5248,6 +5405,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5286,6 +5444,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5327,6 +5486,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5369,6 +5529,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5379,17 +5540,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5397,6 +5561,7 @@
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5499,6 +5664,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5528,6 +5694,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5559,6 +5726,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5591,6 +5759,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5624,6 +5793,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5649,6 +5819,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5687,6 +5858,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5728,6 +5900,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5770,6 +5943,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5812,6 +5986,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5821,17 +5996,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "num_elems": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5839,6 +6017,7 @@
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "optional": true,
                                 "value": true
@@ -5846,6 +6025,7 @@
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -295,6 +295,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -334,6 +335,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -358,6 +360,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -382,6 +385,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -391,11 +395,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -510,6 +516,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -549,6 +556,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -573,6 +581,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -597,6 +606,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -606,11 +616,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -705,6 +717,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -745,6 +758,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_enum*"
@@ -753,11 +767,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "out"
                             }
                         }
@@ -863,6 +879,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -903,6 +920,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_enum*"
@@ -911,11 +929,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "inout": {
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "inout"
                             }
                         }

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -291,6 +291,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -329,6 +330,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -381,6 +383,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -420,6 +423,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -444,6 +448,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -468,6 +473,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -477,11 +483,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -590,6 +598,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -628,6 +637,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -683,6 +693,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -722,6 +733,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -746,6 +758,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -770,6 +783,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -779,11 +793,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -874,6 +890,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -913,6 +930,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_enum*"
@@ -938,6 +956,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -978,6 +997,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_enum*"
@@ -986,11 +1006,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "out"
                             }
                         }
@@ -1090,6 +1112,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -1129,6 +1152,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_enum*"
@@ -1183,6 +1207,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -1223,6 +1248,7 @@
                                 "typemap_name": "Color"
                             },
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_enum*"
@@ -1231,11 +1257,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "inout": {
                             "meta": {
+                                "abstract": "enum*",
                                 "intent": "inout"
                             }
                         }

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -319,6 +319,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -362,11 +363,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -415,6 +418,7 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "function"
                             },
                             "stmt": "c_mixin_unknown"
@@ -423,6 +427,7 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "function"
                             }
                         }
@@ -430,6 +435,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "function"
                             }
                         }
@@ -466,6 +472,7 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -474,6 +481,7 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -481,6 +489,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -522,6 +531,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -558,6 +568,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -611,11 +622,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -665,11 +678,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "assumedtype": true,
                                 "intent": "in",
                                 "value": true
@@ -719,11 +734,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "charlen": true,
                                 "intent": "in",
                                 "value": true
@@ -773,11 +790,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "char",
                                 "charlen": true,
                                 "intent": "in",
                                 "value": true
@@ -832,11 +851,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": true,
                                 "intent": "inout"
                             }
@@ -890,12 +911,14 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_char*"
@@ -904,11 +927,13 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "blanknull": true,
                                 "intent": "inout"
@@ -918,11 +943,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             }
                         }
@@ -972,11 +999,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "vector*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1047,11 +1076,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "vector<native,native>*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1113,11 +1144,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native<native>*",
                                 "intent": "inout"
                             }
                         }
@@ -1170,11 +1203,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dimension": "n+=2",
                                 "intent": "inout"
                             }
@@ -1223,11 +1258,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "inout",
                                 "value": true
                             }
@@ -1276,11 +1313,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "out",
                                 "value": true
                             }
@@ -1334,12 +1373,14 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -1348,11 +1389,13 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -1360,11 +1403,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -1417,12 +1462,14 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -1431,11 +1478,13 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "inout"
                             }
@@ -1444,11 +1493,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -1505,12 +1556,14 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native**"
@@ -1519,11 +1572,13 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "pointer",
                                 "intent": "in"
                             }
@@ -1532,11 +1587,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -1584,12 +1641,14 @@
                     "c": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1599,11 +1658,13 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1612,11 +1673,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1665,11 +1728,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1724,11 +1789,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -1783,11 +1850,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 30
                             }
@@ -1838,11 +1907,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1894,11 +1965,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1950,11 +2023,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "rank": 2,
                                 "value": true
@@ -2014,11 +2089,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "owner": "none"
                             }
@@ -2086,17 +2163,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2164,17 +2244,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2252,23 +2335,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "mtext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ntext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "text": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -2345,23 +2432,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "mtext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ntext": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "text": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -2430,11 +2521,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "alloc": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "alloc  None ****************************************",
                                     "ast": {
@@ -2474,11 +2567,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "tc": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "inout",
                                                     "value": true
                                                 }
@@ -2706,28 +2801,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2827,28 +2927,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 8
                             }
@@ -2950,28 +3055,33 @@
                     "f": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -2979,28 +3089,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -3123,6 +3238,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointerxx",
                                 "dim_ast": [
                                     {
@@ -3168,6 +3284,7 @@
                                 "typemap_name": "struct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -3176,6 +3293,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "narg2"
@@ -3187,6 +3305,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -3291,6 +3410,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -3329,6 +3449,7 @@
                                 "typemap_name": "struct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -3371,6 +3492,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -3380,16 +3502,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             }

--- a/regression/reference/error/error.json
+++ b/regression/reference/error/error.json
@@ -84,6 +84,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -92,6 +93,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -179,6 +181,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -217,6 +220,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -226,11 +230,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -328,6 +334,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -336,6 +343,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -423,6 +431,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -461,6 +470,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -470,11 +480,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -572,6 +584,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -580,6 +593,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -667,6 +681,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -705,6 +720,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -714,11 +730,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -946,6 +964,7 @@
                             },
                             "fstmts": "c",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -971,6 +990,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -982,6 +1002,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -990,6 +1011,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -1144,6 +1166,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1180,6 +1203,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -1191,6 +1215,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1215,6 +1240,7 @@
                                 "value_var": "SHValue_data"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -1223,11 +1249,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "data": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -1325,6 +1353,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1364,6 +1393,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 0
                             },
@@ -1373,11 +1403,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "data": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 0
                             }
@@ -1463,6 +1495,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1505,6 +1538,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -1514,11 +1548,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "data": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1604,6 +1640,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1646,6 +1683,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 2
                             },
@@ -1655,11 +1693,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "data": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 2
                             }
@@ -1708,6 +1748,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1716,6 +1757,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -100,6 +100,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "api": "capptr",
                                                         "intent": "ctor"
                                                     },
@@ -152,6 +153,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "api": "capsule",
                                                         "intent": "ctor"
                                                     },
@@ -169,6 +171,7 @@
                                                         "stmt": "lua_ctor"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     }
                                                 }
@@ -197,6 +200,7 @@
                                                         "vargs": "SHCXX_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     },
                                                     "stmt": "py_ctor_shadow"
@@ -205,6 +209,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     }
                                                 }
@@ -347,6 +352,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "api": "capptr",
                                                         "intent": "ctor"
                                                     },
@@ -385,6 +391,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "c_in_string*"
@@ -437,6 +444,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "api": "capsule",
                                                         "intent": "ctor"
                                                     },
@@ -480,6 +488,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "api": "buf",
                                                         "intent": "in"
                                                     },
@@ -497,6 +506,7 @@
                                                         "stmt": "lua_ctor"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     }
                                                 },
@@ -515,6 +525,7 @@
                                                         "stmt": "lua_in_string*"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     }
                                                 }
@@ -543,6 +554,7 @@
                                                         "vargs": "SHCXX_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     },
                                                     "stmt": "py_ctor_shadow"
@@ -568,6 +580,7 @@
                                                         "value_var": "SHValue_name"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "py_in_string*"
@@ -576,11 +589,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     }
                                                 },
                                                 "name": {
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     }
                                                 }
@@ -661,6 +676,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     },
                                                     "stmt": "c_dtor"
@@ -684,6 +700,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     },
                                                     "stmt": "f_dtor"
@@ -695,6 +712,7 @@
                                                         "stmt": "lua_dtor"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     }
                                                 }
@@ -702,6 +720,7 @@
                                             "py": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     }
                                                 }
@@ -709,6 +728,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     }
                                                 }
@@ -805,6 +825,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_native"
@@ -834,6 +855,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -885,6 +907,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_native"
@@ -923,6 +946,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -941,6 +965,7 @@
                                                         "stmt": "lua_function_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 },
@@ -959,6 +984,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -982,6 +1008,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_native"
@@ -1005,6 +1032,7 @@
                                                         "value_var": "SHValue_incr"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -1014,11 +1042,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 },
                                                 "incr": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -1149,6 +1179,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_string&"
@@ -1211,6 +1242,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "api": "cdesc",
                                                         "deref": "allocatable",
                                                         "intent": "function"
@@ -1231,6 +1263,7 @@
                                                         "stmt": "lua_function_string&"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -1254,6 +1287,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_string&"
@@ -1262,6 +1296,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -1382,6 +1417,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_string&"
@@ -1434,6 +1470,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "api": "buf",
                                                         "deref": "arg",
                                                         "intent": "function"
@@ -1454,6 +1491,7 @@
                                                         "stmt": "lua_function_string&"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -1477,6 +1515,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_string&"
@@ -1485,6 +1524,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -1593,6 +1633,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_native"
@@ -1622,6 +1663,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -1673,6 +1715,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_native"
@@ -1711,6 +1754,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -1729,6 +1773,7 @@
                                                         "stmt": "lua_function_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 },
@@ -1747,6 +1792,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -1770,6 +1816,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_native"
@@ -1793,6 +1840,7 @@
                                                         "value_var": "SHValue_value"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -1802,11 +1850,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -1921,6 +1971,7 @@
                                                         "typemap_name": "long"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_native"
@@ -1950,6 +2001,7 @@
                                                         "typemap_name": "long"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -2001,6 +2053,7 @@
                                                         "typemap_name": "long"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_native"
@@ -2039,6 +2092,7 @@
                                                         "typemap_name": "long"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -2057,6 +2111,7 @@
                                                         "stmt": "lua_function_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 },
@@ -2075,6 +2130,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -2098,6 +2154,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_native"
@@ -2121,6 +2178,7 @@
                                                         "value_var": "SHValue_value"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -2130,11 +2188,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -2234,6 +2294,7 @@
                                                         "typemap_name": "bool"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_bool"
@@ -2263,6 +2324,7 @@
                                                         "typemap_name": "bool"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -2312,6 +2374,7 @@
                                                         "typemap_name": "bool"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_bool"
@@ -2349,6 +2412,7 @@
                                                         "typemap_name": "bool"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -2367,6 +2431,7 @@
                                                         "stmt": "lua_function_bool"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "function"
                                                     }
                                                 },
@@ -2385,6 +2450,7 @@
                                                         "stmt": "lua_in_bool"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -2409,6 +2475,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_bool"
@@ -2434,6 +2501,7 @@
                                                         "value_var": "SHValue_in"
                                                     },
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -2443,11 +2511,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "function"
                                                     }
                                                 },
                                                 "in": {
                                                     "meta": {
+                                                        "abstract": "bool",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -2533,6 +2603,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "c_subroutine"
@@ -2556,6 +2627,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "f_subroutine"
@@ -2567,6 +2639,7 @@
                                                         "stmt": "lua_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 }
@@ -2577,6 +2650,7 @@
                                                         "stmt": "py_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "py_subroutine"
@@ -2585,6 +2659,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 }
@@ -2817,6 +2892,7 @@
                                                         "typemap_name": "example::nested::ExClass2"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "api": "capptr",
                                                         "intent": "ctor"
                                                     },
@@ -2855,6 +2931,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "c_in_string*"
@@ -2907,6 +2984,7 @@
                                                         "typemap_name": "example::nested::ExClass2"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "api": "capsule",
                                                         "intent": "ctor"
                                                     },
@@ -2950,6 +3028,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "api": "buf",
                                                         "intent": "in"
                                                     },
@@ -2967,6 +3046,7 @@
                                                         "stmt": "lua_ctor"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     }
                                                 },
@@ -2985,6 +3065,7 @@
                                                         "stmt": "lua_in_string*"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     }
                                                 }
@@ -3013,6 +3094,7 @@
                                                         "vargs": "SHCXX_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     },
                                                     "stmt": "py_ctor_shadow"
@@ -3038,6 +3120,7 @@
                                                         "value_var": "SHValue_name"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "py_in_string*"
@@ -3046,11 +3129,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "shadow",
                                                         "intent": "ctor"
                                                     }
                                                 },
                                                 "name": {
                                                     "meta": {
+                                                        "abstract": "string*",
                                                         "intent": "in"
                                                     }
                                                 }
@@ -3139,6 +3224,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     },
                                                     "stmt": "c_dtor"
@@ -3162,6 +3248,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     },
                                                     "stmt": "f_dtor"
@@ -3173,6 +3260,7 @@
                                                         "stmt": "lua_dtor"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     }
                                                 }
@@ -3180,6 +3268,7 @@
                                             "py": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     }
                                                 }
@@ -3187,6 +3276,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "dtor"
                                                     }
                                                 }
@@ -3302,6 +3392,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function",
                                                         "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
                                                     },
@@ -3358,6 +3449,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "api": "buf",
                                                         "deref": "copy",
                                                         "intent": "function",
@@ -3379,6 +3471,7 @@
                                                         "stmt": "lua_function_string&"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function",
                                                         "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
                                                     }
@@ -3403,6 +3496,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function",
                                                         "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
                                                     },
@@ -3412,6 +3506,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function",
                                                         "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
                                                     }
@@ -3535,6 +3630,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_string&"
@@ -3597,6 +3693,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "api": "cdesc",
                                                         "deref": "allocatable",
                                                         "intent": "function"
@@ -3617,6 +3714,7 @@
                                                         "stmt": "lua_function_string&"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -3640,6 +3738,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_string&"
@@ -3648,6 +3747,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -3771,6 +3871,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_string&"
@@ -3833,6 +3934,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "api": "cdesc",
                                                         "deref": "allocatable",
                                                         "intent": "function"
@@ -3853,6 +3955,7 @@
                                                         "stmt": "lua_function_string&"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -3876,6 +3979,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_string&"
@@ -3884,6 +3988,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -4005,6 +4110,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_string&"
@@ -4067,6 +4173,7 @@
                                                         "typemap_name": "std::string"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "api": "cdesc",
                                                         "deref": "allocatable",
                                                         "intent": "function"
@@ -4087,6 +4194,7 @@
                                                         "stmt": "lua_function_string&"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -4110,6 +4218,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_string&"
@@ -4118,6 +4227,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "string&",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -4218,6 +4328,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_native"
@@ -4268,6 +4379,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_native"
@@ -4285,6 +4397,7 @@
                                                         "stmt": "lua_function_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -4307,6 +4420,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_native"
@@ -4315,6 +4429,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -4448,6 +4563,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "api": "capptr",
                                                         "intent": "function"
                                                     },
@@ -4489,6 +4605,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "c_in_shadow*"
@@ -4544,6 +4661,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "api": "capsule",
                                                         "intent": "function"
                                                     },
@@ -4586,6 +4704,7 @@
                                                         "typemap_name": "example::nested::ExClass1"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "f_in_shadow*"
@@ -4604,6 +4723,7 @@
                                                         "stmt": "lua_function_shadow*"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "function"
                                                     }
                                                 },
@@ -4623,6 +4743,7 @@
                                                         "stmt": "lua_in_shadow*"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "in"
                                                     }
                                                 }
@@ -4649,6 +4770,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_shadow*"
@@ -4677,6 +4799,7 @@
                                                         "value_var": "SHValue_in"
                                                     },
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "in"
                                                     },
                                                     "stmt": "py_in_shadow*"
@@ -4685,11 +4808,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "function"
                                                     }
                                                 },
                                                 "in": {
                                                     "meta": {
+                                                        "abstract": "shadow*",
                                                         "intent": "in"
                                                     }
                                                 }
@@ -4774,6 +4899,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "c_subroutine"
@@ -4797,6 +4923,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "f_subroutine"
@@ -4808,6 +4935,7 @@
                                                         "stmt": "lua_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 }
@@ -4818,6 +4946,7 @@
                                                         "stmt": "py_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "py_subroutine"
@@ -4826,6 +4955,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 }
@@ -4957,11 +5087,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "template",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -5079,6 +5211,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "c_subroutine"
@@ -5108,6 +5241,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5133,6 +5267,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "f_subroutine"
@@ -5171,6 +5306,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5183,6 +5319,7 @@
                                                         "stmt": "lua_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
@@ -5201,6 +5338,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -5212,6 +5350,7 @@
                                                         "stmt": "py_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "py_subroutine"
@@ -5235,6 +5374,7 @@
                                                         "value_var": "SHValue_value"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5244,11 +5384,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -5404,6 +5546,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "c_subroutine"
@@ -5433,6 +5576,7 @@
                                                         "typemap_name": "long"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5458,6 +5602,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "f_subroutine"
@@ -5496,6 +5641,7 @@
                                                         "typemap_name": "long"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5508,6 +5654,7 @@
                                                         "stmt": "lua_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
@@ -5526,6 +5673,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -5537,6 +5685,7 @@
                                                         "stmt": "py_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "py_subroutine"
@@ -5560,6 +5709,7 @@
                                                         "value_var": "SHValue_value"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5569,11 +5719,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -5717,6 +5869,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "c_subroutine"
@@ -5746,6 +5899,7 @@
                                                         "typemap_name": "float"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5771,6 +5925,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "f_subroutine"
@@ -5809,6 +5964,7 @@
                                                         "typemap_name": "float"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5821,6 +5977,7 @@
                                                         "stmt": "lua_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
@@ -5839,6 +5996,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -5850,6 +6008,7 @@
                                                         "stmt": "py_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "py_subroutine"
@@ -5873,6 +6032,7 @@
                                                         "value_var": "SHValue_value"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -5882,11 +6042,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -6036,6 +6198,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "c_subroutine"
@@ -6065,6 +6228,7 @@
                                                         "typemap_name": "double"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -6090,6 +6254,7 @@
                                                         "typemap_name": "void"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "f_subroutine"
@@ -6128,6 +6293,7 @@
                                                         "typemap_name": "double"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -6140,6 +6306,7 @@
                                                         "stmt": "lua_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
@@ -6158,6 +6325,7 @@
                                                         "stmt": "lua_in_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -6169,6 +6337,7 @@
                                                         "stmt": "py_subroutine"
                                                     },
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     },
                                                     "stmt": "py_subroutine"
@@ -6192,6 +6361,7 @@
                                                         "value_var": "SHValue_value"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     },
@@ -6201,11 +6371,13 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "void",
                                                         "intent": "subroutine"
                                                     }
                                                 },
                                                 "value": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "in",
                                                         "value": true
                                                     }
@@ -6301,6 +6473,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "template",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -6398,6 +6571,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_native"
@@ -6447,6 +6621,7 @@
                                                         "typemap_name": "int"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_native"
@@ -6464,6 +6639,7 @@
                                                         "stmt": "lua_function_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -6486,6 +6662,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_native"
@@ -6494,6 +6671,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -6628,6 +6806,7 @@
                                                         "typemap_name": "double"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "c_function_native"
@@ -6677,6 +6856,7 @@
                                                         "typemap_name": "double"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "f_function_native"
@@ -6694,6 +6874,7 @@
                                                         "stmt": "lua_function_native"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -6716,6 +6897,7 @@
                                                         "value_var": "SHValue_rv"
                                                     },
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     },
                                                     "stmt": "py_function_native"
@@ -6724,6 +6906,7 @@
                                             "share": {
                                                 "+result": {
                                                     "meta": {
+                                                        "abstract": "native",
                                                         "intent": "function"
                                                     }
                                                 }
@@ -6861,6 +7044,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -6883,6 +7067,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -6894,6 +7079,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -6904,6 +7090,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -6912,6 +7099,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -7038,6 +7226,7 @@
                                                 "typemap_name": "bool"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             },
                                             "stmt": "c_function_bool"
@@ -7075,6 +7264,7 @@
                                                 "typemap_name": "std::string"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             },
                                             "stmt": "c_in_string&"
@@ -7124,6 +7314,7 @@
                                                 "typemap_name": "bool"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             },
                                             "stmt": "f_function_bool"
@@ -7166,6 +7357,7 @@
                                                 "typemap_name": "std::string"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "api": "buf",
                                                 "intent": "in"
                                             },
@@ -7184,6 +7376,7 @@
                                                 "stmt": "lua_function_bool"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             }
                                         },
@@ -7202,6 +7395,7 @@
                                                 "stmt": "lua_in_string&"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             }
                                         }
@@ -7225,6 +7419,7 @@
                                                 "value_var": "SHValue_rv"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             },
                                             "stmt": "py_function_bool"
@@ -7250,6 +7445,7 @@
                                                 "value_var": "SHValue_name"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             },
                                             "stmt": "py_in_string&"
@@ -7258,11 +7454,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             }
                                         },
                                         "name": {
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             }
                                         }
@@ -7354,6 +7552,7 @@
                                                 "typemap_name": "bool"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             },
                                             "stmt": "c_function_bool"
@@ -7400,6 +7599,7 @@
                                                 "typemap_name": "bool"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             },
                                             "stmt": "f_function_bool"
@@ -7417,6 +7617,7 @@
                                                 "stmt": "lua_function_bool"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             }
                                         }
@@ -7440,6 +7641,7 @@
                                                 "value_var": "SHValue_rv"
                                             },
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             },
                                             "stmt": "py_function_bool"
@@ -7448,6 +7650,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "bool",
                                                 "intent": "function"
                                             }
                                         }
@@ -7550,6 +7753,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -7587,6 +7791,7 @@
                                                 "typemap_name": "std::string"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             },
                                             "stmt": "c_in_string&"
@@ -7612,6 +7817,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -7654,6 +7860,7 @@
                                                 "typemap_name": "std::string"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "api": "buf",
                                                 "intent": "in"
                                             },
@@ -7666,6 +7873,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -7684,6 +7892,7 @@
                                                 "stmt": "lua_in_string&"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             }
                                         }
@@ -7694,6 +7903,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -7719,6 +7929,7 @@
                                                 "value_var": "SHValue_name"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             },
                                             "stmt": "py_in_string&"
@@ -7727,11 +7938,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "name": {
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             }
                                         }
@@ -7849,6 +8062,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -7886,6 +8100,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -7924,6 +8139,7 @@
                                                 "typemap_name": "std::string"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             },
                                             "stmt": "c_in_string&"
@@ -7949,6 +8165,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -7987,6 +8204,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8030,6 +8248,7 @@
                                                 "typemap_name": "std::string"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "api": "buf",
                                                 "intent": "in"
                                             },
@@ -8042,6 +8261,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -8060,6 +8280,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -8079,6 +8300,7 @@
                                                 "stmt": "lua_in_string&"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             }
                                         }
@@ -8089,6 +8311,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -8112,6 +8335,7 @@
                                                 "value_var": "SHValue_flag"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8138,6 +8362,7 @@
                                                 "value_var": "SHValue_name"
                                             },
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             },
                                             "stmt": "py_in_string&"
@@ -8146,17 +8371,20 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "flag": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "name": {
                                             "meta": {
+                                                "abstract": "string&",
                                                 "intent": "in"
                                             }
                                         }
@@ -8228,6 +8456,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -8250,6 +8479,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -8258,6 +8488,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -8326,6 +8557,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -8355,6 +8587,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8380,6 +8613,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -8418,6 +8652,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8427,11 +8662,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "i": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -8518,6 +8755,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -8547,6 +8785,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8577,6 +8816,7 @@
                                                 "typemap_name": "long"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8602,6 +8842,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -8640,6 +8881,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8679,6 +8921,7 @@
                                                 "typemap_name": "long"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8691,6 +8934,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -8709,6 +8953,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -8728,6 +8973,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -8739,6 +8985,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -8762,6 +9009,7 @@
                                                 "value_var": "SHValue_i"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8786,6 +9034,7 @@
                                                 "value_var": "SHValue_j"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -8795,17 +9044,20 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "i": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "j": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -8898,6 +9150,7 @@
                                                 "typemap_name": "size_t"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             },
                                             "stmt": "c_function_native"
@@ -8946,6 +9199,7 @@
                                                 "typemap_name": "size_t"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             },
                                             "stmt": "f_function_native"
@@ -8963,6 +9217,7 @@
                                                 "stmt": "lua_function_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             }
                                         }
@@ -8985,6 +9240,7 @@
                                                 "value_var": "SHValue_rv"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             },
                                             "stmt": "py_function_native"
@@ -8993,6 +9249,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             }
                                         }
@@ -9081,6 +9338,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -9112,6 +9370,7 @@
                                                 "typemap_name": "MPI_Comm"
                                             },
                                             "meta": {
+                                                "abstract": "unknown",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -9137,6 +9396,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -9177,6 +9437,7 @@
                                                 "typemap_name": "MPI_Comm"
                                             },
                                             "meta": {
+                                                "abstract": "unknown",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -9189,6 +9450,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -9208,6 +9470,7 @@
                                                 "stmt": "lua_in_unknown"
                                             },
                                             "meta": {
+                                                "abstract": "unknown",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -9219,6 +9482,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -9246,6 +9510,7 @@
                                                 "value_var": "SHValue_comm"
                                             },
                                             "meta": {
+                                                "abstract": "unknown",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -9255,11 +9520,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "comm": {
                                             "meta": {
+                                                "abstract": "unknown",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -9343,6 +9610,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -9365,6 +9633,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -9376,6 +9645,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -9386,6 +9656,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -9394,6 +9665,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -9481,6 +9753,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -9510,6 +9783,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -9539,6 +9813,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -9547,6 +9822,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             }
@@ -9583,6 +9859,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -9622,6 +9899,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -9651,6 +9929,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -9659,6 +9938,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             }
@@ -9682,6 +9962,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -9700,6 +9981,7 @@
                                                 "stmt": "lua_in_procedure"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -9729,6 +10011,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -9737,6 +10020,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             }
@@ -9759,6 +10043,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -9782,6 +10067,7 @@
                                                 "value_var": "SHValue_get"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -9811,6 +10097,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -9819,6 +10106,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             }
@@ -9839,11 +10127,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "get": {
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -9873,6 +10163,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -9881,6 +10172,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             }
@@ -9996,6 +10288,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -10024,6 +10317,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10070,6 +10364,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "deref": "pointer",
                                                                     "intent": "function"
                                                                 },
@@ -10079,6 +10374,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "intent": "function"
                                                                 }
                                                             }
@@ -10114,6 +10410,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -10152,6 +10449,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10198,6 +10496,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "deref": "pointer",
                                                                     "intent": "function"
                                                                 },
@@ -10207,6 +10506,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "intent": "function"
                                                                 }
                                                             }
@@ -10229,6 +10529,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -10247,6 +10548,7 @@
                                                 "stmt": "lua_in_procedure"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10293,6 +10595,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "deref": "pointer",
                                                                     "intent": "function"
                                                                 },
@@ -10302,6 +10605,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "intent": "function"
                                                                 }
                                                             }
@@ -10323,6 +10627,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -10347,6 +10652,7 @@
                                                 "value_var": "SHValue_get"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10393,6 +10699,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "deref": "pointer",
                                                                     "intent": "function"
                                                                 },
@@ -10402,6 +10709,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "intent": "function"
                                                                 }
                                                             }
@@ -10421,11 +10729,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "get": {
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10472,6 +10782,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "deref": "pointer",
                                                                     "intent": "function"
                                                                 },
@@ -10481,6 +10792,7 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native*",
                                                                     "intent": "function"
                                                                 }
                                                             }
@@ -10612,6 +10924,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -10641,6 +10954,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10702,6 +11016,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -10723,6 +11038,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -10745,6 +11061,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -10754,17 +11071,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "i": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -10802,6 +11122,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -10841,6 +11162,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -10902,6 +11224,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -10923,6 +11246,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -10945,6 +11269,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -10954,17 +11279,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "i": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -10989,6 +11317,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -11007,6 +11336,7 @@
                                                 "stmt": "lua_in_procedure"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -11068,6 +11398,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -11089,6 +11420,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11111,6 +11443,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11120,17 +11453,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "i": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -11154,6 +11490,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -11177,6 +11514,7 @@
                                                 "value_var": "SHValue_get"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -11238,6 +11576,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -11259,6 +11598,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11281,6 +11621,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11290,17 +11631,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "i": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -11322,11 +11666,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "get": {
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -11388,6 +11734,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -11409,6 +11756,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11431,6 +11779,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11440,17 +11789,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "i": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -11585,6 +11937,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -11614,6 +11967,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -11672,6 +12026,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -11693,6 +12048,7 @@
                                                                     "typemap_name": "double"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11715,6 +12071,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11724,17 +12081,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -11772,6 +12132,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -11811,6 +12172,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -11869,6 +12231,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -11890,6 +12253,7 @@
                                                                     "typemap_name": "double"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11912,6 +12276,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -11921,17 +12286,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -11953,11 +12321,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "get": {
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -12016,6 +12386,7 @@
                                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 },
                                                                 "stmt": "f_function_native"
@@ -12037,6 +12408,7 @@
                                                                     "typemap_name": "double"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12059,6 +12431,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12068,17 +12441,20 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "function"
                                                                 }
                                                             },
                                                             "arg1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "arg2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -12265,6 +12641,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -12294,6 +12671,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -12424,6 +12802,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -12445,6 +12824,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12467,6 +12847,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12489,6 +12870,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12511,6 +12893,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12533,6 +12916,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12555,6 +12939,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12577,6 +12962,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12599,6 +12985,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12621,6 +13008,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12643,6 +13031,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12652,65 +13041,76 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             },
                                                             "verylongname1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname10": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname3": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname4": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname5": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname6": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname7": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname8": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname9": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -12748,6 +13148,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -12787,6 +13188,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -12917,6 +13319,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -12938,6 +13341,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12960,6 +13364,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -12982,6 +13387,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13004,6 +13410,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13026,6 +13433,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13048,6 +13456,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13070,6 +13479,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13092,6 +13502,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13114,6 +13525,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13136,6 +13548,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13145,65 +13558,76 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             },
                                                             "verylongname1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname10": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname3": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname4": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname5": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname6": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname7": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname8": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname9": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -13228,6 +13652,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -13246,6 +13671,7 @@
                                                 "stmt": "lua_in_procedure"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -13376,6 +13802,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -13397,6 +13824,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13419,6 +13847,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13441,6 +13870,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13463,6 +13893,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13485,6 +13916,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13507,6 +13939,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13529,6 +13962,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13551,6 +13985,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13573,6 +14008,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13595,6 +14031,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13604,65 +14041,76 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             },
                                                             "verylongname1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname10": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname3": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname4": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname5": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname6": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname7": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname8": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname9": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -13686,6 +14134,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -13709,6 +14158,7 @@
                                                 "value_var": "SHValue_get"
                                             },
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -13839,6 +14289,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -13860,6 +14311,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13882,6 +14334,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13904,6 +14357,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13926,6 +14380,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13948,6 +14403,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13970,6 +14426,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -13992,6 +14449,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14014,6 +14472,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14036,6 +14495,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14058,6 +14518,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14067,65 +14528,76 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             },
                                                             "verylongname1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname10": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname3": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname4": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname5": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname6": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname7": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname8": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname9": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -14147,11 +14619,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "get": {
                                             "meta": {
+                                                "abstract": "procedure",
                                                 "fptr": {
                                                     "<FUNCTION>": "get  None ****************************************",
                                                     "ast": {
@@ -14282,6 +14756,7 @@
                                                                     "i_subprogram": "subroutine"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 },
                                                                 "stmt": "f_subroutine"
@@ -14303,6 +14778,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14325,6 +14801,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14347,6 +14824,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14369,6 +14847,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14391,6 +14870,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14413,6 +14893,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14435,6 +14916,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14457,6 +14939,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14479,6 +14962,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14501,6 +14985,7 @@
                                                                     "typemap_name": "int"
                                                                 },
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 },
@@ -14510,65 +14995,76 @@
                                                         "share": {
                                                             "+result": {
                                                                 "meta": {
+                                                                    "abstract": "void",
                                                                     "intent": "subroutine"
                                                                 }
                                                             },
                                                             "verylongname1": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname10": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname2": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname3": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname4": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname5": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname6": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname7": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname8": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
                                                             },
                                                             "verylongname9": {
                                                                 "meta": {
+                                                                    "abstract": "native",
                                                                     "intent": "none",
                                                                     "value": true
                                                                 }
@@ -14839,6 +15335,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -14867,6 +15364,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -14895,6 +15393,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -14923,6 +15422,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -14951,6 +15451,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -14979,6 +15480,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -15007,6 +15509,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -15035,6 +15538,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -15063,6 +15567,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -15091,6 +15596,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -15119,6 +15625,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "c_inout_native*"
@@ -15143,6 +15650,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -15180,6 +15688,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15217,6 +15726,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15254,6 +15764,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15291,6 +15802,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15328,6 +15840,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15365,6 +15878,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15402,6 +15916,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15439,6 +15954,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15476,6 +15992,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15513,6 +16030,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "f_inout_native*"
@@ -15524,6 +16042,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -15542,6 +16061,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15560,6 +16080,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15578,6 +16099,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15596,6 +16118,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15614,6 +16137,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15632,6 +16156,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15650,6 +16175,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15668,6 +16194,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15686,6 +16213,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
@@ -15704,6 +16232,7 @@
                                                 "stmt": "lua_inout_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         }
@@ -15714,6 +16243,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -15738,6 +16268,7 @@
                                                 "value_var": "SHValue_verylongname1"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15762,6 +16293,7 @@
                                                 "value_var": "SHValue_verylongname10"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15786,6 +16318,7 @@
                                                 "value_var": "SHValue_verylongname2"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15810,6 +16343,7 @@
                                                 "value_var": "SHValue_verylongname3"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15834,6 +16368,7 @@
                                                 "value_var": "SHValue_verylongname4"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15858,6 +16393,7 @@
                                                 "value_var": "SHValue_verylongname5"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15882,6 +16418,7 @@
                                                 "value_var": "SHValue_verylongname6"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15906,6 +16443,7 @@
                                                 "value_var": "SHValue_verylongname7"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15930,6 +16468,7 @@
                                                 "value_var": "SHValue_verylongname8"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15954,6 +16493,7 @@
                                                 "value_var": "SHValue_verylongname9"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             },
                                             "stmt": "py_inout_native*"
@@ -15962,56 +16502,67 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "verylongname1": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname10": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname2": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname3": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname4": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname5": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname6": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname7": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname8": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         },
                                         "verylongname9": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "inout"
                                             }
                                         }
@@ -16207,6 +16758,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             },
                                             "stmt": "c_function_native"
@@ -16236,6 +16788,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16266,6 +16819,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16296,6 +16850,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16326,6 +16881,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16356,6 +16912,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16386,6 +16943,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16416,6 +16974,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16446,6 +17005,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16476,6 +17036,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16506,6 +17067,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16557,6 +17119,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             },
                                             "stmt": "f_function_native"
@@ -16595,6 +17158,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16634,6 +17198,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16673,6 +17238,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16712,6 +17278,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16751,6 +17318,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16790,6 +17358,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16829,6 +17398,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16868,6 +17438,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16907,6 +17478,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16946,6 +17518,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -16964,6 +17537,7 @@
                                                 "stmt": "lua_function_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             }
                                         },
@@ -16982,6 +17556,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17001,6 +17576,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17020,6 +17596,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17039,6 +17616,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17058,6 +17636,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17077,6 +17656,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17096,6 +17676,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17115,6 +17696,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17134,6 +17716,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17153,6 +17736,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17176,6 +17760,7 @@
                                                 "value_var": "SHValue_rv"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             },
                                             "stmt": "py_function_native"
@@ -17199,6 +17784,7 @@
                                                 "value_var": "SHValue_verylongname1"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17223,6 +17809,7 @@
                                                 "value_var": "SHValue_verylongname10"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17247,6 +17834,7 @@
                                                 "value_var": "SHValue_verylongname2"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17271,6 +17859,7 @@
                                                 "value_var": "SHValue_verylongname3"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17295,6 +17884,7 @@
                                                 "value_var": "SHValue_verylongname4"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17319,6 +17909,7 @@
                                                 "value_var": "SHValue_verylongname5"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17343,6 +17934,7 @@
                                                 "value_var": "SHValue_verylongname6"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17367,6 +17959,7 @@
                                                 "value_var": "SHValue_verylongname7"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17391,6 +17984,7 @@
                                                 "value_var": "SHValue_verylongname8"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17415,6 +18009,7 @@
                                                 "value_var": "SHValue_verylongname9"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17424,65 +18019,76 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "function"
                                             }
                                         },
                                         "verylongname1": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname10": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname2": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname3": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname4": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname5": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname6": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname7": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname8": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "verylongname9": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17619,6 +18225,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -17647,6 +18254,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "in",
                                                 "rank": 2
                                             },
@@ -17678,6 +18286,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "dim_ast": [
                                                     {
                                                         "args": [
@@ -17718,6 +18327,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17743,6 +18353,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -17785,6 +18396,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "in",
                                                 "rank": 2
                                             },
@@ -17829,6 +18441,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "dim_ast": [
                                                     {
                                                         "args": [
@@ -17879,6 +18492,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -17891,6 +18505,7 @@
                                                 "stmt": "lua_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
@@ -17909,6 +18524,7 @@
                                                 "stmt": "lua_in_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "in",
                                                 "rank": 2
                                             }
@@ -17927,6 +18543,7 @@
                                                 "stmt": "lua_out_native*"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "dim_ast": [
                                                     {
                                                         "args": [
@@ -17956,6 +18573,7 @@
                                                 "stmt": "lua_in_native"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -17967,6 +18585,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -17992,6 +18611,7 @@
                                                 "value_var": "SHValue_in"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "in",
                                                 "rank": 2
                                             },
@@ -18022,6 +18642,7 @@
                                                 "value_var": "SHValue_out"
                                             },
                                             "meta": {
+                                                "abstract": "native*",
                                                 "dim_ast": [
                                                     {
                                                         "args": [
@@ -18057,6 +18678,7 @@
                                                 "value_var": "SHValue_sizein"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "implied": "size(in)",
                                                 "intent": "in",
                                                 "value": true
@@ -18067,17 +18689,20 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "in": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "intent": "in",
                                                 "rank": 2
                                             }
                                         },
                                         "out": {
                                             "meta": {
+                                                "abstract": "native*",
                                                 "dim_ast": [
                                                     {
                                                         "args": [
@@ -18094,6 +18719,7 @@
                                         },
                                         "sizein": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -133,6 +133,7 @@
                                         "typemap_name": "forward::Class2"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -185,6 +186,7 @@
                                         "typemap_name": "forward::Class2"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -202,6 +204,7 @@
                                         "stmt": "lua_ctor"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -230,6 +233,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_shadow"
@@ -238,6 +242,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -315,6 +320,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "c_dtor"
@@ -338,6 +344,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "f_dtor"
@@ -349,6 +356,7 @@
                                         "stmt": "lua_dtor"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -356,6 +364,7 @@
                             "py": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -363,6 +372,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -454,6 +464,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -483,6 +494,7 @@
                                         "typemap_name": "tutorial::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     },
                                     "stmt": "c_in_shadow*"
@@ -507,6 +519,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -548,6 +561,7 @@
                                         "typemap_name": "tutorial::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     },
                                     "stmt": "f_in_shadow*"
@@ -559,6 +573,7 @@
                                         "stmt": "lua_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
@@ -578,6 +593,7 @@
                                         "stmt": "lua_in_shadow*"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     }
                                 }
@@ -588,6 +604,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -614,6 +631,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     },
                                     "stmt": "py_in_shadow*"
@@ -622,11 +640,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     }
                                 }
@@ -727,6 +747,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -756,6 +777,7 @@
                                         "typemap_name": "forward::Class3"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     },
                                     "stmt": "c_in_shadow*"
@@ -780,6 +802,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -821,6 +844,7 @@
                                         "typemap_name": "forward::Class3"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     },
                                     "stmt": "f_in_shadow*"
@@ -832,6 +856,7 @@
                                         "stmt": "lua_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
@@ -851,6 +876,7 @@
                                         "stmt": "lua_in_shadow*"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     }
                                 }
@@ -861,6 +887,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -889,6 +916,7 @@
                                         "value_var": "SHValue_arg"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     },
                                     "stmt": "py_in_shadow*"
@@ -897,11 +925,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "in"
                                     }
                                 }
@@ -1073,6 +1103,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1101,6 +1132,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_struct*"
@@ -1151,6 +1183,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1189,6 +1222,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -1197,11 +1231,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }

--- a/regression/reference/funptr-c/funptr.json
+++ b/regression/reference/funptr-c/funptr.json
@@ -77,6 +77,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -116,6 +117,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1  None ****************************************",
                                     "ast": {
@@ -142,6 +144,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -150,6 +153,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -170,11 +174,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1  None ****************************************",
                                     "ast": {
@@ -201,6 +207,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -209,6 +216,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -302,6 +310,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -341,6 +350,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_wrap  None ****************************************",
                                     "ast": {
@@ -367,6 +377,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -375,6 +386,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -395,11 +407,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1_wrap": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_wrap  None ****************************************",
                                     "ast": {
@@ -426,6 +440,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -434,6 +449,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -527,6 +543,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -566,6 +583,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "external",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_external  None ****************************************",
@@ -596,6 +614,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -604,6 +623,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -624,11 +644,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1_external": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_external  None ****************************************",
                                     "ast": {
@@ -658,6 +680,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -666,6 +689,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -762,6 +786,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -800,6 +825,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_funptr  None ****************************************",
@@ -830,6 +856,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -838,6 +865,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -858,11 +886,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1_funptr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_funptr  None ****************************************",
                                     "ast": {
@@ -892,6 +922,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -900,6 +931,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1006,6 +1038,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1045,6 +1078,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1084,6 +1118,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1121,6 +1156,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1130,23 +1166,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ival": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1244,6 +1284,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1283,6 +1324,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "external",
                                 "intent": "in",
                                 "value": true
@@ -1323,6 +1365,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1360,6 +1403,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1369,23 +1413,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ival": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1484,6 +1532,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1523,6 +1572,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "intent": "in",
                                 "value": true
@@ -1563,6 +1613,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1600,6 +1651,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1609,23 +1661,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ival": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1736,6 +1792,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1773,6 +1830,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             },
@@ -1812,6 +1870,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "fptr": {
                                     "<FUNCTION>": "incr3  None ****************************************",
@@ -1842,6 +1901,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -1850,6 +1910,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1900,6 +1961,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1909,17 +1971,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             }
                         },
                         "incr3": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr3  None ****************************************",
                                     "ast": {
@@ -1949,6 +2014,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -1957,6 +2023,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1974,6 +2041,7 @@
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2144,6 +2212,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2183,6 +2252,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "actor  None ****************************************",
                                     "ast": {
@@ -2254,6 +2324,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -2281,6 +2352,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 },
@@ -2305,6 +2377,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -2314,17 +2387,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "ilow": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 }
                                             },
                                             "nargs": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -2380,6 +2456,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2420,6 +2497,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2429,11 +2507,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "actor": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "actor  None ****************************************",
                                     "ast": {
@@ -2505,6 +2585,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -2532,6 +2613,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 },
@@ -2556,6 +2638,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -2565,17 +2648,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "ilow": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 }
                                             },
                                             "nargs": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -2594,12 +2680,14 @@
                         },
                         "ilow": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "nargs": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2685,6 +2773,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2723,6 +2812,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_ptr  None ****************************************",
                                     "ast": {
@@ -2766,6 +2856,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "deref": "pointer",
                                                     "intent": "function"
                                                 },
@@ -2775,6 +2866,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "function"
                                                 }
                                             }
@@ -2794,11 +2886,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "get_ptr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_ptr  None ****************************************",
                                     "ast": {
@@ -2842,6 +2936,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "deref": "pointer",
                                                     "intent": "function"
                                                 },
@@ -2851,6 +2946,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "function"
                                                 }
                                             }
@@ -2963,6 +3059,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3002,6 +3099,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get  None ****************************************",
                                     "ast": {
@@ -3060,6 +3158,7 @@
                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3081,6 +3180,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3103,6 +3203,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3112,17 +3213,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -3144,11 +3248,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "get": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get  None ****************************************",
                                     "ast": {
@@ -3207,6 +3313,7 @@
                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3228,6 +3335,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3250,6 +3358,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3259,17 +3368,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -3420,6 +3532,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3459,6 +3572,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_abs  None ****************************************",
                                     "ast": {
@@ -3516,6 +3630,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3537,6 +3652,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3559,6 +3675,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3568,17 +3685,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -3630,6 +3750,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3639,11 +3760,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "get_abs": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_abs  None ****************************************",
                                     "ast": {
@@ -3701,6 +3824,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3722,6 +3846,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3744,6 +3869,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3753,17 +3879,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -3782,6 +3911,7 @@
                         },
                         "input": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3876,6 +4006,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3915,6 +4046,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "void_ptr_arg  None ****************************************",
                                     "ast": {
@@ -3956,6 +4088,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -3977,6 +4110,7 @@
                                                     "typemap_name": "void"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -3986,11 +4120,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -4012,11 +4148,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "void_ptr_arg": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "void_ptr_arg  None ****************************************",
                                     "ast": {
@@ -4058,6 +4196,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4079,6 +4218,7 @@
                                                     "typemap_name": "void"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4088,11 +4228,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -4257,6 +4399,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4296,6 +4439,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "all_types  None ****************************************",
                                     "ast": {
@@ -4395,6 +4539,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4416,6 +4561,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4442,6 +4588,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 },
@@ -4463,6 +4610,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4483,6 +4631,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_char*"
@@ -4502,6 +4651,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4521,6 +4671,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_bool*"
@@ -4529,40 +4680,47 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 }
                                             },
                                             "arg3": {
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg4": {
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 }
                                             },
                                             "arg5": {
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg6": {
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 }
                                             }
@@ -4583,11 +4741,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "all_types": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "all_types  None ****************************************",
                                     "ast": {
@@ -4687,6 +4847,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4708,6 +4869,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4734,6 +4896,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 },
@@ -4755,6 +4918,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4775,6 +4939,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_char*"
@@ -4794,6 +4959,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4813,6 +4979,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_bool*"
@@ -4821,40 +4988,47 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 }
                                             },
                                             "arg3": {
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg4": {
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 }
                                             },
                                             "arg5": {
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg6": {
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 }
                                             }
@@ -5035,6 +5209,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5056,6 +5231,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5078,6 +5254,7 @@
                                                     "typemap_name": "TypeID"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5087,17 +5264,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "j": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5166,6 +5346,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5187,6 +5368,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5209,6 +5391,7 @@
                                                     "typemap_name": "TypeID"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5218,17 +5401,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "j": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5368,6 +5554,7 @@
                                                     "sh_type": "SH_TYPE_OTHER"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -5389,6 +5576,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5411,6 +5599,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5420,17 +5609,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5509,6 +5701,7 @@
                                                     "sh_type": "SH_TYPE_OTHER"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -5530,6 +5723,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5552,6 +5746,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5561,17 +5756,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }

--- a/regression/reference/funptr-cxx/funptr.json
+++ b/regression/reference/funptr-cxx/funptr.json
@@ -72,6 +72,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -101,6 +102,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1  None ****************************************",
                                     "ast": {
@@ -128,6 +130,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -136,6 +139,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -172,6 +176,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -211,6 +216,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1  None ****************************************",
                                     "ast": {
@@ -238,6 +244,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -246,6 +253,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -266,11 +274,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1  None ****************************************",
                                     "ast": {
@@ -298,6 +308,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -306,6 +317,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -394,6 +406,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -423,6 +436,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_wrap  None ****************************************",
                                     "ast": {
@@ -450,6 +464,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -458,6 +473,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -494,6 +510,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -533,6 +550,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_wrap  None ****************************************",
                                     "ast": {
@@ -560,6 +578,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -568,6 +587,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -588,11 +608,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1_wrap": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_wrap  None ****************************************",
                                     "ast": {
@@ -620,6 +642,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -628,6 +651,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -716,6 +740,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -745,6 +770,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "external",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_external  None ****************************************",
@@ -776,6 +802,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -784,6 +811,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -820,6 +848,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -859,6 +888,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "external",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_external  None ****************************************",
@@ -890,6 +920,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -898,6 +929,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -918,11 +950,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1_external": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_external  None ****************************************",
                                     "ast": {
@@ -953,6 +987,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -961,6 +996,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1052,6 +1088,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1081,6 +1118,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_funptr  None ****************************************",
@@ -1112,6 +1150,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -1120,6 +1159,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1156,6 +1196,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1194,6 +1235,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_funptr  None ****************************************",
@@ -1225,6 +1267,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -1233,6 +1276,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1253,11 +1297,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr1_funptr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr1_funptr  None ****************************************",
                                     "ast": {
@@ -1288,6 +1334,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -1296,6 +1343,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -1397,6 +1445,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1426,6 +1475,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1456,6 +1506,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1485,6 +1536,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -1509,6 +1561,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1548,6 +1601,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1587,6 +1641,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1624,6 +1679,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1633,23 +1689,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ival": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1742,6 +1802,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1771,6 +1832,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "external",
                                 "intent": "in",
                                 "value": true
@@ -1802,6 +1864,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1831,6 +1894,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -1855,6 +1919,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1894,6 +1959,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "external",
                                 "intent": "in",
                                 "value": true
@@ -1934,6 +2000,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1971,6 +2038,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -1980,23 +2048,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ival": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -2090,6 +2162,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2119,6 +2192,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "intent": "in",
                                 "value": true
@@ -2150,6 +2224,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2179,6 +2254,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -2203,6 +2279,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2242,6 +2319,7 @@
                                 "typemap_name": "incrtype"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "intent": "in",
                                 "value": true
@@ -2282,6 +2360,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2319,6 +2398,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -2328,23 +2408,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "ival": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -2450,6 +2534,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2478,6 +2563,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             },
@@ -2508,6 +2594,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "fptr": {
                                     "<FUNCTION>": "incr3  None ****************************************",
@@ -2539,6 +2626,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -2547,6 +2635,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -2588,6 +2677,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2613,6 +2703,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2650,6 +2741,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             },
@@ -2689,6 +2781,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "deref": "funptr",
                                 "fptr": {
                                     "<FUNCTION>": "incr3  None ****************************************",
@@ -2720,6 +2813,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -2728,6 +2822,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -2778,6 +2873,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2787,17 +2883,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "void*",
                                 "assumedtype": true,
                                 "intent": "in"
                             }
                         },
                         "incr3": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr3  None ****************************************",
                                     "ast": {
@@ -2828,6 +2927,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -2836,6 +2936,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             }
@@ -2853,6 +2954,7 @@
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3005,6 +3107,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3034,6 +3137,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "actor  None ****************************************",
                                     "ast": {
@@ -3106,6 +3210,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3133,6 +3238,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 },
@@ -3157,6 +3263,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -3166,17 +3273,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "ilow": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 }
                                             },
                                             "nargs": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -3218,6 +3328,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3248,6 +3359,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3299,6 +3411,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3338,6 +3451,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "actor  None ****************************************",
                                     "ast": {
@@ -3410,6 +3524,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3437,6 +3552,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 },
@@ -3461,6 +3577,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -3470,17 +3587,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "ilow": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 }
                                             },
                                             "nargs": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -3536,6 +3656,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3576,6 +3697,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3585,11 +3707,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "actor": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "actor  None ****************************************",
                                     "ast": {
@@ -3662,6 +3786,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -3689,6 +3814,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 },
@@ -3713,6 +3839,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 },
@@ -3722,17 +3849,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "ilow": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in",
                                                     "rank": 1
                                                 }
                                             },
                                             "nargs": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "in",
                                                     "value": true
                                                 }
@@ -3751,12 +3881,14 @@
                         },
                         "ilow": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "nargs": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3837,6 +3969,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3865,6 +3998,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_ptr  None ****************************************",
                                     "ast": {
@@ -3909,6 +4043,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "deref": "pointer",
                                                     "intent": "function"
                                                 },
@@ -3918,6 +4053,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "function"
                                                 }
                                             }
@@ -3953,6 +4089,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3991,6 +4128,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_ptr  None ****************************************",
                                     "ast": {
@@ -4035,6 +4173,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "deref": "pointer",
                                                     "intent": "function"
                                                 },
@@ -4044,6 +4183,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "function"
                                                 }
                                             }
@@ -4063,11 +4203,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "get_ptr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_ptr  None ****************************************",
                                     "ast": {
@@ -4112,6 +4254,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "deref": "pointer",
                                                     "intent": "function"
                                                 },
@@ -4121,6 +4264,7 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "function"
                                                 }
                                             }
@@ -4228,6 +4372,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4257,6 +4402,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get  None ****************************************",
                                     "ast": {
@@ -4316,6 +4462,7 @@
                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -4337,6 +4484,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4359,6 +4507,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4368,17 +4517,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -4416,6 +4568,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4455,6 +4608,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get  None ****************************************",
                                     "ast": {
@@ -4514,6 +4668,7 @@
                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -4535,6 +4690,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4557,6 +4713,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4566,17 +4723,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -4598,11 +4758,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "get": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get  None ****************************************",
                                     "ast": {
@@ -4662,6 +4824,7 @@
                                                     "sh_type": "SH_TYPE_DOUBLE"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -4683,6 +4846,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4705,6 +4869,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4714,17 +4879,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -4857,6 +5025,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4886,6 +5055,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_abs  None ****************************************",
                                     "ast": {
@@ -4944,6 +5114,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -4965,6 +5136,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4987,6 +5159,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -4996,17 +5169,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5049,6 +5225,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5100,6 +5277,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5139,6 +5317,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_abs  None ****************************************",
                                     "ast": {
@@ -5197,6 +5376,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -5218,6 +5398,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5240,6 +5421,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5249,17 +5431,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5311,6 +5496,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5320,11 +5506,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "get_abs": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "get_abs  None ****************************************",
                                     "ast": {
@@ -5383,6 +5571,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -5404,6 +5593,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5426,6 +5616,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5435,17 +5626,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5464,6 +5658,7 @@
                         },
                         "input": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5553,6 +5748,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5582,6 +5778,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "void_ptr_arg  None ****************************************",
                                     "ast": {
@@ -5624,6 +5821,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5645,6 +5843,7 @@
                                                     "typemap_name": "void"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5654,11 +5853,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5696,6 +5897,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5735,6 +5937,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "void_ptr_arg  None ****************************************",
                                     "ast": {
@@ -5777,6 +5980,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5798,6 +6002,7 @@
                                                     "typemap_name": "void"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5807,11 +6012,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -5833,11 +6040,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "void_ptr_arg": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "void_ptr_arg  None ****************************************",
                                     "ast": {
@@ -5880,6 +6089,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5901,6 +6111,7 @@
                                                     "typemap_name": "void"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -5910,11 +6121,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "void*",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -6074,6 +6287,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6103,6 +6317,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "all_types  None ****************************************",
                                     "ast": {
@@ -6203,6 +6418,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -6224,6 +6440,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6250,6 +6467,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 },
@@ -6271,6 +6489,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6291,6 +6510,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_char*"
@@ -6310,6 +6530,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6329,6 +6550,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_bool*"
@@ -6337,40 +6559,47 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 }
                                             },
                                             "arg3": {
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg4": {
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 }
                                             },
                                             "arg5": {
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg6": {
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 }
                                             }
@@ -6407,6 +6636,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6446,6 +6676,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "all_types  None ****************************************",
                                     "ast": {
@@ -6546,6 +6777,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -6567,6 +6799,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6593,6 +6826,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 },
@@ -6614,6 +6848,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6634,6 +6869,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_char*"
@@ -6653,6 +6889,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6672,6 +6909,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_bool*"
@@ -6680,40 +6918,47 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 }
                                             },
                                             "arg3": {
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg4": {
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 }
                                             },
                                             "arg5": {
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg6": {
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 }
                                             }
@@ -6734,11 +6979,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "all_types": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "all_types  None ****************************************",
                                     "ast": {
@@ -6839,6 +7086,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -6860,6 +7108,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6886,6 +7135,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 },
@@ -6907,6 +7157,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6927,6 +7178,7 @@
                                                     "typemap_name": "char"
                                                 },
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_char*"
@@ -6946,6 +7198,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -6965,6 +7218,7 @@
                                                     "typemap_name": "bool"
                                                 },
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 },
                                                 "stmt": "f_none_bool*"
@@ -6973,40 +7227,47 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "none",
                                                     "rank": 1
                                                 }
                                             },
                                             "arg3": {
                                                 "meta": {
+                                                    "abstract": "char",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg4": {
                                                 "meta": {
+                                                    "abstract": "char*",
                                                     "intent": "none"
                                                 }
                                             },
                                             "arg5": {
                                                 "meta": {
+                                                    "abstract": "bool",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg6": {
                                                 "meta": {
+                                                    "abstract": "bool*",
                                                     "intent": "none"
                                                 }
                                             }
@@ -7193,6 +7454,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -7214,6 +7476,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7236,6 +7499,7 @@
                                                     "typemap_name": "TypeID"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7245,17 +7509,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "j": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -7325,6 +7592,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -7346,6 +7614,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7368,6 +7637,7 @@
                                                     "typemap_name": "TypeID"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7377,17 +7647,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "j": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -7457,6 +7730,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -7478,6 +7752,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7500,6 +7775,7 @@
                                                     "typemap_name": "TypeID"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7509,17 +7785,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "i": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "j": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -7661,6 +7940,7 @@
                                                     "sh_type": "SH_TYPE_OTHER"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -7682,6 +7962,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7704,6 +7985,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7713,17 +7995,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -7803,6 +8088,7 @@
                                                     "sh_type": "SH_TYPE_OTHER"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -7824,6 +8110,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7846,6 +8133,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7855,17 +8143,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -7945,6 +8236,7 @@
                                                     "sh_type": "SH_TYPE_OTHER"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -7966,6 +8258,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7988,6 +8281,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -7997,17 +8291,20 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
                                             },
                                             "arg2": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -110,6 +110,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -148,6 +149,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -157,11 +159,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -233,6 +237,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -271,6 +276,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -280,11 +286,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -364,6 +372,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -372,6 +381,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -473,6 +483,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -510,6 +521,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -519,11 +531,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -597,6 +611,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -634,6 +649,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -643,11 +659,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -725,6 +743,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -762,6 +781,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -771,11 +791,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -932,6 +954,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -969,6 +992,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1007,6 +1031,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1016,17 +1041,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1133,6 +1161,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1170,6 +1199,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1208,6 +1238,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1217,17 +1248,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1338,6 +1372,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1375,6 +1410,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1413,6 +1449,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1422,17 +1459,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1552,6 +1592,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1590,6 +1631,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1636,6 +1678,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "dim_ast": {
                                     "assumedrank": true
@@ -1649,17 +1692,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": {
                                     "assumedrank": true
                                 },
@@ -1938,28 +1984,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -2075,6 +2126,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2112,6 +2164,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -2150,6 +2203,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2189,6 +2243,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2227,6 +2282,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -2235,28 +2291,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -2379,6 +2440,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2416,6 +2478,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -2454,6 +2517,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2493,6 +2557,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2540,6 +2605,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "inout",
                                 "rank": 1
@@ -2550,28 +2616,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -2698,6 +2769,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2744,6 +2816,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -2784,6 +2857,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2823,6 +2897,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2870,6 +2945,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "inout",
                                 "rank": 1
@@ -2880,29 +2956,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -3085,23 +3166,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3209,6 +3294,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3255,6 +3341,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -3296,6 +3383,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3336,6 +3424,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3345,23 +3434,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3473,6 +3566,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3519,6 +3613,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 2
@@ -3560,6 +3655,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3600,6 +3696,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3609,23 +3706,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3838,23 +3939,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3990,6 +4095,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4036,6 +4142,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -4077,6 +4184,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4117,6 +4225,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4126,23 +4235,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4282,6 +4395,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4328,6 +4442,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 2
@@ -4369,6 +4484,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4409,6 +4525,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4418,23 +4535,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4549,6 +4670,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4586,6 +4708,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -4623,6 +4746,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -4660,6 +4784,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -4668,21 +4793,25 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4916,21 +5045,25 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5053,6 +5186,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5112,6 +5246,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "out",
@@ -5151,6 +5286,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5188,6 +5324,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5197,22 +5334,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "rank": 1
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5339,6 +5480,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5398,6 +5540,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "out",
@@ -5437,6 +5580,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5474,6 +5618,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5483,22 +5628,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "rank": 2
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5592,6 +5741,7 @@
                                 "typemap_name": "StructAsClass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5601,6 +5751,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -5728,16 +5879,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             }
                         },
                         "inew": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5851,6 +6005,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5892,6 +6047,7 @@
                                 "typemap_name": "StructAsClass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_shadow*"
@@ -5930,6 +6086,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5939,16 +6096,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             }
                         },
                         "inew": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6066,6 +6226,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6107,6 +6268,7 @@
                                 "typemap_name": "StructAsClass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_shadow*"
@@ -6145,6 +6307,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6154,16 +6317,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             }
                         },
                         "inew": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -110,6 +110,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -148,6 +149,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -157,11 +159,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -233,6 +237,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -271,6 +276,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -280,11 +286,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -364,6 +372,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -372,6 +381,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -473,6 +483,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -510,6 +521,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -519,11 +531,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -597,6 +611,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -634,6 +649,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -643,11 +659,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -725,6 +743,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -762,6 +781,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -771,11 +791,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -932,6 +954,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -969,6 +992,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1007,6 +1031,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1016,17 +1041,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1133,6 +1161,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1170,6 +1199,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1208,6 +1238,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1217,17 +1248,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1338,6 +1372,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1375,6 +1410,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1413,6 +1449,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1422,17 +1459,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1612,17 +1652,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -1745,6 +1788,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1783,6 +1827,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1823,6 +1868,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 0
                             },
@@ -1832,17 +1878,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 0
                             }
@@ -1970,6 +2019,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2008,6 +2058,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2051,6 +2102,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2060,17 +2112,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2198,6 +2253,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2236,6 +2292,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2279,6 +2336,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -2288,17 +2346,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
@@ -2575,28 +2636,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -2712,6 +2778,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2749,6 +2816,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -2787,6 +2855,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2826,6 +2895,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2864,6 +2934,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -2872,28 +2943,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -3016,6 +3092,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3053,6 +3130,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -3091,6 +3169,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3130,6 +3209,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3173,6 +3253,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3182,28 +3263,33 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -3330,6 +3416,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3372,6 +3459,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3411,6 +3499,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3450,6 +3539,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3493,6 +3583,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3502,29 +3593,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "from": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "nfrom": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "nto": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "to": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -3707,23 +3803,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3831,6 +3931,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3873,6 +3974,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3913,6 +4015,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3953,6 +4056,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3962,23 +4066,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4090,6 +4198,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4132,6 +4241,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -4172,6 +4282,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4212,6 +4323,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4221,23 +4333,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4450,23 +4566,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4602,6 +4722,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4644,6 +4765,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -4684,6 +4806,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4724,6 +4847,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4733,23 +4857,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4889,6 +5017,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4931,6 +5060,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -4971,6 +5101,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5011,6 +5142,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5020,23 +5152,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5151,6 +5287,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5188,6 +5325,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -5225,6 +5363,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -5262,6 +5401,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -5270,21 +5410,25 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5526,21 +5670,25 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5671,6 +5819,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5720,6 +5869,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out",
@@ -5759,6 +5909,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5796,6 +5947,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5805,22 +5957,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "rank": 1
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5955,6 +6111,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6004,6 +6161,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out",
@@ -6043,6 +6201,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6080,6 +6239,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6089,22 +6249,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "rank": 2
                             }
                         },
                         "size": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -6198,6 +6362,7 @@
                                 "typemap_name": "StructAsClass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -6207,6 +6372,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -6334,16 +6500,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             }
                         },
                         "inew": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6457,6 +6626,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6498,6 +6668,7 @@
                                 "typemap_name": "StructAsClass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_shadow*"
@@ -6536,6 +6707,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6545,16 +6717,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             }
                         },
                         "inew": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6672,6 +6847,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6713,6 +6889,7 @@
                                 "typemap_name": "StructAsClass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_shadow*"
@@ -6751,6 +6928,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6760,16 +6938,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "inout"
                             }
                         },
                         "inew": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -58,6 +58,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -89,6 +90,7 @@
                                         "typemap_name": "MPI_Comm"
                                     },
                                     "meta": {
+                                        "abstract": "unknown",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -114,6 +116,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -154,6 +157,7 @@
                                         "typemap_name": "MPI_Comm"
                                     },
                                     "meta": {
+                                        "abstract": "unknown",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -163,11 +167,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "comm": {
                                     "meta": {
+                                        "abstract": "unknown",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -238,6 +244,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -267,6 +274,7 @@
                                         "typemap_name": "three::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "inout"
                                     },
                                     "stmt": "c_inout_shadow*"
@@ -291,6 +299,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -332,6 +341,7 @@
                                         "typemap_name": "three::Class1"
                                     },
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "inout"
                                     },
                                     "stmt": "f_inout_shadow*"
@@ -340,11 +350,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "c2": {
                                     "meta": {
+                                        "abstract": "shadow*",
                                         "intent": "inout"
                                     }
                                 }
@@ -447,6 +459,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -469,6 +482,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -477,6 +491,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -606,6 +621,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -635,6 +651,7 @@
                                                 "typemap_name": "CustomType"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -660,6 +677,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -698,6 +716,7 @@
                                                 "typemap_name": "CustomType"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -707,11 +726,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "arg1": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -830,6 +851,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -853,6 +875,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -861,6 +884,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -943,6 +967,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -965,6 +990,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -973,6 +999,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -1061,6 +1088,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -1084,6 +1112,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -1092,6 +1121,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -1174,6 +1204,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -1196,6 +1227,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -1204,6 +1236,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -51,6 +51,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -59,6 +60,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -160,6 +162,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -198,6 +201,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -237,6 +241,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -246,17 +251,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -91,6 +91,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -154,6 +155,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function",
@@ -165,6 +167,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             }

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -461,6 +461,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -498,6 +499,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout",
                                 "len": "worklen"
                             },
@@ -524,6 +526,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -570,6 +573,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "inout",
                                 "len": "worklen"
@@ -583,6 +587,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -607,6 +612,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout",
                                 "len": "worklen"
                             },
@@ -616,11 +622,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout",
                                 "len": "worklen"
                             }
@@ -688,6 +696,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -710,6 +719,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -721,6 +731,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -729,6 +740,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -794,6 +806,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -816,6 +829,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -827,6 +841,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -835,6 +850,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -914,6 +930,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -943,6 +960,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -968,6 +986,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1006,6 +1025,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1018,6 +1038,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1041,6 +1062,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1050,11 +1072,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1139,6 +1163,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1168,6 +1193,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1193,6 +1219,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1231,6 +1258,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1243,6 +1271,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1266,6 +1295,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1275,11 +1305,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1396,6 +1428,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1433,6 +1466,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -1484,6 +1518,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1526,6 +1561,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -1550,6 +1586,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1575,6 +1612,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -1583,11 +1621,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "rv": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -1657,6 +1697,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1679,6 +1720,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1690,6 +1732,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1698,6 +1741,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -1822,6 +1866,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1859,6 +1904,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string&"
@@ -1895,6 +1941,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1920,6 +1967,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1963,6 +2011,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -2001,6 +2050,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2012,6 +2062,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2037,6 +2088,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_string&"
@@ -2061,6 +2113,7 @@
                                 "value_var": "SHValue_value"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -2069,16 +2122,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2214,17 +2270,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2361,6 +2420,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2390,6 +2450,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2420,6 +2481,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2445,6 +2507,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2483,6 +2546,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2522,6 +2586,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2534,6 +2599,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2557,6 +2623,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2581,6 +2648,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2590,17 +2658,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2763,6 +2834,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2792,6 +2864,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2822,6 +2895,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2847,6 +2921,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2885,6 +2960,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2924,6 +3000,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2936,6 +3013,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2959,6 +3037,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2983,6 +3062,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2992,17 +3072,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3083,6 +3166,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3170,6 +3254,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3218,6 +3303,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3241,6 +3327,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3249,6 +3336,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3348,6 +3436,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3377,6 +3466,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_shadow*"
@@ -3427,6 +3517,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3468,6 +3559,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_shadow*"
@@ -3491,6 +3583,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3519,6 +3612,7 @@
                                 "value_var": "SHValue_point"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_shadow*"
@@ -3527,11 +3621,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -3802,6 +3898,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3831,6 +3928,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "afree  None ****************************************",
                                     "ast": {
@@ -3877,6 +3975,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -3899,6 +3998,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_native*"
@@ -3907,11 +4007,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 }
                                             }
@@ -3953,6 +4055,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "alloc  None ****************************************",
                                     "ast": {
@@ -4017,6 +4120,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4039,6 +4143,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_native*"
@@ -4061,6 +4166,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 },
                                                 "stmt": "f_out_native*"
@@ -4069,16 +4175,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 }
                                             },
                                             "err": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 }
                                             }
@@ -4120,6 +4229,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "assoc  None ****************************************",
                                     "ast": {
@@ -4184,6 +4294,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4206,6 +4317,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in"
                                                 },
                                                 "stmt": "f_in_native*"
@@ -4228,6 +4340,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 },
                                                 "stmt": "f_out_native*"
@@ -4236,16 +4349,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in"
                                                 }
                                             },
                                             "err": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 }
                                             }
@@ -4286,6 +4402,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -4314,6 +4431,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -4342,6 +4460,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -4366,6 +4485,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4405,6 +4525,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "afree  None ****************************************",
                                     "ast": {
@@ -4451,6 +4572,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4473,6 +4595,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_native*"
@@ -4481,11 +4604,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 }
                                             }
@@ -4537,6 +4662,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "alloc  None ****************************************",
                                     "ast": {
@@ -4601,6 +4727,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4623,6 +4750,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_native*"
@@ -4645,6 +4773,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 },
                                                 "stmt": "f_out_native*"
@@ -4653,16 +4782,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 }
                                             },
                                             "err": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 }
                                             }
@@ -4714,6 +4846,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "assoc  None ****************************************",
                                     "ast": {
@@ -4778,6 +4911,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -4800,6 +4934,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in"
                                                 },
                                                 "stmt": "f_in_native*"
@@ -4822,6 +4957,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 },
                                                 "stmt": "f_out_native*"
@@ -4830,16 +4966,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in"
                                                 }
                                             },
                                             "err": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 }
                                             }
@@ -4888,6 +5027,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -4925,6 +5065,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -4962,6 +5103,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -4971,11 +5113,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "afree": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "afree  None ****************************************",
                                     "ast": {
@@ -5022,6 +5166,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5044,6 +5189,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_native*"
@@ -5052,11 +5198,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 }
                                             }
@@ -5074,6 +5222,7 @@
                         },
                         "alloc": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "alloc  None ****************************************",
                                     "ast": {
@@ -5138,6 +5287,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5160,6 +5310,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 },
                                                 "stmt": "f_inout_native*"
@@ -5182,6 +5333,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 },
                                                 "stmt": "f_out_native*"
@@ -5190,16 +5342,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "inout"
                                                 }
                                             },
                                             "err": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 }
                                             }
@@ -5217,6 +5372,7 @@
                         },
                         "assoc": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "assoc  None ****************************************",
                                     "ast": {
@@ -5281,6 +5437,7 @@
                                                     "i_subprogram": "subroutine"
                                                 },
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 },
                                                 "stmt": "f_subroutine"
@@ -5303,6 +5460,7 @@
                                                     "typemap_name": "double"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in"
                                                 },
                                                 "stmt": "f_in_native*"
@@ -5325,6 +5483,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 },
                                                 "stmt": "f_out_native*"
@@ -5333,16 +5492,19 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "void",
                                                     "intent": "subroutine"
                                                 }
                                             },
                                             "arr": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "in"
                                                 }
                                             },
                                             "err": {
                                                 "meta": {
+                                                    "abstract": "native*",
                                                     "intent": "out"
                                                 }
                                             }
@@ -5360,16 +5522,19 @@
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         },
                         "pkg": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         },
                         "rdbase": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -5432,6 +5597,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5461,6 +5627,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5486,6 +5653,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "attr": true,
                                 "foo": 1,
                                 "intent": "subroutine"
@@ -5526,6 +5694,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "attr": true,
                                 "bar": 2,
                                 "intent": "in",
@@ -5543,11 +5712,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5646,6 +5817,7 @@
                                                 "typemap_name": "ns0::Names"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "api": "capptr",
                                                 "intent": "ctor"
                                             },
@@ -5698,6 +5870,7 @@
                                                 "typemap_name": "ns0::Names"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "api": "capsule",
                                                 "intent": "ctor"
                                             },
@@ -5728,6 +5901,7 @@
                                                 "vargs": "ARG_rv"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "intent": "ctor"
                                             },
                                             "stmt": "py_ctor_shadow"
@@ -5736,6 +5910,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "intent": "ctor"
                                             }
                                         }
@@ -5803,6 +5978,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -5826,6 +6002,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -5837,6 +6014,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -5845,6 +6023,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -5915,6 +6094,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -5938,6 +6118,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -5949,6 +6130,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -5957,6 +6139,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -6212,6 +6395,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -6234,6 +6418,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -6245,6 +6430,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -6253,6 +6439,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -6864,6 +7051,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -6887,6 +7075,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -6895,6 +7084,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         }
@@ -6977,6 +7167,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -6999,6 +7190,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -7007,6 +7199,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -7091,6 +7284,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -7113,6 +7307,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -7121,6 +7316,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -44,6 +44,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -66,6 +67,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -74,6 +76,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -96,6 +96,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -158,6 +159,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -184,6 +186,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string&"
@@ -192,6 +195,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -253,6 +257,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -275,6 +280,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -286,6 +292,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -294,6 +301,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -493,6 +501,7 @@
                                                 "vargs": "SHCXX_rv"
                                             },
                                             "meta": {
+                                                "abstract": "struct",
                                                 "intent": "ctor"
                                             },
                                             "stmt": "py_ctor_struct"
@@ -518,6 +527,7 @@
                                                 "value_var": "SHValue_dfield"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -544,6 +554,7 @@
                                                 "value_var": "SHValue_ifield"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -553,17 +564,20 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "struct",
                                                 "intent": "ctor"
                                             }
                                         },
                                         "dfield": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
                                         },
                                         "ifield": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -752,6 +766,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -774,6 +789,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -785,6 +801,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -793,6 +810,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }

--- a/regression/reference/namespacedoc/namespacedoc.json
+++ b/regression/reference/namespacedoc/namespacedoc.json
@@ -45,6 +45,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -67,6 +68,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -78,6 +80,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -86,6 +89,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -146,6 +150,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -168,6 +173,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -179,6 +185,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -187,6 +194,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -253,6 +261,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -275,6 +284,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -286,6 +296,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -294,6 +305,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -390,6 +402,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -412,6 +425,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -423,6 +437,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -431,6 +446,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -527,6 +543,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -549,6 +566,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -560,6 +578,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -568,6 +587,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -1,659 +1,4 @@
 ***** Fortran/C
-root
-  c
-    ctor
-      shadow
-        capptr -- c_ctor_shadow_capptr
-          shared -- c_ctor_shadow_capptr_shared
-        capsule -- c_ctor_shadow_capsule
-    dtor -- c_dtor
-    function
-      bool -- c_function_bool
-      char -- c_function_char
-      char* -- c_function_char*
-        arg -- c_function_char*_arg
-        buf
-          arg -- c_function_char*_buf_arg
-          copy -- c_function_char*_buf_copy
-      enum -- c_function_enum
-      native -- c_function_native
-      native& -- c_function_native&
-      native* -- c_function_native*
-        caller -- c_function_native*_caller
-        scalar -- c_function_native*_scalar
-      native** -- c_function_native**
-      shadow
-        capptr -- c_function_shadow_capptr
-      shadow&
-        capptr -- c_function_shadow&_capptr
-          caller -- c_function_shadow&_capptr_caller
-          library -- c_function_shadow&_capptr_library
-        capsule -- c_function_shadow&_capsule
-          caller -- c_function_shadow&_capsule_caller
-          library -- c_function_shadow&_capsule_library
-      shadow*
-        capptr -- c_function_shadow*_capptr
-          caller -- c_function_shadow*_capptr_caller
-          library -- c_function_shadow*_capptr_library
-          shared -- c_function_shadow*_capptr_shared
-        capsule -- c_function_shadow*_capsule
-        this -- c_function_shadow*_this
-      shadow<native>
-        capptr -- c_function_shadow<native>_capptr
-      string -- c_function_string
-        buf
-          arg -- c_function_string_buf_arg
-          copy -- c_function_string_buf_copy
-      string& -- c_function_string&
-        buf
-          arg -- c_function_string&_buf_arg
-          copy -- c_function_string&_buf_copy
-        copy -- c_function_string&_copy
-      string* -- c_function_string*
-        buf
-          copy -- c_function_string*_buf_copy
-        caller -- c_function_string*_caller
-        copy -- c_function_string*_copy
-        library -- c_function_string*_library
-      struct -- c_function_struct
-      struct* -- c_function_struct*
-      vector<native> -- c_function_vector<native>
-        malloc -- c_function_vector<native>_malloc
-      void* -- c_function_void*
-    getter
-      native -- c_getter_native
-      native* -- c_getter_native*
-    in
-      bool -- c_in_bool
-      char -- c_in_char
-      char* -- c_in_char*
-        buf -- c_in_char*_buf
-      char** -- c_in_char**
-        buf -- c_in_char**_buf
-      enum -- c_in_enum
-      native -- c_in_native
-      native& -- c_in_native&
-      native* -- c_in_native*
-        cdesc -- c_in_native*_cdesc
-      native** -- c_in_native**
-      procedure -- c_in_procedure
-        external -- c_in_procedure_external
-        funptr -- c_in_procedure_funptr
-      shadow -- c_in_shadow
-      shadow& -- c_in_shadow&
-      shadow* -- c_in_shadow*
-      string -- c_in_string
-        buf -- c_in_string_buf
-      string& -- c_in_string&
-        buf -- c_in_string&_buf
-      string* -- c_in_string*
-        buf -- c_in_string*_buf
-      struct -- c_in_struct
-      struct& -- c_in_struct&
-      struct* -- c_in_struct*
-      unknown -- c_in_unknown
-      vector<native*>& -- c_in_vector<native*>&
-        buf -- c_in_vector<native*>&_buf
-      vector<native>
-        buf -- c_in_vector<native>_buf
-      vector<native>& -- c_in_vector<native>&
-        buf -- c_in_vector<native>&_buf
-      vector<native>*
-        buf -- c_in_vector<native>*_buf
-      vector<string>
-        buf -- c_in_vector<string>_buf
-      vector<string>& -- c_in_vector<string>&
-        buf -- c_in_vector<string>&_buf
-      vector<string>*
-        buf -- c_in_vector<string>*_buf
-      void -- c_in_void
-      void* -- c_in_void*
-        cdesc -- c_in_void*_cdesc
-      void** -- c_in_void**
-    inout
-      bool
-        * -- c_inout_bool_*
-      char* -- c_inout_char*
-        buf -- c_inout_char*_buf
-      enum* -- c_inout_enum*
-      native& -- c_inout_native&
-        hidden -- c_inout_native&_hidden
-      native* -- c_inout_native*
-        cdesc -- c_inout_native*_cdesc
-        hidden -- c_inout_native*_hidden
-      shadow& -- c_inout_shadow&
-      shadow* -- c_inout_shadow*
-      string& -- c_inout_string&
-        buf -- c_inout_string&_buf
-      string* -- c_inout_string*
-        buf -- c_inout_string*_buf
-      struct& -- c_inout_struct&
-      struct* -- c_inout_struct*
-      vector<native>
-        buf
-          copy -- c_inout_vector<native>_buf_copy
-          malloc -- c_inout_vector<native>_buf_malloc
-      vector<native>&
-        buf
-          copy -- c_inout_vector<native>&_buf_copy
-          malloc -- c_inout_vector<native>&_buf_malloc
-      vector<native>*
-        buf
-          copy -- c_inout_vector<native>*_buf_copy
-          malloc -- c_inout_vector<native>*_buf_malloc
-      vector<scalar>& -- c_inout_vector<scalar>&
-      void*
-        cdesc -- c_inout_void*_cdesc
-      void** -- c_inout_void**
-    mixin
-      arg
-        cfi -- c_mixin_arg_cfi
-        character
-          cfi -- c_mixin_arg_character_cfi
-        native
-          cfi -- c_mixin_arg_native_cfi
-      character -- c_mixin_character
-      cvar-capsule-fill -- c_mixin_cvar-capsule-fill
-      declare-arg -- c_mixin_declare-arg
-      declare-fortran-result -- c_mixin_declare-fortran-result
-      destructor
-        new-shadow-shared -- c_mixin_destructor_new-shadow-shared
-        new-string -- c_mixin_destructor_new-string
-        new-vector -- c_mixin_destructor_new-vector
-      function -- c_mixin_function
-        char*
-          cdesc -- c_mixin_function_char*_cdesc
-        shadow
-          capptr -- c_mixin_function_shadow_capptr
-        string
-          cdesc -- c_mixin_function_string_cdesc
-        vector
-          malloc -- c_mixin_function_vector_malloc
-      in
-        character
-          buf -- c_mixin_in_character_buf
-      inout
-        vector
-          cdesc -- c_mixin_inout_vector_cdesc
-        vector<native>
-          cdesc -- c_mixin_inout_vector<native>_cdesc
-      native
-        capsule
-          fill -- c_mixin_native_capsule_fill
-        cdesc
-          fill-cdesc -- c_mixin_native_cdesc_fill-cdesc
-        cfi
-          allocatable -- c_mixin_native_cfi_allocatable
-          pointer -- c_mixin_native_cfi_pointer
-      noargs -- c_mixin_noargs
-      out
-        native** -- c_mixin_out_native**
-        vector
-          buf
-            malloc -- c_mixin_out_vector_buf_malloc
-        vector<native>
-          cdesc -- c_mixin_out_vector<native>_cdesc
-      shadow -- c_mixin_shadow
-      unknown -- c_mixin_unknown
-      vector
-        cdesc
-          fill-cdesc -- c_mixin_vector_cdesc_fill-cdesc
-    out
-      bool
-        * -- c_out_bool_*
-      char
-        *
-          buf -- c_out_char_*_buf
-      char* -- c_out_char*
-      enum* -- c_out_enum*
-      native& -- c_out_native&
-        hidden -- c_out_native&_hidden
-      native* -- c_out_native*
-        cdesc -- c_out_native*_cdesc
-        hidden -- c_out_native*_hidden
-      native*& -- c_out_native*&
-      native** -- c_out_native**
-        raw -- c_out_native**_raw
-      native*** -- c_out_native***
-      string& -- c_out_string&
-        buf -- c_out_string&_buf
-      string* -- c_out_string*
-        buf -- c_out_string*_buf
-      string** -- c_out_string**
-        cdesc
-          copy -- c_out_string**_cdesc_copy
-      struct& -- c_out_struct&
-      struct* -- c_out_struct*
-      vector<native>
-        buf
-          copy -- c_out_vector<native>_buf_copy
-          malloc -- c_out_vector<native>_buf_malloc
-      vector<native>& -- c_out_vector<native>&
-        buf
-          copy -- c_out_vector<native>&_buf_copy
-          malloc -- c_out_vector<native>&_buf_malloc
-        cdesc -- c_out_vector<native>&_cdesc
-      vector<native>*
-        buf
-          copy -- c_out_vector<native>*_buf_copy
-          malloc -- c_out_vector<native>*_buf_malloc
-        cdesc -- c_out_vector<native>*_cdesc
-      vector<string>
-        buf
-          copy -- c_out_vector<string>_buf_copy
-      vector<string>& -- c_out_vector<string>&
-        buf
-          copy -- c_out_vector<string>&_buf_copy
-        cdesc -- c_out_vector<string>&_cdesc
-          allocatable -- c_out_vector<string>&_cdesc_allocatable
-      vector<string>*
-        buf
-          copy -- c_out_vector<string>*_buf_copy
-      void*
-        cdesc -- c_out_void*_cdesc
-      void*& -- c_out_void*&
-      void** -- c_out_void**
-    setter -- c_setter
-      native -- c_setter_native
-      native* -- c_setter_native*
-      string
-        scalar
-          buf -- c_setter_string_scalar_buf
-    subroutine -- c_subroutine
-  f
-    ctor
-      shadow
-        capsule -- f_ctor_shadow_capsule
-          shared -- f_ctor_shadow_capsule_shared
-    dtor -- f_dtor
-    function
-      bool -- f_function_bool
-      char -- f_function_char
-        cdesc
-          allocatable -- f_function_char_cdesc_allocatable
-          pointer -- f_function_char_cdesc_pointer
-        cfi
-          allocatable -- f_function_char_cfi_allocatable
-          pointer -- f_function_char_cfi_pointer
-      char* -- f_function_char*
-        allocatable -- f_function_char*_allocatable
-        arg -- f_function_char*_arg
-        buf
-          arg -- f_function_char*_buf_arg
-          copy -- f_function_char*_buf_copy
-        cdesc
-          allocatable -- f_function_char*_cdesc_allocatable
-          pointer -- f_function_char*_cdesc_pointer
-        cfi
-          allocatable -- f_function_char*_cfi_allocatable
-          arg -- f_function_char*_cfi_arg
-          copy -- f_function_char*_cfi_copy
-          pointer -- f_function_char*_cfi_pointer
-        copy -- f_function_char*_copy
-        pointer -- f_function_char*_pointer
-        raw -- f_function_char*_raw
-      enum -- f_function_enum
-      native -- f_function_native
-      native& -- f_function_native&
-        pointer -- f_function_native&_pointer
-      native*
-        cdesc
-          allocatable -- f_function_native*_cdesc_allocatable
-          pointer -- f_function_native*_cdesc_pointer
-            caller -- f_function_native*_cdesc_pointer_caller
-        cfi
-          allocatable -- f_function_native*_cfi_allocatable
-          pointer -- f_function_native*_cfi_pointer
-        pointer -- f_function_native*_pointer
-          caller -- f_function_native*_pointer_caller
-        raw -- f_function_native*_raw
-        scalar -- f_function_native*_scalar
-      native** -- f_function_native**
-      shadow
-        capsule -- f_function_shadow_capsule
-      shadow&
-        capsule -- f_function_shadow&_capsule
-          caller -- f_function_shadow&_capsule_caller
-          library -- f_function_shadow&_capsule_library
-      shadow*
-        capsule -- f_function_shadow*_capsule
-          caller -- f_function_shadow*_capsule_caller
-          library -- f_function_shadow*_capsule_library
-        this -- f_function_shadow*_this
-      shadow<native>
-        capsule -- f_function_shadow<native>_capsule
-      string
-        buf -- f_function_string_buf
-          arg -- f_function_string_buf_arg
-          copy -- f_function_string_buf_copy
-        cdesc
-          allocatable -- f_function_string_cdesc_allocatable
-            caller -- f_function_string_cdesc_allocatable_caller
-            library -- f_function_string_cdesc_allocatable_library
-        cfi
-          allocatable -- f_function_string_cfi_allocatable
-            caller -- f_function_string_cfi_allocatable_caller
-            library -- f_function_string_cfi_allocatable_library
-          arg -- f_function_string_cfi_arg
-          copy -- f_function_string_cfi_copy
-          pointer -- f_function_string_cfi_pointer
-            caller -- f_function_string_cfi_pointer_caller
-            library -- f_function_string_cfi_pointer_library
-      string&
-        buf -- f_function_string&_buf
-          arg -- f_function_string&_buf_arg
-          copy -- f_function_string&_buf_copy
-        cdesc
-          allocatable -- f_function_string&_cdesc_allocatable
-            caller -- f_function_string&_cdesc_allocatable_caller
-            library -- f_function_string&_cdesc_allocatable_library
-          pointer -- f_function_string&_cdesc_pointer
-            caller -- f_function_string&_cdesc_pointer_caller
-            library -- f_function_string&_cdesc_pointer_library
-        cfi
-          allocatable -- f_function_string&_cfi_allocatable
-            caller -- f_function_string&_cfi_allocatable_caller
-            library -- f_function_string&_cfi_allocatable_library
-          arg -- f_function_string&_cfi_arg
-          copy -- f_function_string&_cfi_copy
-          pointer -- f_function_string&_cfi_pointer
-            caller -- f_function_string&_cfi_pointer_caller
-            library -- f_function_string&_cfi_pointer_library
-      string*
-        buf -- f_function_string*_buf
-          copy -- f_function_string*_buf_copy
-        cdesc
-          allocatable -- f_function_string*_cdesc_allocatable
-            caller -- f_function_string*_cdesc_allocatable_caller
-            library -- f_function_string*_cdesc_allocatable_library
-          pointer -- f_function_string*_cdesc_pointer
-            caller -- f_function_string*_cdesc_pointer_caller
-            library -- f_function_string*_cdesc_pointer_library
-        cfi
-          allocatable -- f_function_string*_cfi_allocatable
-            caller -- f_function_string*_cfi_allocatable_caller
-            library -- f_function_string*_cfi_allocatable_library
-          copy -- f_function_string*_cfi_copy
-          pointer -- f_function_string*_cfi_pointer
-            caller -- f_function_string*_cfi_pointer_caller
-            library -- f_function_string*_cfi_pointer_library
-      struct -- f_function_struct
-      struct*
-        cdesc
-          pointer -- f_function_struct*_cdesc_pointer
-        pointer -- f_function_struct*_pointer
-      vector
-        scalar
-          cdesc -- f_function_vector_scalar_cdesc
-      vector<native>
-        cdesc
-          allocatable -- f_function_vector<native>_cdesc_allocatable
-      void* -- f_function_void*
-    getter
-      bool -- f_getter_bool
-      native -- f_getter_native
-      native*
-        cdesc
-          pointer -- f_getter_native*_cdesc_pointer
-        pointer -- f_getter_native*_pointer
-      string
-        cdesc
-          allocatable -- f_getter_string_cdesc_allocatable
-      struct*
-        cdesc
-          pointer -- f_getter_struct*_cdesc_pointer
-        fapi
-          pointer -- f_getter_struct*_fapi_pointer
-      struct**
-        cdesc
-          raw -- f_getter_struct**_cdesc_raw
-    in
-      bool -- f_in_bool
-      char -- f_in_char
-      char* -- f_in_char*
-        buf -- f_in_char*_buf
-        capi -- f_in_char*_capi
-        cfi -- f_in_char*_cfi
-      char** -- f_in_char**
-        buf -- f_in_char**_buf
-        cfi -- f_in_char**_cfi
-      enum -- f_in_enum
-      native -- f_in_native
-      native& -- f_in_native&
-      native* -- f_in_native*
-        cdesc -- f_in_native*_cdesc
-        cfi -- f_in_native*_cfi
-      native** -- f_in_native**
-      procedure -- f_in_procedure
-        external -- f_in_procedure_external
-        funptr -- f_in_procedure_funptr
-      shadow -- f_in_shadow
-      shadow& -- f_in_shadow&
-      shadow* -- f_in_shadow*
-      string
-        buf -- f_in_string_buf
-        cfi -- f_in_string_cfi
-      string& -- f_in_string&
-        buf -- f_in_string&_buf
-        cfi -- f_in_string&_cfi
-      string* -- f_in_string*
-        buf -- f_in_string*_buf
-        cfi -- f_in_string*_cfi
-      struct -- f_in_struct
-      struct& -- f_in_struct&
-      struct* -- f_in_struct*
-      unknown -- f_in_unknown
-      vector
-        &
-          cdesc
-            targ
-              native
-                scalar -- f_in_vector_&_cdesc_targ_native_scalar
-      vector<native*>&
-        buf -- f_in_vector<native*>&_buf
-      vector<native>
-        buf -- f_in_vector<native>_buf
-      vector<native>&
-        buf -- f_in_vector<native>&_buf
-      vector<native>*
-        buf -- f_in_vector<native>*_buf
-      vector<string>
-        buf -- f_in_vector<string>_buf
-      vector<string>&
-        buf -- f_in_vector<string>&_buf
-      vector<string>*
-        buf -- f_in_vector<string>*_buf
-      void -- f_in_void
-      void* -- f_in_void*
-        cdesc -- f_in_void*_cdesc
-      void** -- f_in_void**
-        cfi -- f_in_void**_cfi
-    inout
-      bool* -- f_inout_bool*
-      char* -- f_inout_char*
-        buf -- f_inout_char*_buf
-        capi -- f_inout_char*_capi
-        cfi -- f_inout_char*_cfi
-      enum* -- f_inout_enum*
-      native& -- f_inout_native&
-        hidden -- f_inout_native&_hidden
-      native* -- f_inout_native*
-        cdesc -- f_inout_native*_cdesc
-        cfi -- f_inout_native*_cfi
-        hidden -- f_inout_native*_hidden
-      shadow& -- f_inout_shadow&
-      shadow* -- f_inout_shadow*
-      string& -- f_inout_string&
-        buf -- f_inout_string&_buf
-        cfi -- f_inout_string&_cfi
-      string* -- f_inout_string*
-        buf -- f_inout_string*_buf
-        cfi -- f_inout_string*_cfi
-      struct& -- f_inout_struct&
-      struct* -- f_inout_struct*
-      vector
-        buf
-          targ
-            string
-              scalar -- f_inout_vector_buf_targ_string_scalar
-      vector<native>&
-        cdesc -- f_inout_vector<native>&_cdesc
-          allocatable -- f_inout_vector<native>&_cdesc_allocatable
-      void*
-        cdesc -- f_inout_void*_cdesc
-      void** -- f_inout_void**
-    mixin
-      arg
-        capsule -- f_mixin_arg_capsule
-      capsule
-        dtor -- f_mixin_capsule_dtor
-      char
-        cdesc
-          allocate -- f_mixin_char_cdesc_allocate
-          pointer -- f_mixin_char_cdesc_pointer
-      declare-as-cptr -- f_mixin_declare-as-cptr
-      declare-fortran-arg -- f_mixin_declare-fortran-arg
-      declare-fortran-result -- f_mixin_declare-fortran-result
-      declare-interface-arg -- f_mixin_declare-interface-arg
-      function -- f_mixin_function
-        c-ptr -- f_mixin_function_c-ptr
-        ptr -- f_mixin_function_ptr
-        shadow
-          capsule -- f_mixin_function_shadow_capsule
-        string
-          cfi
-            allocatable -- f_mixin_function_string_cfi_allocatable
-      function-to-subroutine -- f_mixin_function-to-subroutine
-      getter
-        cdesc -- f_mixin_getter_cdesc
-      helper
-        array
-          string
-            allocatable -- f_mixin_helper_array_string_allocatable
-        vector
-          string
-            allocatable -- f_mixin_helper_vector_string_allocatable
-      in
-        2d
-          vector
-            buf -- f_mixin_in_2d_vector_buf
-        string
-          array
-            buf -- f_mixin_in_string_array_buf
-        vector
-          buf -- f_mixin_in_vector_buf
-      inout
-        array
-          cdesc -- f_mixin_inout_array_cdesc
-      interface-as-cptr -- f_mixin_interface-as-cptr
-      interface-as-cptr-value -- f_mixin_interface-as-cptr-value
-      local-logical-var -- f_mixin_local-logical-var
-      native
-        cdesc
-          allocate -- f_mixin_native_cdesc_allocate
-          pointer -- f_mixin_native_cdesc_pointer
-          raw -- f_mixin_native_cdesc_raw
-      out
-        array
-          cdesc
-            allocatable -- f_mixin_out_array_cdesc_allocatable
-        native
-          cdesc
-            allocate -- f_mixin_out_native_cdesc_allocate
-            pointer -- f_mixin_out_native_cdesc_pointer
-        string**
-          cfi -- f_mixin_out_string**_cfi
-        vector
-          buf -- f_mixin_out_vector_buf
-      pass
-        capsule -- f_mixin_pass_capsule
-        cdesc -- f_mixin_pass_cdesc
-        character
-          buf -- f_mixin_pass_character_buf
-      shadow-arg -- f_mixin_shadow-arg
-      str
-        array -- f_mixin_str_array
-      unknown -- f_mixin_unknown
-      use
-        capsule -- f_mixin_use_capsule
-    none
-      bool -- f_none_bool
-      bool* -- f_none_bool*
-      char -- f_none_char
-      char* -- f_none_char*
-      native -- f_none_native
-      native* -- f_none_native*
-      void* -- f_none_void*
-    out
-      bool* -- f_out_bool*
-      char* -- f_out_char*
-        buf -- f_out_char*_buf
-        capi -- f_out_char*_capi
-        cfi -- f_out_char*_cfi
-      enum* -- f_out_enum*
-      native& -- f_out_native&
-        hidden -- f_out_native&_hidden
-      native* -- f_out_native*
-        cdesc -- f_out_native*_cdesc
-        cfi
-          allocatable -- f_out_native*_cfi_allocatable
-        hidden -- f_out_native*_hidden
-      native*&
-        cdesc -- f_out_native*&_cdesc
-          pointer -- f_out_native*&_cdesc_pointer
-      native**
-        cdesc
-          allocatable -- f_out_native**_cdesc_allocatable
-          pointer -- f_out_native**_cdesc_pointer
-        cfi
-          allocatable -- f_out_native**_cfi_allocatable
-          pointer -- f_out_native**_cfi_pointer
-        raw -- f_out_native**_raw
-      native*** -- f_out_native***
-      string&
-        buf -- f_out_string&_buf
-        cfi -- f_out_string&_cfi
-      string*
-        buf -- f_out_string*_buf
-        cfi -- f_out_string*_cfi
-      string**
-        cdesc
-          allocatable -- f_out_string**_cdesc_allocatable
-          copy -- f_out_string**_cdesc_copy
-        cfi
-          allocatable -- f_out_string**_cfi_allocatable
-          copy -- f_out_string**_cfi_copy
-        copy -- f_out_string**_copy
-      struct& -- f_out_struct&
-      struct* -- f_out_struct*
-      vector
-        buf
-          targ
-            string
-              scalar -- f_out_vector_buf_targ_string_scalar
-      vector<native>&
-        cdesc -- f_out_vector<native>&_cdesc
-          allocatable -- f_out_vector<native>&_cdesc_allocatable
-      vector<native>*
-        cdesc -- f_out_vector<native>*_cdesc
-          allocatable -- f_out_vector<native>*_cdesc_allocatable
-      vector<string>&
-        cdesc -- f_out_vector<string>&_cdesc
-          allocatable -- f_out_vector<string>&_cdesc_allocatable
-      void*
-        cdesc -- f_out_void*_cdesc
-      void*& -- f_out_void*&
-      void** -- f_out_void**
-    setter -- f_setter
-      bool -- f_setter_bool
-      native -- f_setter_native
-      native* -- f_setter_native*
-      string
-        buf -- f_setter_string_buf
-      struct* -- f_setter_struct*
-        pointer -- f_setter_struct*_pointer
-      struct** -- f_setter_struct**
-    subroutine -- f_subroutine
 c_ctor_shadow_capptr:
   name: c_ctor_shadow_capptr
   comments:
@@ -14429,207 +13774,662 @@ f_subroutine:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   owner: library
-***** Python
 root
-  py
+  c
     ctor
-      char* -- py_ctor_char*
-        numpy -- py_ctor_char*_numpy
-      char** -- py_ctor_char**
-        list -- py_ctor_char**_list
-      char[] -- py_ctor_char[]
-        list -- py_ctor_char[]_list
-        numpy -- py_ctor_char[]_numpy
-      native -- py_ctor_native
-        list -- py_ctor_native_list
-        numpy -- py_ctor_native_numpy
-      native* -- py_ctor_native*
-        list -- py_ctor_native*_list
-        numpy -- py_ctor_native*_numpy
-      native[] -- py_ctor_native[]
-        list -- py_ctor_native[]_list
-        numpy -- py_ctor_native[]_numpy
-      shadow -- py_ctor_shadow
-      struct -- py_ctor_struct
-    descr
-      bool -- py_descr_bool
-      char* -- py_descr_char*
-        numpy -- py_descr_char*_numpy
-      char**
-        list -- py_descr_char**_list
-      char[] -- py_descr_char[]
-        list -- py_descr_char[]_list
-        numpy -- py_descr_char[]_numpy
-      native -- py_descr_native
-      native*
-        list -- py_descr_native*_list
-        numpy -- py_descr_native*_numpy
-      native[]
-        list -- py_descr_native[]_list
-        numpy -- py_descr_native[]_numpy
+      shadow
+        capptr -- c_ctor_shadow_capptr
+          shared -- c_ctor_shadow_capptr_shared
+        capsule -- c_ctor_shadow_capsule
+    dtor -- c_dtor
     function
-      bool -- py_function_bool
-      char -- py_function_char
-      char* -- py_function_char*
-      enum -- py_function_enum
-      native -- py_function_native
-      native&
-        numpy -- py_function_native&_numpy
-      native*
-        list -- py_function_native*_list
-        numpy -- py_function_native*_numpy
-        scalar -- py_function_native*_scalar
-      shadow -- py_function_shadow
-      shadow& -- py_function_shadow&
-      shadow* -- py_function_shadow*
-      string -- py_function_string
-      string& -- py_function_string&
-      string* -- py_function_string*
-      struct
-        class -- py_function_struct_class
-        list -- py_function_struct_list
-        numpy -- py_function_struct_numpy
-      struct*
-        class -- py_function_struct*_class
-        list -- py_function_struct*_list
-        numpy -- py_function_struct*_numpy
-      vector
-        list -- py_function_vector_list
-        numpy -- py_function_vector_numpy
-      vector<native>
-        list -- py_function_vector<native>_list
-        numpy -- py_function_vector<native>_numpy
-      void* -- py_function_void*
-    implied
-      bool -- py_implied_bool
-      native -- py_implied_native
+      bool -- c_function_bool
+      char -- c_function_char
+      char* -- c_function_char*
+        arg -- c_function_char*_arg
+        buf
+          arg -- c_function_char*_buf_arg
+          copy -- c_function_char*_buf_copy
+      enum -- c_function_enum
+      native -- c_function_native
+      native& -- c_function_native&
+      native* -- c_function_native*
+        caller -- c_function_native*_caller
+        scalar -- c_function_native*_scalar
+      native** -- c_function_native**
+      shadow
+        capptr -- c_function_shadow_capptr
+      shadow&
+        capptr -- c_function_shadow&_capptr
+          caller -- c_function_shadow&_capptr_caller
+          library -- c_function_shadow&_capptr_library
+        capsule -- c_function_shadow&_capsule
+          caller -- c_function_shadow&_capsule_caller
+          library -- c_function_shadow&_capsule_library
+      shadow*
+        capptr -- c_function_shadow*_capptr
+          caller -- c_function_shadow*_capptr_caller
+          library -- c_function_shadow*_capptr_library
+          shared -- c_function_shadow*_capptr_shared
+        capsule -- c_function_shadow*_capsule
+        this -- c_function_shadow*_this
+      shadow<native>
+        capptr -- c_function_shadow<native>_capptr
+      string -- c_function_string
+        buf
+          arg -- c_function_string_buf_arg
+          copy -- c_function_string_buf_copy
+      string& -- c_function_string&
+        buf
+          arg -- c_function_string&_buf_arg
+          copy -- c_function_string&_buf_copy
+        copy -- c_function_string&_copy
+      string* -- c_function_string*
+        buf
+          copy -- c_function_string*_buf_copy
+        caller -- c_function_string*_caller
+        copy -- c_function_string*_copy
+        library -- c_function_string*_library
+      struct -- c_function_struct
+      struct* -- c_function_struct*
+      vector<native> -- c_function_vector<native>
+        malloc -- c_function_vector<native>_malloc
+      void* -- c_function_void*
+    getter
+      native -- c_getter_native
+      native* -- c_getter_native*
     in
-      bool -- py_in_bool
-      char -- py_in_char
-      char* -- py_in_char*
-      char** -- py_in_char**
-      enum -- py_in_enum
-      native -- py_in_native
-      native& -- py_in_native&
-      native* -- py_in_native*
-        list -- py_in_native*_list
-        numpy -- py_in_native*_numpy
-      procedure -- py_in_procedure
-      shadow -- py_in_shadow
-      shadow& -- py_in_shadow&
-      shadow* -- py_in_shadow*
-      string -- py_in_string
-      string& -- py_in_string&
-      string* -- py_in_string*
-      struct
-        class -- py_in_struct_class
-        list -- py_in_struct_list
-        numpy -- py_in_struct_numpy
-      struct&
-        class -- py_in_struct&_class
-        numpy -- py_in_struct&_numpy
-      struct*
-        class -- py_in_struct*_class
-        list -- py_in_struct*_list
-        numpy -- py_in_struct*_numpy
-      unknown -- py_in_unknown
-      vector<native>&
-        list -- py_in_vector<native>&_list
-        numpy -- py_in_vector<native>&_numpy
-      void* -- py_in_void*
+      bool -- c_in_bool
+      char -- c_in_char
+      char* -- c_in_char*
+        buf -- c_in_char*_buf
+      char** -- c_in_char**
+        buf -- c_in_char**_buf
+      enum -- c_in_enum
+      native -- c_in_native
+      native& -- c_in_native&
+      native* -- c_in_native*
+        cdesc -- c_in_native*_cdesc
+      native** -- c_in_native**
+      procedure -- c_in_procedure
+        external -- c_in_procedure_external
+        funptr -- c_in_procedure_funptr
+      shadow -- c_in_shadow
+      shadow& -- c_in_shadow&
+      shadow* -- c_in_shadow*
+      string -- c_in_string
+        buf -- c_in_string_buf
+      string& -- c_in_string&
+        buf -- c_in_string&_buf
+      string* -- c_in_string*
+        buf -- c_in_string*_buf
+      struct -- c_in_struct
+      struct& -- c_in_struct&
+      struct* -- c_in_struct*
+      unknown -- c_in_unknown
+      vector<native*>& -- c_in_vector<native*>&
+        buf -- c_in_vector<native*>&_buf
+      vector<native>
+        buf -- c_in_vector<native>_buf
+      vector<native>& -- c_in_vector<native>&
+        buf -- c_in_vector<native>&_buf
+      vector<native>*
+        buf -- c_in_vector<native>*_buf
+      vector<string>
+        buf -- c_in_vector<string>_buf
+      vector<string>& -- c_in_vector<string>&
+        buf -- c_in_vector<string>&_buf
+      vector<string>*
+        buf -- c_in_vector<string>*_buf
+      void -- c_in_void
+      void* -- c_in_void*
+        cdesc -- c_in_void*_cdesc
+      void** -- c_in_void**
     inout
-      bool -- py_inout_bool
-      bool* -- py_inout_bool*
-      char* -- py_inout_char*
-      native& -- py_inout_native&
-      native* -- py_inout_native*
-        list -- py_inout_native*_list
-        numpy -- py_inout_native*_numpy
-      shadow
-        * -- py_inout_shadow_*
-      string -- py_inout_string
-      string& -- py_inout_string&
-      string* -- py_inout_string*
-      struct
-        list -- py_inout_struct_list
-      struct&
-        class -- py_inout_struct&_class
-        numpy -- py_inout_struct&_numpy
-      struct*
-        class -- py_inout_struct*_class
-        list -- py_inout_struct*_list
-        numpy -- py_inout_struct*_numpy
-    mixin
-      alloc-cxx-type -- py_mixin_alloc-cxx-type
-      array
-        error -- py_mixin_array_error
-      array-ContiguousFromObject -- py_mixin_array-ContiguousFromObject
-      array-FROM-OFT-in -- py_mixin_array-FROM-OFT-in
-      array-FROM-OTF -- py_mixin_array-FROM-OTF
-      array-FromAny -- py_mixin_array-FromAny
-      array-NewFromDescr -- py_mixin_array-NewFromDescr
-      array-NewFromDescr2 -- py_mixin_array-NewFromDescr2
-      array-SimpleNew -- py_mixin_array-SimpleNew
-      array-SimpleNewFromData -- py_mixin_array-SimpleNewFromData
-      array-SimpleNewFromData2 -- py_mixin_array-SimpleNewFromData2
-      array-capsule -- py_mixin_array-capsule
-      array-get-data -- py_mixin_array-get-data
-      array-parse -- py_mixin_array-parse
-      ctor
-        array -- py_mixin_ctor_array
-          fill -- py_mixin_ctor_array_fill
-      cxx-as-pointer -- py_mixin_cxx-as-pointer
-      cxx-as-scalar -- py_mixin_cxx-as-scalar
-      function-assign-pointee -- py_mixin_function-assign-pointee
-      function-declare -- py_mixin_function-declare
-      function-struct-class -- py_mixin_function-struct-class
-      function-void -- py_mixin_function-void
-      malloc -- py_mixin_malloc
-        error -- py_mixin_malloc_error
-        error2 -- py_mixin_malloc_error2
-      shadow-create-object -- py_mixin_shadow-create-object
-      string-fmtdict -- py_mixin_string-fmtdict
-      string-fmtdict-scalar -- py_mixin_string-fmtdict-scalar
-      template
-        array
-          error -- py_mixin_template_array_error
-      unknown -- py_mixin_unknown
-    out
-      bool -- py_out_bool
-      bool* -- py_out_bool*
-      char*
-        charlen -- py_out_char*_charlen
-      enum* -- py_out_enum*
-      native& -- py_out_native&
-      native* -- py_out_native*
-        list -- py_out_native*_list
-        numpy -- py_out_native*_numpy
-      native*&
-        numpy -- py_out_native*&_numpy
-      native**
-        list -- py_out_native**_list
-        numpy -- py_out_native**_numpy
-        raw -- py_out_native**_raw
-      shadow
-        * -- py_out_shadow_*
-      string -- py_out_string
-      string& -- py_out_string&
-      string* -- py_out_string*
-      struct
-        list -- py_out_struct_list
-      struct&
-        class -- py_out_struct&_class
-        numpy -- py_out_struct&_numpy
-      struct*
-        class -- py_out_struct*_class
-        list -- py_out_struct*_list
-        numpy -- py_out_struct*_numpy
+      bool
+        * -- c_inout_bool_*
+      char* -- c_inout_char*
+        buf -- c_inout_char*_buf
+      enum* -- c_inout_enum*
+      native& -- c_inout_native&
+        hidden -- c_inout_native&_hidden
+      native* -- c_inout_native*
+        cdesc -- c_inout_native*_cdesc
+        hidden -- c_inout_native*_hidden
+      shadow& -- c_inout_shadow&
+      shadow* -- c_inout_shadow*
+      string& -- c_inout_string&
+        buf -- c_inout_string&_buf
+      string* -- c_inout_string*
+        buf -- c_inout_string*_buf
+      struct& -- c_inout_struct&
+      struct* -- c_inout_struct*
+      vector<native>
+        buf
+          copy -- c_inout_vector<native>_buf_copy
+          malloc -- c_inout_vector<native>_buf_malloc
       vector<native>&
-        list -- py_out_vector<native>&_list
-        numpy -- py_out_vector<native>&_numpy
-      void*& -- py_out_void*&
-      void** -- py_out_void**
-    subroutine -- py_subroutine
+        buf
+          copy -- c_inout_vector<native>&_buf_copy
+          malloc -- c_inout_vector<native>&_buf_malloc
+      vector<native>*
+        buf
+          copy -- c_inout_vector<native>*_buf_copy
+          malloc -- c_inout_vector<native>*_buf_malloc
+      vector<scalar>& -- c_inout_vector<scalar>&
+      void*
+        cdesc -- c_inout_void*_cdesc
+      void** -- c_inout_void**
+    mixin
+      arg
+        cfi -- c_mixin_arg_cfi
+        character
+          cfi -- c_mixin_arg_character_cfi
+        native
+          cfi -- c_mixin_arg_native_cfi
+      character -- c_mixin_character
+      cvar-capsule-fill -- c_mixin_cvar-capsule-fill
+      declare-arg -- c_mixin_declare-arg
+      declare-fortran-result -- c_mixin_declare-fortran-result
+      destructor
+        new-shadow-shared -- c_mixin_destructor_new-shadow-shared
+        new-string -- c_mixin_destructor_new-string
+        new-vector -- c_mixin_destructor_new-vector
+      function -- c_mixin_function
+        char*
+          cdesc -- c_mixin_function_char*_cdesc
+        shadow
+          capptr -- c_mixin_function_shadow_capptr
+        string
+          cdesc -- c_mixin_function_string_cdesc
+        vector
+          malloc -- c_mixin_function_vector_malloc
+      in
+        character
+          buf -- c_mixin_in_character_buf
+      inout
+        vector
+          cdesc -- c_mixin_inout_vector_cdesc
+        vector<native>
+          cdesc -- c_mixin_inout_vector<native>_cdesc
+      native
+        capsule
+          fill -- c_mixin_native_capsule_fill
+        cdesc
+          fill-cdesc -- c_mixin_native_cdesc_fill-cdesc
+        cfi
+          allocatable -- c_mixin_native_cfi_allocatable
+          pointer -- c_mixin_native_cfi_pointer
+      noargs -- c_mixin_noargs
+      out
+        native** -- c_mixin_out_native**
+        vector
+          buf
+            malloc -- c_mixin_out_vector_buf_malloc
+        vector<native>
+          cdesc -- c_mixin_out_vector<native>_cdesc
+      shadow -- c_mixin_shadow
+      unknown -- c_mixin_unknown
+      vector
+        cdesc
+          fill-cdesc -- c_mixin_vector_cdesc_fill-cdesc
+    out
+      bool
+        * -- c_out_bool_*
+      char
+        *
+          buf -- c_out_char_*_buf
+      char* -- c_out_char*
+      enum* -- c_out_enum*
+      native& -- c_out_native&
+        hidden -- c_out_native&_hidden
+      native* -- c_out_native*
+        cdesc -- c_out_native*_cdesc
+        hidden -- c_out_native*_hidden
+      native*& -- c_out_native*&
+      native** -- c_out_native**
+        raw -- c_out_native**_raw
+      native*** -- c_out_native***
+      string& -- c_out_string&
+        buf -- c_out_string&_buf
+      string* -- c_out_string*
+        buf -- c_out_string*_buf
+      string** -- c_out_string**
+        cdesc
+          copy -- c_out_string**_cdesc_copy
+      struct& -- c_out_struct&
+      struct* -- c_out_struct*
+      vector<native>
+        buf
+          copy -- c_out_vector<native>_buf_copy
+          malloc -- c_out_vector<native>_buf_malloc
+      vector<native>& -- c_out_vector<native>&
+        buf
+          copy -- c_out_vector<native>&_buf_copy
+          malloc -- c_out_vector<native>&_buf_malloc
+        cdesc -- c_out_vector<native>&_cdesc
+      vector<native>*
+        buf
+          copy -- c_out_vector<native>*_buf_copy
+          malloc -- c_out_vector<native>*_buf_malloc
+        cdesc -- c_out_vector<native>*_cdesc
+      vector<string>
+        buf
+          copy -- c_out_vector<string>_buf_copy
+      vector<string>& -- c_out_vector<string>&
+        buf
+          copy -- c_out_vector<string>&_buf_copy
+        cdesc -- c_out_vector<string>&_cdesc
+          allocatable -- c_out_vector<string>&_cdesc_allocatable
+      vector<string>*
+        buf
+          copy -- c_out_vector<string>*_buf_copy
+      void*
+        cdesc -- c_out_void*_cdesc
+      void*& -- c_out_void*&
+      void** -- c_out_void**
+    setter -- c_setter
+      native -- c_setter_native
+      native* -- c_setter_native*
+      string
+        scalar
+          buf -- c_setter_string_scalar_buf
+    subroutine -- c_subroutine
+  f
+    ctor
+      shadow
+        capsule -- f_ctor_shadow_capsule
+          shared -- f_ctor_shadow_capsule_shared
+    dtor -- f_dtor
+    function
+      bool -- f_function_bool
+      char -- f_function_char
+        cdesc
+          allocatable -- f_function_char_cdesc_allocatable
+          pointer -- f_function_char_cdesc_pointer
+        cfi
+          allocatable -- f_function_char_cfi_allocatable
+          pointer -- f_function_char_cfi_pointer
+      char* -- f_function_char*
+        allocatable -- f_function_char*_allocatable
+        arg -- f_function_char*_arg
+        buf
+          arg -- f_function_char*_buf_arg
+          copy -- f_function_char*_buf_copy
+        cdesc
+          allocatable -- f_function_char*_cdesc_allocatable
+          pointer -- f_function_char*_cdesc_pointer
+        cfi
+          allocatable -- f_function_char*_cfi_allocatable
+          arg -- f_function_char*_cfi_arg
+          copy -- f_function_char*_cfi_copy
+          pointer -- f_function_char*_cfi_pointer
+        copy -- f_function_char*_copy
+        pointer -- f_function_char*_pointer
+        raw -- f_function_char*_raw
+      enum -- f_function_enum
+      native -- f_function_native
+      native& -- f_function_native&
+        pointer -- f_function_native&_pointer
+      native*
+        cdesc
+          allocatable -- f_function_native*_cdesc_allocatable
+          pointer -- f_function_native*_cdesc_pointer
+            caller -- f_function_native*_cdesc_pointer_caller
+        cfi
+          allocatable -- f_function_native*_cfi_allocatable
+          pointer -- f_function_native*_cfi_pointer
+        pointer -- f_function_native*_pointer
+          caller -- f_function_native*_pointer_caller
+        raw -- f_function_native*_raw
+        scalar -- f_function_native*_scalar
+      native** -- f_function_native**
+      shadow
+        capsule -- f_function_shadow_capsule
+      shadow&
+        capsule -- f_function_shadow&_capsule
+          caller -- f_function_shadow&_capsule_caller
+          library -- f_function_shadow&_capsule_library
+      shadow*
+        capsule -- f_function_shadow*_capsule
+          caller -- f_function_shadow*_capsule_caller
+          library -- f_function_shadow*_capsule_library
+        this -- f_function_shadow*_this
+      shadow<native>
+        capsule -- f_function_shadow<native>_capsule
+      string
+        buf -- f_function_string_buf
+          arg -- f_function_string_buf_arg
+          copy -- f_function_string_buf_copy
+        cdesc
+          allocatable -- f_function_string_cdesc_allocatable
+            caller -- f_function_string_cdesc_allocatable_caller
+            library -- f_function_string_cdesc_allocatable_library
+        cfi
+          allocatable -- f_function_string_cfi_allocatable
+            caller -- f_function_string_cfi_allocatable_caller
+            library -- f_function_string_cfi_allocatable_library
+          arg -- f_function_string_cfi_arg
+          copy -- f_function_string_cfi_copy
+          pointer -- f_function_string_cfi_pointer
+            caller -- f_function_string_cfi_pointer_caller
+            library -- f_function_string_cfi_pointer_library
+      string&
+        buf -- f_function_string&_buf
+          arg -- f_function_string&_buf_arg
+          copy -- f_function_string&_buf_copy
+        cdesc
+          allocatable -- f_function_string&_cdesc_allocatable
+            caller -- f_function_string&_cdesc_allocatable_caller
+            library -- f_function_string&_cdesc_allocatable_library
+          pointer -- f_function_string&_cdesc_pointer
+            caller -- f_function_string&_cdesc_pointer_caller
+            library -- f_function_string&_cdesc_pointer_library
+        cfi
+          allocatable -- f_function_string&_cfi_allocatable
+            caller -- f_function_string&_cfi_allocatable_caller
+            library -- f_function_string&_cfi_allocatable_library
+          arg -- f_function_string&_cfi_arg
+          copy -- f_function_string&_cfi_copy
+          pointer -- f_function_string&_cfi_pointer
+            caller -- f_function_string&_cfi_pointer_caller
+            library -- f_function_string&_cfi_pointer_library
+      string*
+        buf -- f_function_string*_buf
+          copy -- f_function_string*_buf_copy
+        cdesc
+          allocatable -- f_function_string*_cdesc_allocatable
+            caller -- f_function_string*_cdesc_allocatable_caller
+            library -- f_function_string*_cdesc_allocatable_library
+          pointer -- f_function_string*_cdesc_pointer
+            caller -- f_function_string*_cdesc_pointer_caller
+            library -- f_function_string*_cdesc_pointer_library
+        cfi
+          allocatable -- f_function_string*_cfi_allocatable
+            caller -- f_function_string*_cfi_allocatable_caller
+            library -- f_function_string*_cfi_allocatable_library
+          copy -- f_function_string*_cfi_copy
+          pointer -- f_function_string*_cfi_pointer
+            caller -- f_function_string*_cfi_pointer_caller
+            library -- f_function_string*_cfi_pointer_library
+      struct -- f_function_struct
+      struct*
+        cdesc
+          pointer -- f_function_struct*_cdesc_pointer
+        pointer -- f_function_struct*_pointer
+      vector
+        scalar
+          cdesc -- f_function_vector_scalar_cdesc
+      vector<native>
+        cdesc
+          allocatable -- f_function_vector<native>_cdesc_allocatable
+      void* -- f_function_void*
+    getter
+      bool -- f_getter_bool
+      native -- f_getter_native
+      native*
+        cdesc
+          pointer -- f_getter_native*_cdesc_pointer
+        pointer -- f_getter_native*_pointer
+      string
+        cdesc
+          allocatable -- f_getter_string_cdesc_allocatable
+      struct*
+        cdesc
+          pointer -- f_getter_struct*_cdesc_pointer
+        fapi
+          pointer -- f_getter_struct*_fapi_pointer
+      struct**
+        cdesc
+          raw -- f_getter_struct**_cdesc_raw
+    in
+      bool -- f_in_bool
+      char -- f_in_char
+      char* -- f_in_char*
+        buf -- f_in_char*_buf
+        capi -- f_in_char*_capi
+        cfi -- f_in_char*_cfi
+      char** -- f_in_char**
+        buf -- f_in_char**_buf
+        cfi -- f_in_char**_cfi
+      enum -- f_in_enum
+      native -- f_in_native
+      native& -- f_in_native&
+      native* -- f_in_native*
+        cdesc -- f_in_native*_cdesc
+        cfi -- f_in_native*_cfi
+      native** -- f_in_native**
+      procedure -- f_in_procedure
+        external -- f_in_procedure_external
+        funptr -- f_in_procedure_funptr
+      shadow -- f_in_shadow
+      shadow& -- f_in_shadow&
+      shadow* -- f_in_shadow*
+      string
+        buf -- f_in_string_buf
+        cfi -- f_in_string_cfi
+      string& -- f_in_string&
+        buf -- f_in_string&_buf
+        cfi -- f_in_string&_cfi
+      string* -- f_in_string*
+        buf -- f_in_string*_buf
+        cfi -- f_in_string*_cfi
+      struct -- f_in_struct
+      struct& -- f_in_struct&
+      struct* -- f_in_struct*
+      unknown -- f_in_unknown
+      vector
+        &
+          cdesc
+            targ
+              native
+                scalar -- f_in_vector_&_cdesc_targ_native_scalar
+      vector<native*>&
+        buf -- f_in_vector<native*>&_buf
+      vector<native>
+        buf -- f_in_vector<native>_buf
+      vector<native>&
+        buf -- f_in_vector<native>&_buf
+      vector<native>*
+        buf -- f_in_vector<native>*_buf
+      vector<string>
+        buf -- f_in_vector<string>_buf
+      vector<string>&
+        buf -- f_in_vector<string>&_buf
+      vector<string>*
+        buf -- f_in_vector<string>*_buf
+      void -- f_in_void
+      void* -- f_in_void*
+        cdesc -- f_in_void*_cdesc
+      void** -- f_in_void**
+        cfi -- f_in_void**_cfi
+    inout
+      bool* -- f_inout_bool*
+      char* -- f_inout_char*
+        buf -- f_inout_char*_buf
+        capi -- f_inout_char*_capi
+        cfi -- f_inout_char*_cfi
+      enum* -- f_inout_enum*
+      native& -- f_inout_native&
+        hidden -- f_inout_native&_hidden
+      native* -- f_inout_native*
+        cdesc -- f_inout_native*_cdesc
+        cfi -- f_inout_native*_cfi
+        hidden -- f_inout_native*_hidden
+      shadow& -- f_inout_shadow&
+      shadow* -- f_inout_shadow*
+      string& -- f_inout_string&
+        buf -- f_inout_string&_buf
+        cfi -- f_inout_string&_cfi
+      string* -- f_inout_string*
+        buf -- f_inout_string*_buf
+        cfi -- f_inout_string*_cfi
+      struct& -- f_inout_struct&
+      struct* -- f_inout_struct*
+      vector
+        buf
+          targ
+            string
+              scalar -- f_inout_vector_buf_targ_string_scalar
+      vector<native>&
+        cdesc -- f_inout_vector<native>&_cdesc
+          allocatable -- f_inout_vector<native>&_cdesc_allocatable
+      void*
+        cdesc -- f_inout_void*_cdesc
+      void** -- f_inout_void**
+    mixin
+      arg
+        capsule -- f_mixin_arg_capsule
+      capsule
+        dtor -- f_mixin_capsule_dtor
+      char
+        cdesc
+          allocate -- f_mixin_char_cdesc_allocate
+          pointer -- f_mixin_char_cdesc_pointer
+      declare-as-cptr -- f_mixin_declare-as-cptr
+      declare-fortran-arg -- f_mixin_declare-fortran-arg
+      declare-fortran-result -- f_mixin_declare-fortran-result
+      declare-interface-arg -- f_mixin_declare-interface-arg
+      function -- f_mixin_function
+        c-ptr -- f_mixin_function_c-ptr
+        ptr -- f_mixin_function_ptr
+        shadow
+          capsule -- f_mixin_function_shadow_capsule
+        string
+          cfi
+            allocatable -- f_mixin_function_string_cfi_allocatable
+      function-to-subroutine -- f_mixin_function-to-subroutine
+      getter
+        cdesc -- f_mixin_getter_cdesc
+      helper
+        array
+          string
+            allocatable -- f_mixin_helper_array_string_allocatable
+        vector
+          string
+            allocatable -- f_mixin_helper_vector_string_allocatable
+      in
+        2d
+          vector
+            buf -- f_mixin_in_2d_vector_buf
+        string
+          array
+            buf -- f_mixin_in_string_array_buf
+        vector
+          buf -- f_mixin_in_vector_buf
+      inout
+        array
+          cdesc -- f_mixin_inout_array_cdesc
+      interface-as-cptr -- f_mixin_interface-as-cptr
+      interface-as-cptr-value -- f_mixin_interface-as-cptr-value
+      local-logical-var -- f_mixin_local-logical-var
+      native
+        cdesc
+          allocate -- f_mixin_native_cdesc_allocate
+          pointer -- f_mixin_native_cdesc_pointer
+          raw -- f_mixin_native_cdesc_raw
+      out
+        array
+          cdesc
+            allocatable -- f_mixin_out_array_cdesc_allocatable
+        native
+          cdesc
+            allocate -- f_mixin_out_native_cdesc_allocate
+            pointer -- f_mixin_out_native_cdesc_pointer
+        string**
+          cfi -- f_mixin_out_string**_cfi
+        vector
+          buf -- f_mixin_out_vector_buf
+      pass
+        capsule -- f_mixin_pass_capsule
+        cdesc -- f_mixin_pass_cdesc
+        character
+          buf -- f_mixin_pass_character_buf
+      shadow-arg -- f_mixin_shadow-arg
+      str
+        array -- f_mixin_str_array
+      unknown -- f_mixin_unknown
+      use
+        capsule -- f_mixin_use_capsule
+    none
+      bool -- f_none_bool
+      bool* -- f_none_bool*
+      char -- f_none_char
+      char* -- f_none_char*
+      native -- f_none_native
+      native* -- f_none_native*
+      void* -- f_none_void*
+    out
+      bool* -- f_out_bool*
+      char* -- f_out_char*
+        buf -- f_out_char*_buf
+        capi -- f_out_char*_capi
+        cfi -- f_out_char*_cfi
+      enum* -- f_out_enum*
+      native& -- f_out_native&
+        hidden -- f_out_native&_hidden
+      native* -- f_out_native*
+        cdesc -- f_out_native*_cdesc
+        cfi
+          allocatable -- f_out_native*_cfi_allocatable
+        hidden -- f_out_native*_hidden
+      native*&
+        cdesc -- f_out_native*&_cdesc
+          pointer -- f_out_native*&_cdesc_pointer
+      native**
+        cdesc
+          allocatable -- f_out_native**_cdesc_allocatable
+          pointer -- f_out_native**_cdesc_pointer
+        cfi
+          allocatable -- f_out_native**_cfi_allocatable
+          pointer -- f_out_native**_cfi_pointer
+        raw -- f_out_native**_raw
+      native*** -- f_out_native***
+      string&
+        buf -- f_out_string&_buf
+        cfi -- f_out_string&_cfi
+      string*
+        buf -- f_out_string*_buf
+        cfi -- f_out_string*_cfi
+      string**
+        cdesc
+          allocatable -- f_out_string**_cdesc_allocatable
+          copy -- f_out_string**_cdesc_copy
+        cfi
+          allocatable -- f_out_string**_cfi_allocatable
+          copy -- f_out_string**_cfi_copy
+        copy -- f_out_string**_copy
+      struct& -- f_out_struct&
+      struct* -- f_out_struct*
+      vector
+        buf
+          targ
+            string
+              scalar -- f_out_vector_buf_targ_string_scalar
+      vector<native>&
+        cdesc -- f_out_vector<native>&_cdesc
+          allocatable -- f_out_vector<native>&_cdesc_allocatable
+      vector<native>*
+        cdesc -- f_out_vector<native>*_cdesc
+          allocatable -- f_out_vector<native>*_cdesc_allocatable
+      vector<string>&
+        cdesc -- f_out_vector<string>&_cdesc
+          allocatable -- f_out_vector<string>&_cdesc_allocatable
+      void*
+        cdesc -- f_out_void*_cdesc
+      void*& -- f_out_void*&
+      void** -- f_out_void**
+    setter -- f_setter
+      bool -- f_setter_bool
+      native -- f_setter_native
+      native* -- f_setter_native*
+      string
+        buf -- f_setter_string_buf
+      struct* -- f_setter_struct*
+        pointer -- f_setter_struct*_pointer
+      struct** -- f_setter_struct**
+    subroutine -- f_subroutine
+***** Python
 py_ctor_char*:
   name: py_ctor_char*
   intent: ctor
@@ -17181,39 +16981,207 @@ py_subroutine:
   intent: subroutine
   call:
   - '{C_call_function};'
-***** Lua
 root
-  lua
-    ctor -- lua_ctor
-    dtor -- lua_dtor
+  py
+    ctor
+      char* -- py_ctor_char*
+        numpy -- py_ctor_char*_numpy
+      char** -- py_ctor_char**
+        list -- py_ctor_char**_list
+      char[] -- py_ctor_char[]
+        list -- py_ctor_char[]_list
+        numpy -- py_ctor_char[]_numpy
+      native -- py_ctor_native
+        list -- py_ctor_native_list
+        numpy -- py_ctor_native_numpy
+      native* -- py_ctor_native*
+        list -- py_ctor_native*_list
+        numpy -- py_ctor_native*_numpy
+      native[] -- py_ctor_native[]
+        list -- py_ctor_native[]_list
+        numpy -- py_ctor_native[]_numpy
+      shadow -- py_ctor_shadow
+      struct -- py_ctor_struct
+    descr
+      bool -- py_descr_bool
+      char* -- py_descr_char*
+        numpy -- py_descr_char*_numpy
+      char**
+        list -- py_descr_char**_list
+      char[] -- py_descr_char[]
+        list -- py_descr_char[]_list
+        numpy -- py_descr_char[]_numpy
+      native -- py_descr_native
+      native*
+        list -- py_descr_native*_list
+        numpy -- py_descr_native*_numpy
+      native[]
+        list -- py_descr_native[]_list
+        numpy -- py_descr_native[]_numpy
     function
-      bool -- lua_function_bool
-      enum -- lua_function_enum
-      native -- lua_function_native
-      shadow* -- lua_function_shadow*
-      string -- lua_function_string
-      string& -- lua_function_string&
-      void* -- lua_function_void*
+      bool -- py_function_bool
+      char -- py_function_char
+      char* -- py_function_char*
+      enum -- py_function_enum
+      native -- py_function_native
+      native&
+        numpy -- py_function_native&_numpy
+      native*
+        list -- py_function_native*_list
+        numpy -- py_function_native*_numpy
+        scalar -- py_function_native*_scalar
+      shadow -- py_function_shadow
+      shadow& -- py_function_shadow&
+      shadow* -- py_function_shadow*
+      string -- py_function_string
+      string& -- py_function_string&
+      string* -- py_function_string*
+      struct
+        class -- py_function_struct_class
+        list -- py_function_struct_list
+        numpy -- py_function_struct_numpy
+      struct*
+        class -- py_function_struct*_class
+        list -- py_function_struct*_list
+        numpy -- py_function_struct*_numpy
+      vector
+        list -- py_function_vector_list
+        numpy -- py_function_vector_numpy
+      vector<native>
+        list -- py_function_vector<native>_list
+        numpy -- py_function_vector<native>_numpy
+      void* -- py_function_void*
+    implied
+      bool -- py_implied_bool
+      native -- py_implied_native
     in
-      bool -- lua_in_bool
-      enum -- lua_in_enum
-      native -- lua_in_native
-      native* -- lua_in_native*
-      procedure -- lua_in_procedure
-      shadow* -- lua_in_shadow*
-      string& -- lua_in_string&
-      string* -- lua_in_string*
-      unknown -- lua_in_unknown
-      void -- lua_in_void
+      bool -- py_in_bool
+      char -- py_in_char
+      char* -- py_in_char*
+      char** -- py_in_char**
+      enum -- py_in_enum
+      native -- py_in_native
+      native& -- py_in_native&
+      native* -- py_in_native*
+        list -- py_in_native*_list
+        numpy -- py_in_native*_numpy
+      procedure -- py_in_procedure
+      shadow -- py_in_shadow
+      shadow& -- py_in_shadow&
+      shadow* -- py_in_shadow*
+      string -- py_in_string
+      string& -- py_in_string&
+      string* -- py_in_string*
+      struct
+        class -- py_in_struct_class
+        list -- py_in_struct_list
+        numpy -- py_in_struct_numpy
+      struct&
+        class -- py_in_struct&_class
+        numpy -- py_in_struct&_numpy
+      struct*
+        class -- py_in_struct*_class
+        list -- py_in_struct*_list
+        numpy -- py_in_struct*_numpy
+      unknown -- py_in_unknown
+      vector<native>&
+        list -- py_in_vector<native>&_list
+        numpy -- py_in_vector<native>&_numpy
+      void* -- py_in_void*
     inout
-      native* -- lua_inout_native*
+      bool -- py_inout_bool
+      bool* -- py_inout_bool*
+      char* -- py_inout_char*
+      native& -- py_inout_native&
+      native* -- py_inout_native*
+        list -- py_inout_native*_list
+        numpy -- py_inout_native*_numpy
+      shadow
+        * -- py_inout_shadow_*
+      string -- py_inout_string
+      string& -- py_inout_string&
+      string* -- py_inout_string*
+      struct
+        list -- py_inout_struct_list
+      struct&
+        class -- py_inout_struct&_class
+        numpy -- py_inout_struct&_numpy
+      struct*
+        class -- py_inout_struct*_class
+        list -- py_inout_struct*_list
+        numpy -- py_inout_struct*_numpy
     mixin
-      callfunction -- lua_mixin_callfunction
-      push -- lua_mixin_push
-      unknown -- lua_mixin_unknown
+      alloc-cxx-type -- py_mixin_alloc-cxx-type
+      array
+        error -- py_mixin_array_error
+      array-ContiguousFromObject -- py_mixin_array-ContiguousFromObject
+      array-FROM-OFT-in -- py_mixin_array-FROM-OFT-in
+      array-FROM-OTF -- py_mixin_array-FROM-OTF
+      array-FromAny -- py_mixin_array-FromAny
+      array-NewFromDescr -- py_mixin_array-NewFromDescr
+      array-NewFromDescr2 -- py_mixin_array-NewFromDescr2
+      array-SimpleNew -- py_mixin_array-SimpleNew
+      array-SimpleNewFromData -- py_mixin_array-SimpleNewFromData
+      array-SimpleNewFromData2 -- py_mixin_array-SimpleNewFromData2
+      array-capsule -- py_mixin_array-capsule
+      array-get-data -- py_mixin_array-get-data
+      array-parse -- py_mixin_array-parse
+      ctor
+        array -- py_mixin_ctor_array
+          fill -- py_mixin_ctor_array_fill
+      cxx-as-pointer -- py_mixin_cxx-as-pointer
+      cxx-as-scalar -- py_mixin_cxx-as-scalar
+      function-assign-pointee -- py_mixin_function-assign-pointee
+      function-declare -- py_mixin_function-declare
+      function-struct-class -- py_mixin_function-struct-class
+      function-void -- py_mixin_function-void
+      malloc -- py_mixin_malloc
+        error -- py_mixin_malloc_error
+        error2 -- py_mixin_malloc_error2
+      shadow-create-object -- py_mixin_shadow-create-object
+      string-fmtdict -- py_mixin_string-fmtdict
+      string-fmtdict-scalar -- py_mixin_string-fmtdict-scalar
+      template
+        array
+          error -- py_mixin_template_array_error
+      unknown -- py_mixin_unknown
     out
-      native* -- lua_out_native*
-    subroutine -- lua_subroutine
+      bool -- py_out_bool
+      bool* -- py_out_bool*
+      char*
+        charlen -- py_out_char*_charlen
+      enum* -- py_out_enum*
+      native& -- py_out_native&
+      native* -- py_out_native*
+        list -- py_out_native*_list
+        numpy -- py_out_native*_numpy
+      native*&
+        numpy -- py_out_native*&_numpy
+      native**
+        list -- py_out_native**_list
+        numpy -- py_out_native**_numpy
+        raw -- py_out_native**_raw
+      shadow
+        * -- py_out_shadow_*
+      string -- py_out_string
+      string& -- py_out_string&
+      string* -- py_out_string*
+      struct
+        list -- py_out_struct_list
+      struct&
+        class -- py_out_struct&_class
+        numpy -- py_out_struct&_numpy
+      struct*
+        class -- py_out_struct*_class
+        list -- py_out_struct*_list
+        numpy -- py_out_struct*_numpy
+      vector<native>&
+        list -- py_out_vector<native>&_list
+        numpy -- py_out_vector<native>&_numpy
+      void*& -- py_out_void*&
+      void** -- py_out_void**
+    subroutine -- py_subroutine
+***** Lua
 lua_ctor:
   name: lua_ctor
   intent: ctor
@@ -17346,3 +17314,35 @@ lua_subroutine:
   intent: subroutine
   call:
   - '{LUA_this_call}{function_name}({cxx_call_list});'
+root
+  lua
+    ctor -- lua_ctor
+    dtor -- lua_dtor
+    function
+      bool -- lua_function_bool
+      enum -- lua_function_enum
+      native -- lua_function_native
+      shadow* -- lua_function_shadow*
+      string -- lua_function_string
+      string& -- lua_function_string&
+      void* -- lua_function_void*
+    in
+      bool -- lua_in_bool
+      enum -- lua_in_enum
+      native -- lua_in_native
+      native* -- lua_in_native*
+      procedure -- lua_in_procedure
+      shadow* -- lua_in_shadow*
+      string& -- lua_in_string&
+      string* -- lua_in_string*
+      unknown -- lua_in_unknown
+      void -- lua_in_void
+    inout
+      native* -- lua_inout_native*
+    mixin
+      callfunction -- lua_mixin_callfunction
+      push -- lua_mixin_push
+      unknown -- lua_mixin_unknown
+    out
+      native* -- lua_out_native*
+    subroutine -- lua_subroutine

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -47,6 +47,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "c_dtor"
@@ -70,6 +71,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "f_dtor"
@@ -81,6 +83,7 @@
                                         "stmt": "lua_dtor"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -88,6 +91,7 @@
                             "py": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -95,6 +99,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }
@@ -205,6 +210,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -213,6 +219,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -403,6 +410,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -411,6 +419,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -493,6 +502,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -541,6 +551,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -550,6 +561,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -573,6 +585,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -582,6 +595,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -679,6 +693,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -729,6 +744,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -738,6 +754,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -761,6 +778,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_numpy"
@@ -769,6 +787,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -887,6 +906,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -923,6 +943,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -931,11 +952,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1055,6 +1078,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1097,6 +1121,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1161,6 +1186,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -1205,6 +1231,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -1214,6 +1241,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1225,6 +1253,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1253,6 +1282,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1283,6 +1313,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -1292,6 +1323,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1303,6 +1335,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1441,6 +1474,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1483,6 +1517,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1554,6 +1589,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -1598,6 +1634,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -1607,6 +1644,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1618,6 +1656,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1646,6 +1685,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1676,6 +1716,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -1685,6 +1726,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1696,6 +1738,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1829,6 +1872,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1871,6 +1915,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1935,6 +1980,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -1979,6 +2025,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -1988,6 +2035,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -1999,6 +2047,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2027,6 +2076,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2057,6 +2107,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -2066,6 +2117,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2077,6 +2129,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2203,6 +2256,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2246,6 +2300,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -2254,6 +2309,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2266,6 +2322,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2386,6 +2443,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2429,6 +2487,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -2496,6 +2555,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -2541,6 +2601,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -2550,6 +2611,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2562,6 +2624,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2590,6 +2653,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2621,6 +2685,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -2630,6 +2695,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2642,6 +2708,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2769,6 +2836,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2812,6 +2880,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -2820,6 +2889,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2832,6 +2902,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -2860,6 +2931,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2891,6 +2963,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -2900,6 +2973,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -2912,6 +2986,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3044,6 +3119,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3087,6 +3163,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3154,6 +3231,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3199,6 +3277,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3208,6 +3287,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3220,6 +3300,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3248,6 +3329,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3279,6 +3361,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3288,6 +3371,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3300,6 +3384,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3396,17 +3481,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "owner": "library"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3489,11 +3577,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3506,6 +3596,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3588,11 +3679,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3605,6 +3698,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3686,11 +3780,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3703,6 +3799,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3784,17 +3881,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out",
                                 "owner": "caller"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3877,11 +3977,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3894,6 +3996,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3976,11 +4079,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -3993,6 +4098,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4074,11 +4180,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "len"
@@ -4091,6 +4199,7 @@
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4151,6 +4260,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4180,6 +4290,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4205,6 +4316,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4243,6 +4355,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4252,11 +4365,13 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4268,6 +4383,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4291,6 +4407,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4300,11 +4417,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4413,6 +4532,7 @@
                                 "typemap_name": "Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function",
                                 "owner": "library"
@@ -4469,6 +4589,7 @@
                                 "typemap_name": "Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function",
                                 "owner": "library"
@@ -4479,6 +4600,7 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function",
                                 "owner": "library"
                             }
@@ -4506,6 +4628,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -4515,6 +4638,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function",
                                 "owner": "library"
                             }
@@ -4635,6 +4759,7 @@
                                 "typemap_name": "Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function",
                                 "owner": "caller"
@@ -4674,6 +4799,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4730,6 +4856,7 @@
                                 "typemap_name": "Class1"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function",
                                 "owner": "caller"
@@ -4770,6 +4897,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4779,12 +4907,14 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function",
                                 "owner": "caller"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4812,6 +4942,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function",
                                 "owner": "caller"
                             },
@@ -4836,6 +4967,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4845,12 +4977,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function",
                                 "owner": "caller"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/pointers-c-c/pointers.json
+++ b/regression/reference/pointers-c-c/pointers.json
@@ -52,11 +52,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -109,11 +111,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -166,11 +170,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -255,22 +261,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -360,17 +370,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -387,6 +400,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -477,17 +491,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -504,6 +521,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -580,16 +598,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -672,11 +693,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -688,6 +711,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -757,17 +781,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -860,22 +887,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -933,11 +964,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1013,17 +1046,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1090,17 +1126,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1168,17 +1207,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1238,11 +1280,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1288,11 +1332,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1330,6 +1376,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1387,11 +1434,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -1451,11 +1500,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -1540,11 +1591,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -1556,6 +1609,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1615,11 +1669,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -1685,11 +1741,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -1747,11 +1805,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -1834,11 +1894,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -1850,6 +1912,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -1909,11 +1972,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -1976,11 +2041,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2040,11 +2107,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2107,11 +2176,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2175,11 +2246,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -2240,11 +2313,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -2304,11 +2379,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2380,11 +2457,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2440,11 +2519,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2497,11 +2578,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2558,11 +2641,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -2621,11 +2706,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -2684,11 +2771,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2728,6 +2817,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -2769,6 +2859,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2814,6 +2905,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -2856,6 +2948,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2903,6 +2996,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -2949,6 +3043,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -3012,11 +3107,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -3064,6 +3161,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -3108,6 +3206,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-c-f/pointers.json
+++ b/regression/reference/pointers-c-f/pointers.json
@@ -70,6 +70,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -107,6 +108,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -115,11 +117,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -193,6 +197,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -230,6 +235,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -238,11 +244,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -316,6 +324,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -353,6 +362,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -361,11 +371,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -471,6 +483,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -509,6 +522,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -547,6 +561,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -584,6 +599,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -592,22 +608,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -718,6 +738,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -760,6 +781,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -804,6 +826,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -854,6 +877,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -863,17 +887,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -890,6 +917,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1001,6 +1029,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1043,6 +1072,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1087,6 +1117,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1137,6 +1168,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1146,17 +1178,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1173,6 +1208,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1270,6 +1306,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1307,6 +1344,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -1350,6 +1388,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1364,16 +1403,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1477,6 +1519,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1520,6 +1563,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1569,6 +1613,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1583,11 +1628,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1599,6 +1646,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1689,6 +1737,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1727,6 +1776,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1771,6 +1821,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1785,17 +1836,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1909,6 +1963,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1948,6 +2003,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1986,6 +2042,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2028,6 +2085,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2037,22 +2095,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2131,6 +2193,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2174,6 +2237,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2188,11 +2252,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2289,6 +2355,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2331,6 +2398,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2371,6 +2439,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2380,17 +2449,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2478,6 +2550,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2520,6 +2593,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2560,6 +2634,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2569,17 +2644,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2694,6 +2772,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2736,6 +2815,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2776,6 +2856,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2785,17 +2866,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2909,6 +2993,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2957,6 +3042,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2967,11 +3053,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -3038,6 +3126,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3076,6 +3165,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3085,11 +3175,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3172,6 +3264,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3180,6 +3273,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3267,6 +3361,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3310,6 +3405,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -3320,11 +3416,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3414,6 +3512,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3467,6 +3566,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3483,11 +3583,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3602,6 +3704,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3655,6 +3758,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3699,6 +3803,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3708,11 +3813,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3724,6 +3831,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3813,6 +3921,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3866,6 +3975,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3883,11 +3993,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3983,6 +4095,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4026,6 +4139,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -4036,11 +4150,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4128,6 +4244,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4181,6 +4298,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4197,11 +4315,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4314,6 +4434,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4367,6 +4488,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4411,6 +4533,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -4420,11 +4543,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -4436,6 +4561,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4516,6 +4642,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4553,6 +4680,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4562,11 +4690,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4650,6 +4780,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4687,6 +4818,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4696,11 +4828,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4781,6 +4915,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4818,6 +4953,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4827,11 +4963,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4915,6 +5053,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4952,6 +5091,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4961,11 +5101,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -5050,6 +5192,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5087,6 +5230,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native***"
@@ -5095,11 +5239,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -5207,6 +5353,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5244,6 +5391,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native**"
@@ -5252,11 +5400,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -5337,6 +5487,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5380,6 +5531,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5397,11 +5549,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5506,6 +5660,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5566,6 +5721,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -5582,11 +5738,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5689,6 +5847,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -5727,6 +5886,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5736,11 +5896,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5840,6 +6002,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -5878,6 +6041,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5887,11 +6051,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5969,6 +6135,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6006,6 +6173,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -6014,11 +6182,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -6098,6 +6268,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6135,6 +6306,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_void**"
@@ -6143,11 +6315,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -6253,6 +6427,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6295,6 +6470,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -6304,11 +6480,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -6395,6 +6573,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -6404,6 +6583,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6513,6 +6693,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6529,6 +6710,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6621,6 +6803,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -6630,6 +6813,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6740,6 +6924,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6756,6 +6941,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6848,6 +7034,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -6857,6 +7044,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6948,6 +7136,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -6957,6 +7146,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -7067,6 +7257,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -7104,6 +7295,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -7113,11 +7305,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -7210,6 +7404,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native**"
@@ -7218,6 +7413,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -7340,6 +7536,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -7356,6 +7553,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -70,6 +70,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -107,6 +108,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -115,11 +117,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -193,6 +197,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -230,6 +235,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -238,11 +244,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -316,6 +324,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -353,6 +362,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -361,11 +371,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -471,6 +483,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -509,6 +522,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -547,6 +561,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -584,6 +599,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -592,22 +608,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -718,6 +738,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -760,6 +781,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -804,6 +826,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -854,6 +877,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -863,17 +887,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -890,6 +917,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1001,6 +1029,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1043,6 +1072,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1087,6 +1117,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1137,6 +1168,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1146,17 +1178,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1173,6 +1208,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1270,6 +1306,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1307,6 +1344,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -1350,6 +1388,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1364,16 +1403,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1477,6 +1519,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1520,6 +1563,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1569,6 +1613,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1583,11 +1628,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1599,6 +1646,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1689,6 +1737,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1727,6 +1776,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1771,6 +1821,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1785,17 +1836,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1909,6 +1963,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1948,6 +2003,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1986,6 +2042,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2028,6 +2085,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2037,22 +2095,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2131,6 +2193,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2174,6 +2237,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2188,11 +2252,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2289,6 +2355,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2331,6 +2398,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2371,6 +2439,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2380,17 +2449,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2478,6 +2550,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2520,6 +2593,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2560,6 +2634,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2569,17 +2644,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2694,6 +2772,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2736,6 +2815,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2776,6 +2856,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2785,17 +2866,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2909,6 +2993,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2957,6 +3042,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2967,11 +3053,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -3038,6 +3126,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3076,6 +3165,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3085,11 +3175,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3172,6 +3264,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3180,6 +3273,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3267,6 +3361,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3310,6 +3405,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -3320,11 +3416,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3414,6 +3512,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3467,6 +3566,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3483,11 +3583,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3602,6 +3704,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3655,6 +3758,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3699,6 +3803,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3708,11 +3813,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3724,6 +3831,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3813,6 +3921,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3866,6 +3975,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3883,11 +3993,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3983,6 +4095,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4026,6 +4139,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -4036,11 +4150,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4128,6 +4244,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4181,6 +4298,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4197,11 +4315,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4314,6 +4434,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4367,6 +4488,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4411,6 +4533,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -4420,11 +4543,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -4436,6 +4561,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4516,6 +4642,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4553,6 +4680,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4562,11 +4690,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4650,6 +4780,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4687,6 +4818,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4696,11 +4828,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4781,6 +4915,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4818,6 +4953,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4827,11 +4963,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4915,6 +5053,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4952,6 +5091,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4961,11 +5101,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -5050,6 +5192,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5087,6 +5230,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native***"
@@ -5095,11 +5239,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -5207,6 +5353,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5244,6 +5391,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native**"
@@ -5252,11 +5400,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -5337,6 +5487,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5380,6 +5531,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5397,11 +5549,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5506,6 +5660,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5566,6 +5721,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -5582,11 +5738,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5689,6 +5847,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -5727,6 +5886,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5736,11 +5896,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5840,6 +6002,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -5878,6 +6041,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5887,11 +6051,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5969,6 +6135,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6006,6 +6173,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -6014,11 +6182,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -6098,6 +6268,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6135,6 +6306,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_void**"
@@ -6143,11 +6315,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -6253,6 +6427,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6295,6 +6470,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -6304,11 +6480,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -6395,6 +6573,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -6404,6 +6583,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6513,6 +6693,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6529,6 +6710,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6621,6 +6803,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -6630,6 +6813,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6740,6 +6924,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6756,6 +6941,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6848,6 +7034,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -6857,6 +7044,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6948,6 +7136,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -6957,6 +7146,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -7067,6 +7257,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -7104,6 +7295,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -7113,11 +7305,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -7210,6 +7404,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native**"
@@ -7218,6 +7413,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -7340,6 +7536,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -7356,6 +7553,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-cfi/pointers.json
+++ b/regression/reference/pointers-cfi/pointers.json
@@ -65,6 +65,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -93,6 +94,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native*"
@@ -117,6 +119,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -154,6 +157,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -162,11 +166,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -235,6 +241,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -263,6 +270,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -287,6 +295,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -324,6 +333,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -332,11 +342,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -405,6 +417,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -433,6 +446,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -457,6 +471,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -494,6 +509,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -502,11 +518,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -607,6 +625,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -636,6 +655,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -665,6 +685,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -693,6 +714,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -717,6 +739,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -755,6 +778,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -793,6 +817,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -830,6 +855,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -838,22 +864,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -961,6 +991,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1002,6 +1033,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1045,6 +1077,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1093,6 +1126,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1119,6 +1153,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1165,6 +1200,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -1210,6 +1246,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1260,6 +1297,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1269,17 +1307,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1296,6 +1337,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1404,6 +1446,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1445,6 +1488,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1488,6 +1532,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1536,6 +1581,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1562,6 +1608,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1608,6 +1655,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -1653,6 +1701,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1703,6 +1752,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1712,17 +1762,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1739,6 +1792,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1831,6 +1885,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1859,6 +1914,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1889,6 +1945,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1919,6 +1976,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1956,6 +2014,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -1999,6 +2058,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2013,16 +2073,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2121,6 +2184,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2151,6 +2215,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2187,6 +2252,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2217,6 +2283,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2260,6 +2327,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2309,6 +2377,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2323,11 +2392,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2339,6 +2410,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2424,6 +2496,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2453,6 +2526,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2484,6 +2558,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -2514,6 +2589,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2552,6 +2628,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2596,6 +2673,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -2610,17 +2688,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -2731,6 +2812,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2768,6 +2850,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2805,6 +2888,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -2846,6 +2930,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2872,6 +2957,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2911,6 +2997,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2949,6 +3036,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2995,6 +3083,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -3005,22 +3094,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -3094,6 +3187,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3124,6 +3218,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -3154,6 +3249,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3197,6 +3293,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -3211,11 +3308,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -3309,6 +3408,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3350,6 +3450,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3388,6 +3489,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3414,6 +3516,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3460,6 +3563,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "inout",
                                 "rank": 1
@@ -3501,6 +3605,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3510,17 +3615,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3605,6 +3713,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3646,6 +3755,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3684,6 +3794,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3710,6 +3821,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3756,6 +3868,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "inout",
                                 "rank": 1
@@ -3797,6 +3910,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3806,17 +3920,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3926,6 +4043,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3967,6 +4085,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -4005,6 +4124,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4057,6 +4177,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4103,6 +4224,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -4144,6 +4266,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4153,17 +4276,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4271,6 +4397,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4310,6 +4437,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -4362,6 +4490,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4412,6 +4541,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -4422,11 +4552,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -4488,6 +4620,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4517,6 +4650,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4542,6 +4676,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4580,6 +4715,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4589,11 +4725,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4659,6 +4797,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4707,6 +4846,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4715,6 +4855,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -4790,6 +4931,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4826,6 +4968,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -4851,6 +4994,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4905,6 +5049,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -4915,11 +5060,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4997,6 +5144,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5039,6 +5187,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5070,6 +5219,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5134,6 +5284,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5150,11 +5301,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5257,6 +5410,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5299,6 +5453,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -5341,6 +5496,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -5366,6 +5522,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5430,6 +5587,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5474,6 +5632,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5483,11 +5642,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -5499,6 +5660,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5576,6 +5738,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5618,6 +5781,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -5650,6 +5814,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5714,6 +5879,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5731,11 +5897,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -5819,6 +5987,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5855,6 +6024,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -5880,6 +6050,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5934,6 +6105,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -5944,11 +6116,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -6024,6 +6198,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6066,6 +6241,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6097,6 +6273,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6161,6 +6338,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6177,11 +6355,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6282,6 +6462,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6324,6 +6505,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -6366,6 +6548,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6391,6 +6574,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6455,6 +6639,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6499,6 +6684,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6508,11 +6694,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -6524,6 +6712,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -6599,6 +6788,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6627,6 +6817,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -6651,6 +6842,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6688,6 +6880,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -6697,11 +6890,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -6780,6 +6975,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6808,6 +7004,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -6832,6 +7029,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6869,6 +7067,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -6878,11 +7077,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -6958,6 +7159,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6986,6 +7188,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -7010,6 +7213,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7047,6 +7251,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -7056,11 +7261,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -7139,6 +7346,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7167,6 +7375,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -7191,6 +7400,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7228,6 +7438,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -7237,11 +7448,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -7321,6 +7534,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7349,6 +7563,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native***"
@@ -7373,6 +7588,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7410,6 +7626,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native***"
@@ -7418,11 +7635,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -7512,6 +7731,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -7540,6 +7760,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native**"
@@ -7590,6 +7811,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -7627,6 +7849,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native**"
@@ -7635,11 +7858,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -7715,6 +7940,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7745,6 +7971,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7778,6 +8005,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7821,6 +8049,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7838,11 +8067,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7932,6 +8163,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7974,6 +8206,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -8005,6 +8238,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8061,6 +8295,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -8077,11 +8312,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -8166,6 +8403,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_void*"
@@ -8195,6 +8433,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8246,6 +8485,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -8284,6 +8524,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8293,11 +8534,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8379,6 +8622,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_void*"
@@ -8408,6 +8652,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8459,6 +8704,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -8497,6 +8743,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8506,11 +8753,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8583,6 +8832,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8611,6 +8861,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_void**"
@@ -8635,6 +8886,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8672,6 +8924,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -8680,11 +8933,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -8759,6 +9014,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8787,6 +9043,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_void**"
@@ -8811,6 +9068,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8848,6 +9106,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_void**"
@@ -8856,11 +9115,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -8948,6 +9209,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -8976,6 +9238,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -9027,6 +9290,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -9069,6 +9333,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -9079,11 +9344,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -9164,6 +9431,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9228,6 +9496,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -9238,6 +9507,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9326,6 +9596,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9406,6 +9677,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -9422,6 +9694,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9508,6 +9781,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9572,6 +9846,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -9582,6 +9857,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9671,6 +9947,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9751,6 +10028,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -9767,6 +10045,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9855,6 +10134,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9903,6 +10183,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -9912,6 +10193,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9986,6 +10268,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -10034,6 +10317,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -10043,6 +10327,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -10154,6 +10439,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -10189,6 +10475,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -10240,6 +10527,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -10283,6 +10571,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -10292,11 +10581,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -10372,6 +10663,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native**"
@@ -10420,6 +10712,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native**"
@@ -10428,6 +10721,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -10519,6 +10813,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -10591,6 +10886,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -10607,6 +10903,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-cxx-c/pointers.json
+++ b/regression/reference/pointers-cxx-c/pointers.json
@@ -64,6 +64,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -92,6 +93,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native*"
@@ -100,11 +102,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -169,6 +173,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -197,6 +202,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -205,11 +211,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -274,6 +282,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -302,6 +311,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -310,11 +320,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -411,6 +423,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -440,6 +453,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -469,6 +483,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -497,6 +512,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -505,22 +521,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -622,6 +642,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -650,6 +671,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -681,6 +703,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -721,6 +744,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -730,17 +754,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -757,6 +784,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -859,6 +887,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -887,6 +916,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -918,6 +948,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -958,6 +989,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -967,17 +999,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -994,6 +1029,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1082,6 +1118,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1110,6 +1147,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1140,6 +1178,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1154,16 +1193,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1258,6 +1300,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1288,6 +1331,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1324,6 +1368,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1338,11 +1383,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1354,6 +1401,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1435,6 +1483,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1464,6 +1513,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1495,6 +1545,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1509,17 +1560,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1624,6 +1678,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1653,6 +1708,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1682,6 +1738,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1710,6 +1767,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1719,22 +1777,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1804,6 +1866,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1834,6 +1897,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1848,11 +1912,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1940,6 +2006,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1968,6 +2035,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -1998,6 +2066,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2007,17 +2076,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2096,6 +2168,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2124,6 +2197,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2154,6 +2228,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2163,17 +2238,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2266,6 +2344,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2294,6 +2373,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2324,6 +2404,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2333,17 +2414,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2428,6 +2512,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2456,6 +2541,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2465,11 +2551,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2527,6 +2615,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2556,6 +2645,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2565,11 +2655,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2631,6 +2723,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2639,6 +2732,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -2708,6 +2802,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2736,6 +2831,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -2744,11 +2840,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2820,6 +2918,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2850,6 +2949,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2864,11 +2964,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2965,6 +3067,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2995,6 +3098,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3029,6 +3133,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3037,11 +3142,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3053,6 +3160,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3124,6 +3232,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3154,6 +3263,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3169,11 +3279,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3251,6 +3363,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3279,6 +3392,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -3287,11 +3401,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3361,6 +3477,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3391,6 +3508,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3405,11 +3523,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3504,6 +3624,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3534,6 +3655,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3568,6 +3690,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -3576,11 +3699,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3592,6 +3717,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3663,6 +3789,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3691,6 +3818,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -3699,11 +3827,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3778,6 +3908,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3806,6 +3937,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -3814,11 +3946,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3890,6 +4024,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3918,6 +4053,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -3926,11 +4062,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4005,6 +4143,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4033,6 +4172,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -4041,11 +4181,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4121,6 +4263,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4149,6 +4292,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native***"
@@ -4157,11 +4301,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -4247,6 +4393,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4275,6 +4422,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native**"
@@ -4283,11 +4431,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -4359,6 +4509,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4389,6 +4540,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4406,11 +4558,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4494,6 +4648,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4524,6 +4679,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4538,11 +4694,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4623,6 +4781,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_void*"
@@ -4652,6 +4811,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4661,11 +4821,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4743,6 +4905,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_void*"
@@ -4772,6 +4935,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4781,11 +4945,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4854,6 +5020,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4882,6 +5049,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_void**"
@@ -4890,11 +5058,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -4965,6 +5135,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4993,6 +5164,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_void**"
@@ -5001,11 +5173,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -5089,6 +5263,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5117,6 +5292,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -5126,11 +5302,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -5194,6 +5372,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -5202,6 +5381,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5269,6 +5449,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5283,6 +5464,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5352,6 +5534,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -5360,6 +5543,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5428,6 +5612,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5442,6 +5627,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5513,6 +5699,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -5521,6 +5708,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5591,6 +5779,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -5599,6 +5788,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5687,6 +5877,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -5715,6 +5906,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -5723,11 +5915,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -5799,6 +5993,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native**"
@@ -5807,6 +6002,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -5877,6 +6073,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5891,6 +6088,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-cxx-f/pointers.json
+++ b/regression/reference/pointers-cxx-f/pointers.json
@@ -71,6 +71,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -108,6 +109,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -116,11 +118,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -195,6 +199,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -232,6 +237,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -240,11 +246,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -319,6 +327,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -356,6 +365,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -364,11 +374,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -475,6 +487,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -513,6 +526,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -551,6 +565,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -588,6 +603,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -596,22 +612,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -723,6 +743,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -765,6 +786,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -809,6 +831,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -859,6 +882,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -868,17 +892,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -895,6 +922,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1007,6 +1035,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1049,6 +1078,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1093,6 +1123,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1143,6 +1174,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1152,17 +1184,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1179,6 +1214,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1277,6 +1313,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1314,6 +1351,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -1357,6 +1395,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1371,16 +1410,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1485,6 +1527,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1528,6 +1571,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1577,6 +1621,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1591,11 +1636,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1607,6 +1654,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1698,6 +1746,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1736,6 +1785,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1780,6 +1830,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1794,17 +1845,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1919,6 +1973,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1958,6 +2013,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1996,6 +2052,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2038,6 +2095,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2047,22 +2105,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2142,6 +2204,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2185,6 +2248,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2199,11 +2263,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2301,6 +2367,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2343,6 +2410,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2383,6 +2451,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2392,17 +2461,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2491,6 +2563,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2533,6 +2606,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2573,6 +2647,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2582,17 +2657,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2708,6 +2786,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2750,6 +2829,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2790,6 +2870,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2799,17 +2880,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2923,6 +3007,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2971,6 +3056,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2981,11 +3067,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -3053,6 +3141,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3091,6 +3180,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3100,11 +3190,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3188,6 +3280,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3196,6 +3289,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3283,6 +3377,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3326,6 +3421,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -3336,11 +3432,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3430,6 +3528,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3483,6 +3582,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3499,11 +3599,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3618,6 +3720,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3671,6 +3774,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3715,6 +3819,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3724,11 +3829,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3740,6 +3847,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3829,6 +3937,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3882,6 +3991,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -3899,11 +4009,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3999,6 +4111,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4042,6 +4155,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -4052,11 +4166,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4144,6 +4260,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4197,6 +4314,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4213,11 +4331,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4330,6 +4450,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4383,6 +4504,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4427,6 +4549,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -4436,11 +4559,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -4452,6 +4577,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -4533,6 +4659,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4570,6 +4697,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4579,11 +4707,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4668,6 +4798,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4705,6 +4836,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4714,11 +4846,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4800,6 +4934,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4837,6 +4972,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4846,11 +4982,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4935,6 +5073,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4972,6 +5111,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -4981,11 +5121,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -5071,6 +5213,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5108,6 +5251,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native***"
@@ -5116,11 +5260,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -5229,6 +5375,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5266,6 +5413,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native**"
@@ -5274,11 +5422,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -5360,6 +5510,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5403,6 +5554,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5420,11 +5572,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5529,6 +5683,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5589,6 +5744,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -5605,11 +5761,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5713,6 +5871,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -5751,6 +5910,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5760,11 +5920,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5865,6 +6027,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -5903,6 +6066,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5912,11 +6076,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5995,6 +6161,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6032,6 +6199,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -6040,11 +6208,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -6125,6 +6295,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6162,6 +6333,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_void**"
@@ -6170,11 +6342,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -6281,6 +6455,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6323,6 +6498,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -6332,11 +6508,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -6423,6 +6601,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -6432,6 +6611,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6541,6 +6721,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6557,6 +6738,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6649,6 +6831,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -6658,6 +6841,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6768,6 +6952,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6784,6 +6969,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6876,6 +7062,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -6885,6 +7072,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -6977,6 +7165,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -6986,6 +7175,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -7097,6 +7287,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -7134,6 +7325,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -7143,11 +7335,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -7241,6 +7435,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native**"
@@ -7249,6 +7444,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -7371,6 +7567,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -7387,6 +7584,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -65,6 +65,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -93,6 +94,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native*"
@@ -117,6 +119,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -154,6 +157,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native*"
@@ -162,11 +166,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -235,6 +241,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -263,6 +270,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -287,6 +295,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -324,6 +333,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -332,11 +342,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -405,6 +417,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -433,6 +446,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -457,6 +471,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -494,6 +509,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -502,11 +518,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -607,6 +625,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -636,6 +655,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -665,6 +685,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_native*"
@@ -693,6 +714,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -717,6 +739,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -755,6 +778,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -793,6 +817,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_native*"
@@ -830,6 +855,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -838,22 +864,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -959,6 +989,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -987,6 +1018,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1018,6 +1050,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1058,6 +1091,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1083,6 +1117,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1125,6 +1160,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1169,6 +1205,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1219,6 +1256,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1228,17 +1266,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1255,6 +1296,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1361,6 +1403,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1389,6 +1432,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1420,6 +1464,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1460,6 +1505,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1485,6 +1531,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1527,6 +1574,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1571,6 +1619,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1621,6 +1670,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1630,17 +1680,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -1657,6 +1710,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1749,6 +1803,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1777,6 +1832,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -1807,6 +1863,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1837,6 +1894,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1874,6 +1932,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -1917,6 +1976,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1931,16 +1991,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2039,6 +2102,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2069,6 +2133,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2105,6 +2170,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2135,6 +2201,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2178,6 +2245,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2227,6 +2295,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2241,11 +2310,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2257,6 +2328,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -2342,6 +2414,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2371,6 +2444,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2402,6 +2476,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -2432,6 +2507,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2470,6 +2546,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2514,6 +2591,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -2528,17 +2606,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -2647,6 +2728,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2676,6 +2758,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2705,6 +2788,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -2733,6 +2817,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2758,6 +2843,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2797,6 +2883,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2835,6 +2922,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -2877,6 +2965,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2886,22 +2975,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2975,6 +3068,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3005,6 +3099,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -3035,6 +3130,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3078,6 +3174,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -3092,11 +3189,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -3188,6 +3287,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3216,6 +3316,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3246,6 +3347,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3271,6 +3373,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3313,6 +3416,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3353,6 +3457,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3362,17 +3467,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3455,6 +3563,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3483,6 +3592,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3513,6 +3623,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3538,6 +3649,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3580,6 +3692,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -3620,6 +3733,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3629,17 +3743,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3736,6 +3853,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3764,6 +3882,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3794,6 +3913,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3845,6 +3965,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3887,6 +4008,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -3927,6 +4049,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3936,17 +4059,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4054,6 +4180,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4093,6 +4220,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -4145,6 +4273,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4193,6 +4322,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -4203,11 +4333,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -4269,6 +4401,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4298,6 +4431,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4323,6 +4457,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4361,6 +4496,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4370,11 +4506,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4440,6 +4578,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4488,6 +4627,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4496,6 +4636,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -4579,6 +4720,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4615,6 +4757,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -4640,6 +4783,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4683,6 +4827,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -4693,11 +4838,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4783,6 +4930,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4825,6 +4973,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4856,6 +5005,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4909,6 +5059,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4925,11 +5076,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5040,6 +5193,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5082,6 +5236,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -5124,6 +5279,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -5149,6 +5305,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5202,6 +5359,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5246,6 +5404,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -5255,11 +5414,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -5271,6 +5432,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5356,6 +5518,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5398,6 +5561,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -5430,6 +5594,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5483,6 +5648,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5500,11 +5666,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -5596,6 +5764,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5632,6 +5801,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -5657,6 +5827,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5700,6 +5871,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "out"
@@ -5710,11 +5882,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -5798,6 +5972,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5840,6 +6015,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5871,6 +6047,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5924,6 +6101,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5940,11 +6118,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -6053,6 +6233,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6095,6 +6276,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -6137,6 +6319,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6162,6 +6345,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6215,6 +6399,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6259,6 +6444,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6268,11 +6454,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -6284,6 +6472,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -6359,6 +6548,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6387,6 +6577,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -6411,6 +6602,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6448,6 +6640,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -6457,11 +6650,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -6540,6 +6735,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6568,6 +6764,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -6592,6 +6789,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6629,6 +6827,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -6638,11 +6837,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -6718,6 +6919,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6746,6 +6948,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -6770,6 +6973,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6807,6 +7011,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -6816,11 +7021,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -6899,6 +7106,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6927,6 +7135,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native**"
@@ -6951,6 +7160,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6988,6 +7198,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -6997,11 +7208,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -7081,6 +7294,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7109,6 +7323,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native***"
@@ -7133,6 +7348,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7170,6 +7386,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native***"
@@ -7178,11 +7395,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -7272,6 +7491,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -7300,6 +7520,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "c_in_native**"
@@ -7350,6 +7571,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -7387,6 +7609,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             },
                             "stmt": "f_in_native**"
@@ -7395,11 +7618,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -7475,6 +7700,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7505,6 +7731,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7538,6 +7765,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7581,6 +7809,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7598,11 +7827,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7703,6 +7934,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7745,6 +7977,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7776,6 +8009,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7836,6 +8070,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -7852,11 +8087,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -7941,6 +8178,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_void*"
@@ -7970,6 +8208,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8021,6 +8260,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -8059,6 +8299,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8068,11 +8309,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8154,6 +8397,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_void*"
@@ -8183,6 +8427,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8234,6 +8479,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "f_function_void*"
@@ -8272,6 +8518,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8281,11 +8528,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -8358,6 +8607,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8386,6 +8636,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "c_out_void**"
@@ -8410,6 +8661,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8447,6 +8699,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "f_out_void**"
@@ -8455,11 +8708,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -8534,6 +8789,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8562,6 +8818,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_void**"
@@ -8586,6 +8843,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8623,6 +8881,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_void**"
@@ -8631,11 +8890,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -8723,6 +8984,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -8751,6 +9013,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -8802,6 +9065,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -8844,6 +9108,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -8853,11 +9118,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -8938,6 +9205,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -8988,6 +9256,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -8997,6 +9266,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9093,6 +9363,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9162,6 +9433,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -9178,6 +9450,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9264,6 +9537,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9314,6 +9588,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "function"
                             },
@@ -9323,6 +9598,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9420,6 +9696,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9489,6 +9766,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -9505,6 +9783,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -9593,6 +9872,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9641,6 +9921,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -9650,6 +9931,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9724,6 +10006,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9772,6 +10055,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -9781,6 +10065,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -9873,6 +10158,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native*"
@@ -9901,6 +10187,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -9951,6 +10238,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -9988,6 +10276,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -9997,11 +10286,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -10077,6 +10368,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native**"
@@ -10125,6 +10417,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native**"
@@ -10133,6 +10426,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -10235,6 +10529,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -10311,6 +10606,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -10327,6 +10623,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -57,6 +57,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -81,6 +82,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_native*"
@@ -89,11 +91,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -167,6 +171,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -191,6 +196,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -199,11 +205,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -278,6 +286,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -302,6 +311,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -310,11 +320,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -416,6 +428,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -439,6 +452,7 @@
                                 "value_var": "SHValue_argin"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -464,6 +478,7 @@
                                 "value_var": "SHValue_arginout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -488,6 +503,7 @@
                                 "value_var": "SHValue_argout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -496,22 +512,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -624,6 +644,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -650,6 +671,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -681,6 +703,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -716,6 +739,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -726,17 +750,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -753,6 +780,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -865,6 +893,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -891,6 +920,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -922,6 +952,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -957,6 +988,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -967,17 +999,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -994,6 +1029,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1092,6 +1128,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1116,6 +1153,7 @@
                                 "value_var": "SHValue_nvalues"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1146,6 +1184,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1160,16 +1199,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1270,6 +1312,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1300,6 +1343,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1336,6 +1380,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1350,11 +1395,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1366,6 +1413,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1453,6 +1501,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1476,6 +1525,7 @@
                                 "value_var": "SHValue_nvar"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1507,6 +1557,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1521,17 +1572,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1646,6 +1700,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1670,6 +1725,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(values)",
                                 "intent": "in",
                                 "value": true
@@ -1696,6 +1752,7 @@
                                 "value_var": "SHValue_result"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1722,6 +1779,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1731,22 +1789,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1826,6 +1888,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1856,6 +1919,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1870,11 +1934,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1967,6 +2033,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1994,6 +2061,7 @@
                                 "value_var": "SHValue_array"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2019,6 +2087,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(array)",
                                 "intent": "in",
                                 "value": true
@@ -2029,17 +2098,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2128,6 +2200,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2155,6 +2228,7 @@
                                 "value_var": "SHValue_x"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2180,6 +2254,7 @@
                                 "value_var": "SHValue_x_length"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(x)",
                                 "intent": "in",
                                 "value": true
@@ -2190,17 +2265,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2302,6 +2380,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2328,6 +2407,7 @@
                                 "value_var": "SHValue_arr"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2353,6 +2433,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(arr)",
                                 "intent": "in",
                                 "value": true
@@ -2363,17 +2444,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2467,6 +2551,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2493,6 +2578,7 @@
                                 "value_var": "SHValue_names"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2502,11 +2588,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2574,6 +2662,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2597,6 +2686,7 @@
                                 "value_var": "SHValue_value"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2606,11 +2696,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2681,6 +2773,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2689,6 +2782,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -2758,11 +2852,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2827,6 +2923,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2857,6 +2954,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2871,11 +2969,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2977,6 +3077,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3007,6 +3108,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3037,6 +3139,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3046,11 +3149,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3062,6 +3167,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3138,6 +3244,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3168,6 +3275,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3183,11 +3291,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3265,11 +3375,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3332,6 +3444,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3362,6 +3475,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3376,11 +3490,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3480,6 +3596,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3510,6 +3627,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3540,6 +3658,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3549,11 +3668,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3565,6 +3686,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3641,6 +3763,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3665,6 +3788,7 @@
                                 "value_var": "SHValue_nitems"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3674,11 +3798,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3753,11 +3879,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3822,6 +3950,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3846,6 +3975,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3855,11 +3985,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3934,11 +4066,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4002,11 +4136,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -4067,11 +4203,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -4131,11 +4269,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4207,11 +4347,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4285,6 +4427,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4308,6 +4451,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4317,11 +4461,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4410,6 +4556,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4433,6 +4580,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4442,11 +4590,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4526,6 +4676,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4550,6 +4701,7 @@
                                 "value_var": "SHValue_addr"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "py_out_void**"
@@ -4558,11 +4710,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -4633,11 +4787,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -4696,11 +4852,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -4759,6 +4917,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_list"
@@ -4767,6 +4926,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -4845,6 +5005,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4859,6 +5020,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4936,6 +5098,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_list"
@@ -4944,6 +5107,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5023,6 +5187,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5037,6 +5202,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5115,6 +5281,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -5124,6 +5291,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5182,6 +5350,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5245,11 +5414,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -5297,6 +5468,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -5341,6 +5513,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -57,6 +57,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -81,6 +82,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_native*"
@@ -89,11 +91,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -167,6 +171,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -191,6 +196,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -199,11 +205,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -278,6 +286,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -302,6 +311,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -310,11 +320,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -416,6 +428,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -439,6 +452,7 @@
                                 "value_var": "SHValue_argin"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -464,6 +478,7 @@
                                 "value_var": "SHValue_arginout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -488,6 +503,7 @@
                                 "value_var": "SHValue_argout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -496,22 +512,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -624,6 +644,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -650,6 +671,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -681,6 +703,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -716,6 +739,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -726,17 +750,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -753,6 +780,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -865,6 +893,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -891,6 +920,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -922,6 +952,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -957,6 +988,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -967,17 +999,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -994,6 +1029,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1092,6 +1128,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1116,6 +1153,7 @@
                                 "value_var": "SHValue_nvalues"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1146,6 +1184,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1160,16 +1199,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1270,6 +1312,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1300,6 +1343,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1336,6 +1380,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1350,11 +1395,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1366,6 +1413,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1453,6 +1501,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1476,6 +1525,7 @@
                                 "value_var": "SHValue_nvar"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1507,6 +1557,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1521,17 +1572,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1646,6 +1700,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1670,6 +1725,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(values)",
                                 "intent": "in",
                                 "value": true
@@ -1696,6 +1752,7 @@
                                 "value_var": "SHValue_result"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1722,6 +1779,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1731,22 +1789,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1826,6 +1888,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1856,6 +1919,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1870,11 +1934,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1967,6 +2033,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1994,6 +2061,7 @@
                                 "value_var": "SHValue_array"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2019,6 +2087,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(array)",
                                 "intent": "in",
                                 "value": true
@@ -2029,17 +2098,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2128,6 +2200,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2155,6 +2228,7 @@
                                 "value_var": "SHValue_x"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2180,6 +2254,7 @@
                                 "value_var": "SHValue_x_length"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(x)",
                                 "intent": "in",
                                 "value": true
@@ -2190,17 +2265,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2302,6 +2380,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2328,6 +2407,7 @@
                                 "value_var": "SHValue_arr"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2353,6 +2433,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(arr)",
                                 "intent": "in",
                                 "value": true
@@ -2363,17 +2444,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2467,6 +2551,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2493,6 +2578,7 @@
                                 "value_var": "SHValue_names"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2502,11 +2588,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2574,6 +2662,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2597,6 +2686,7 @@
                                 "value_var": "SHValue_value"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2606,11 +2696,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2681,6 +2773,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2689,6 +2782,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -2758,11 +2852,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2827,6 +2923,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2857,6 +2954,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2871,11 +2969,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2977,6 +3077,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3007,6 +3108,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3037,6 +3139,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3046,11 +3149,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3062,6 +3167,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3138,6 +3244,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3168,6 +3275,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3183,11 +3291,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3265,11 +3375,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3332,6 +3444,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3362,6 +3475,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3376,11 +3490,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3480,6 +3596,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3510,6 +3627,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3540,6 +3658,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3549,11 +3668,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3565,6 +3686,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3641,6 +3763,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3665,6 +3788,7 @@
                                 "value_var": "SHValue_nitems"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3674,11 +3798,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3753,11 +3879,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3822,6 +3950,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3846,6 +3975,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3855,11 +3985,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3934,11 +4066,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -4002,11 +4136,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -4067,11 +4203,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -4131,11 +4269,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4207,11 +4347,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4285,6 +4427,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4308,6 +4451,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4317,11 +4461,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4410,6 +4556,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4433,6 +4580,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4442,11 +4590,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4526,6 +4676,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4550,6 +4701,7 @@
                                 "value_var": "SHValue_addr"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "py_out_void**"
@@ -4558,11 +4710,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -4633,11 +4787,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -4696,11 +4852,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -4759,6 +4917,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_list"
@@ -4767,6 +4926,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -4845,6 +5005,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4859,6 +5020,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4936,6 +5098,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_list"
@@ -4944,6 +5107,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5023,6 +5187,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5037,6 +5202,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5115,6 +5281,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -5124,6 +5291,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5182,6 +5350,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5245,11 +5414,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -5297,6 +5468,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -5341,6 +5513,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -57,6 +57,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -81,6 +82,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_native*"
@@ -89,11 +91,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -167,6 +171,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -191,6 +196,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -199,11 +205,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -278,6 +286,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -302,6 +311,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -310,11 +320,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -416,6 +428,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -439,6 +452,7 @@
                                 "value_var": "SHValue_argin"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -464,6 +478,7 @@
                                 "value_var": "SHValue_arginout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -488,6 +503,7 @@
                                 "value_var": "SHValue_argout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -496,22 +512,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -624,6 +644,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -649,6 +670,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -679,6 +701,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -714,6 +737,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -724,17 +748,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -751,6 +778,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -863,6 +891,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -888,6 +917,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -918,6 +948,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -953,6 +984,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -963,17 +995,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -990,6 +1025,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1088,6 +1124,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1112,6 +1149,7 @@
                                 "value_var": "SHValue_nvalues"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1141,6 +1179,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1155,16 +1194,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1265,6 +1307,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1294,6 +1337,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1329,6 +1373,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1343,11 +1388,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1359,6 +1406,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1446,6 +1494,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1469,6 +1518,7 @@
                                 "value_var": "SHValue_nvar"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1499,6 +1549,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1513,17 +1564,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1638,6 +1692,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1662,6 +1717,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(values)",
                                 "intent": "in",
                                 "value": true
@@ -1688,6 +1744,7 @@
                                 "value_var": "SHValue_result"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1713,6 +1770,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1722,22 +1780,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1817,6 +1879,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1846,6 +1909,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1860,11 +1924,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1957,6 +2023,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1982,6 +2049,7 @@
                                 "value_var": "SHValue_array"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2007,6 +2075,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(array)",
                                 "intent": "in",
                                 "value": true
@@ -2017,17 +2086,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2116,6 +2188,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2141,6 +2214,7 @@
                                 "value_var": "SHValue_x"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2166,6 +2240,7 @@
                                 "value_var": "SHValue_x_length"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(x)",
                                 "intent": "in",
                                 "value": true
@@ -2176,17 +2251,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2288,6 +2366,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2313,6 +2392,7 @@
                                 "value_var": "SHValue_arr"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2338,6 +2418,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(arr)",
                                 "intent": "in",
                                 "value": true
@@ -2348,17 +2429,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2452,6 +2536,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2478,6 +2563,7 @@
                                 "value_var": "SHValue_names"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2487,11 +2573,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2559,6 +2647,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2582,6 +2671,7 @@
                                 "value_var": "SHValue_value"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2591,11 +2681,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2666,6 +2758,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2674,6 +2767,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -2743,11 +2837,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2812,6 +2908,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2841,6 +2938,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2855,11 +2953,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2961,6 +3061,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2990,6 +3091,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3020,6 +3122,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3029,11 +3132,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3045,6 +3150,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3121,6 +3227,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3150,6 +3257,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3165,11 +3273,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3247,11 +3357,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3314,6 +3426,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3343,6 +3456,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3357,11 +3471,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3461,6 +3577,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3490,6 +3607,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3520,6 +3638,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3529,11 +3648,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3545,6 +3666,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3621,6 +3743,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3645,6 +3768,7 @@
                                 "value_var": "SHValue_nitems"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3654,11 +3778,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3733,11 +3859,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3802,6 +3930,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3826,6 +3955,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3835,11 +3965,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3914,11 +4046,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3982,11 +4116,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -4047,11 +4183,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -4111,11 +4249,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4187,11 +4327,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4265,6 +4407,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4288,6 +4431,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4297,11 +4441,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4390,6 +4536,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4413,6 +4560,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4422,11 +4570,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4506,6 +4656,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4530,6 +4681,7 @@
                                 "value_var": "SHValue_addr"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "py_out_void**"
@@ -4538,11 +4690,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -4613,11 +4767,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -4676,11 +4832,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -4738,6 +4896,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_numpy"
@@ -4746,6 +4905,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -4823,6 +4983,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4837,6 +4998,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4913,6 +5075,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_numpy"
@@ -4921,6 +5084,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -4999,6 +5163,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5013,6 +5178,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5091,6 +5257,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -5100,6 +5267,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5158,6 +5326,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5221,11 +5390,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -5273,6 +5444,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -5317,6 +5489,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -57,6 +57,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -81,6 +82,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_native*"
@@ -89,11 +91,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in"
                             }
                         }
@@ -167,6 +171,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -191,6 +196,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -199,11 +205,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         }
@@ -278,6 +286,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -302,6 +311,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -310,11 +320,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -416,6 +428,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -439,6 +452,7 @@
                                 "value_var": "SHValue_argin"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -464,6 +478,7 @@
                                 "value_var": "SHValue_arginout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_native*"
@@ -488,6 +503,7 @@
                                 "value_var": "SHValue_argout"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -496,22 +512,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "argin": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arginout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout"
                             }
                         },
                         "argout": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -624,6 +644,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -649,6 +670,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -679,6 +701,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -714,6 +737,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -724,17 +748,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -751,6 +778,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -863,6 +891,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -888,6 +917,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -918,6 +948,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -953,6 +984,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(in)",
                                 "intent": "in",
                                 "value": true
@@ -963,17 +995,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "args": [
@@ -990,6 +1025,7 @@
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1088,6 +1124,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1112,6 +1149,7 @@
                                 "value_var": "SHValue_nvalues"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1141,6 +1179,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1155,16 +1194,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvalues": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1265,6 +1307,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1294,6 +1337,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1329,6 +1373,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1343,11 +1388,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1359,6 +1406,7 @@
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1446,6 +1494,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1469,6 +1518,7 @@
                                 "value_var": "SHValue_nvar"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1499,6 +1549,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1513,17 +1564,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nvar": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nvar"
@@ -1638,6 +1692,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1662,6 +1717,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(values)",
                                 "intent": "in",
                                 "value": true
@@ -1688,6 +1744,7 @@
                                 "value_var": "SHValue_result"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -1713,6 +1770,7 @@
                                 "value_var": "SHValue_values"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1722,22 +1780,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "values": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1817,6 +1879,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1846,6 +1909,7 @@
                                 "value_var": "SHValue_out"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1860,11 +1924,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "out": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "3"
@@ -1957,6 +2023,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1982,6 +2049,7 @@
                                 "value_var": "SHValue_array"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2007,6 +2075,7 @@
                                 "value_var": "SHValue_sizein"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(array)",
                                 "intent": "in",
                                 "value": true
@@ -2017,17 +2086,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "array": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "sizein": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2116,6 +2188,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2141,6 +2214,7 @@
                                 "value_var": "SHValue_x"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             },
@@ -2166,6 +2240,7 @@
                                 "value_var": "SHValue_x_length"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(x)",
                                 "intent": "in",
                                 "value": true
@@ -2176,17 +2251,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "inout",
                                 "rank": 1
                             }
                         },
                         "x_length": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2288,6 +2366,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2313,6 +2392,7 @@
                                 "value_var": "SHValue_arr"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2338,6 +2418,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(arr)",
                                 "intent": "in",
                                 "value": true
@@ -2348,17 +2429,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arr": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2452,6 +2536,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2478,6 +2563,7 @@
                                 "value_var": "SHValue_names"
                             },
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2487,11 +2573,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "names": {
                             "meta": {
+                                "abstract": "char**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2559,6 +2647,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2582,6 +2671,7 @@
                                 "value_var": "SHValue_value"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2591,11 +2681,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "value": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2666,6 +2758,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2674,6 +2767,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -2743,11 +2837,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -2812,6 +2908,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2841,6 +2938,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2855,11 +2953,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -2961,6 +3061,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2990,6 +3091,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3020,6 +3122,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3029,11 +3132,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3045,6 +3150,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3121,6 +3227,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3150,6 +3257,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3165,11 +3273,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "args": [],
@@ -3247,11 +3357,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3314,6 +3426,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3343,6 +3456,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3357,11 +3471,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -3461,6 +3577,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3490,6 +3607,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3520,6 +3638,7 @@
                                 "value_var": "SHValue_ncount"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -3529,11 +3648,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "name": "ncount"
@@ -3545,6 +3666,7 @@
                         },
                         "ncount": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -3621,6 +3743,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3645,6 +3768,7 @@
                                 "value_var": "SHValue_nitems"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3654,11 +3778,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3733,11 +3859,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nitems": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3802,6 +3930,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3826,6 +3955,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native**",
                                 "deref": "raw",
                                 "intent": "out"
                             },
@@ -3835,11 +3965,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3914,11 +4046,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "out"
                             }
                         }
@@ -3982,11 +4116,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native***",
                                 "intent": "out"
                             }
                         }
@@ -4047,11 +4183,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "in"
                             }
                         }
@@ -4111,11 +4249,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4187,11 +4327,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native**",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4265,6 +4407,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4288,6 +4431,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4297,11 +4441,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4390,6 +4536,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_void*"
@@ -4413,6 +4560,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4422,11 +4570,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4506,6 +4656,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4530,6 +4681,7 @@
                                 "value_var": "SHValue_addr"
                             },
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             },
                             "stmt": "py_out_void**"
@@ -4538,11 +4690,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "out"
                             }
                         }
@@ -4613,11 +4767,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "inout"
                             }
                         }
@@ -4676,11 +4832,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void**",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -4738,6 +4896,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_numpy"
@@ -4746,6 +4905,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -4823,6 +4983,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4837,6 +4998,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -4913,6 +5075,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native*_numpy"
@@ -4921,6 +5084,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -4999,6 +5163,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5013,6 +5178,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"
@@ -5091,6 +5257,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "scalar",
                                 "intent": "function"
                             },
@@ -5100,6 +5267,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5158,6 +5326,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         }
@@ -5221,11 +5390,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -5273,6 +5444,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native**",
                                 "intent": "function"
                             }
                         }
@@ -5317,6 +5489,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "constant": "10"

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -45,6 +45,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -68,6 +69,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -79,6 +81,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -87,6 +90,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -152,6 +156,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -175,6 +180,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -186,6 +192,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -194,6 +201,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -264,6 +272,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -287,6 +296,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -295,6 +305,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -371,6 +382,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -400,6 +412,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -425,6 +438,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -463,6 +477,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -475,6 +490,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -498,6 +514,7 @@
                                         "value_var": "SHValue_i"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -507,11 +524,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "i": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -628,6 +647,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -651,6 +671,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -662,6 +683,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -670,6 +692,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 }
@@ -749,6 +772,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -778,6 +802,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -803,6 +828,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -841,6 +867,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -853,6 +880,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -876,6 +904,7 @@
                                         "value_var": "SHValue_flag"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -885,11 +914,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "flag": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -107,6 +107,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -115,6 +116,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -197,6 +199,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -220,6 +223,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -244,6 +248,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -253,17 +258,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -369,6 +377,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string"
@@ -394,6 +403,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -419,6 +429,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -427,16 +438,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -535,6 +549,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -558,6 +573,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -584,6 +600,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -593,17 +610,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -681,6 +701,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -706,6 +727,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -714,11 +736,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -789,6 +813,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -812,6 +837,7 @@
                                 "value_var": "SHValue_indx"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -821,11 +847,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "indx": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -923,11 +951,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1013,6 +1043,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1036,6 +1067,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1045,11 +1077,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1157,6 +1191,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1180,6 +1215,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1189,11 +1225,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1284,6 +1322,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "function"
                             }
                         }
@@ -1356,6 +1395,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1434,6 +1474,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1475,6 +1516,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1483,6 +1525,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -1629,6 +1672,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1652,6 +1696,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1678,6 +1723,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -1686,17 +1732,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -1804,6 +1853,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1827,6 +1877,7 @@
                                 "value_var": "SHValue_num"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1851,6 +1902,7 @@
                                 "value_var": "SHValue_offset"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1875,6 +1927,7 @@
                                 "value_var": "SHValue_stride"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1884,23 +1937,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2016,6 +2073,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2039,6 +2097,7 @@
                                 "value_var": "SHValue_num"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2063,6 +2122,7 @@
                                 "value_var": "SHValue_offset"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2087,6 +2147,7 @@
                                 "value_var": "SHValue_stride"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2111,6 +2172,7 @@
                                 "value_var": "SHValue_type"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2120,29 +2182,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2224,6 +2291,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2247,6 +2315,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2256,11 +2325,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2340,6 +2411,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -2364,6 +2436,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2373,11 +2446,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2477,6 +2552,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2501,6 +2577,7 @@
                                 "value_var": "SHValue_max"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native&"
@@ -2525,6 +2602,7 @@
                                 "value_var": "SHValue_min"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native&"
@@ -2533,16 +2611,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "max": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         },
                         "min": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         }
@@ -2637,17 +2718,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -2679,11 +2763,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -2757,6 +2843,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -2766,6 +2853,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -655,6 +655,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -701,6 +702,7 @@
                                 "typemap_name": "ns3::DataPointer"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -709,6 +711,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "name": "nitems"
@@ -720,6 +723,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -824,6 +828,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -862,6 +867,7 @@
                                 "typemap_name": "ns3::DataPointer"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -904,6 +910,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -913,16 +920,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             }
@@ -1260,6 +1270,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -1306,6 +1317,7 @@
                                         "typemap_name": "ns1::DataPointer"
                                     },
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "in"
                                     },
                                     "stmt": "f_in_struct*"
@@ -1314,6 +1326,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1325,6 +1338,7 @@
                                 },
                                 "SH_this": {
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "in"
                                     }
                                 }
@@ -1429,6 +1443,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1467,6 +1482,7 @@
                                         "typemap_name": "ns1::DataPointer"
                                     },
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "inout"
                                     },
                                     "stmt": "f_inout_struct*"
@@ -1509,6 +1525,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "setter",
                                         "rank": 1
                                     },
@@ -1518,16 +1535,19 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "SH_this": {
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "inout"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "setter",
                                         "rank": 1
                                     }
@@ -1892,6 +1912,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "api": "cdesc",
                                         "deref": "pointer",
                                         "dim_ast": [
@@ -1938,6 +1959,7 @@
                                         "typemap_name": "ns2::DataPointer"
                                     },
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "in"
                                     },
                                     "stmt": "f_in_struct*"
@@ -1946,6 +1968,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1957,6 +1980,7 @@
                                 },
                                 "SH_this": {
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "in"
                                     }
                                 }
@@ -2061,6 +2085,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -2099,6 +2124,7 @@
                                         "typemap_name": "ns2::DataPointer"
                                     },
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "inout"
                                     },
                                     "stmt": "f_inout_struct*"
@@ -2141,6 +2167,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "setter",
                                         "rank": 1
                                     },
@@ -2150,16 +2177,19 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "SH_this": {
                                     "meta": {
+                                        "abstract": "struct*",
                                         "intent": "inout"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "setter",
                                         "rank": 1
                                     }

--- a/regression/reference/sgroup/sgroup.json
+++ b/regression/reference/sgroup/sgroup.json
@@ -125,6 +125,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -175,6 +176,7 @@
                                 "typemap_name": "twostruct"
                             },
                             "meta": {
+                                "abstract": "twostruct<native,native>",
                                 "intent": "in",
                                 "value": true
                             },
@@ -184,11 +186,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "twostruct<native,native>",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/shared/shared.json
+++ b/regression/reference/shared/shared.json
@@ -83,6 +83,7 @@
                                         "typemap_name": "Object"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor",
                                         "owner": "shared"
@@ -138,6 +139,7 @@
                                         "typemap_name": "Object"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor",
                                         "owner": "shared"
@@ -148,6 +150,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor",
                                         "owner": "shared"
                                     }
@@ -199,6 +202,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "c_dtor"
@@ -222,6 +226,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     },
                                     "stmt": "f_dtor"
@@ -230,6 +235,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "dtor"
                                     }
                                 }

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -71,6 +71,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -120,6 +121,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -128,6 +130,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -220,6 +223,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "get_name_length()"
                             },
@@ -276,6 +280,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -287,6 +292,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "get_name_length()"
                             }
@@ -393,6 +399,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "c_function_bool"
@@ -430,6 +437,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -456,6 +464,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -478,6 +487,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -487,11 +497,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -51,6 +51,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -73,6 +74,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -81,6 +83,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -144,6 +147,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -173,6 +177,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -198,6 +203,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -235,6 +241,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -244,11 +251,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "status": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             }
@@ -316,6 +325,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -345,6 +355,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -370,6 +381,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -407,6 +419,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -416,11 +429,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "status": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             }
@@ -485,6 +500,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char"
@@ -531,6 +547,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "f_function_char"
@@ -539,6 +556,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             }
                         }
@@ -640,6 +658,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -675,6 +694,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -710,6 +730,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -735,6 +756,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -776,6 +798,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "out"
                             },
@@ -819,6 +842,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -828,17 +852,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "dest": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "40",
                                 "intent": "out"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -920,6 +947,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -955,6 +983,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_char*"
@@ -980,6 +1009,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1023,6 +1053,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "inout"
                             },
@@ -1032,11 +1063,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "s": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             }
                         }
@@ -1121,6 +1154,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1170,6 +1204,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -1180,6 +1215,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -1274,6 +1310,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -1329,6 +1366,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "deref": "copy",
                                 "intent": "function",
@@ -1340,6 +1378,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             }
@@ -1433,6 +1472,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1484,6 +1524,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "deref": "arg",
                                 "intent": "function"
@@ -1494,6 +1535,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -1570,6 +1612,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1617,6 +1660,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -1626,6 +1670,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -1713,6 +1758,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1772,6 +1818,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -1782,6 +1829,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -1862,6 +1910,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -1913,6 +1962,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -1923,6 +1973,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         }
@@ -2013,6 +2064,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -2070,6 +2122,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cfi",
                                 "deref": "copy",
                                 "intent": "function",
@@ -2081,6 +2134,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -2170,6 +2224,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -2223,6 +2278,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cfi",
                                 "deref": "arg",
                                 "intent": "function"
@@ -2233,6 +2289,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         }
@@ -2310,6 +2367,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -2361,6 +2419,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -2371,6 +2430,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         }
@@ -2456,6 +2516,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -2507,6 +2568,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -2517,6 +2579,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -2612,6 +2675,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -2669,6 +2733,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "deref": "copy",
                                 "intent": "function",
@@ -2680,6 +2745,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -2774,6 +2840,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -2827,6 +2894,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "deref": "arg",
                                 "intent": "function"
@@ -2837,6 +2905,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -2932,6 +3001,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -2989,6 +3059,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "deref": "copy",
                                 "intent": "function",
@@ -3000,6 +3071,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -3081,6 +3153,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -3132,6 +3205,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -3142,6 +3216,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -3243,6 +3318,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -3301,6 +3377,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "deref": "copy",
                                 "intent": "function",
@@ -3312,6 +3389,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -3396,6 +3474,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -3448,6 +3527,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function",
@@ -3459,6 +3539,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             }
@@ -3546,6 +3627,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "caller"
                             },
@@ -3598,6 +3680,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "intent": "function",
@@ -3609,6 +3692,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "caller"
                             }
@@ -3697,6 +3781,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "free_pattern": "C_string_free",
                                 "intent": "function",
                                 "owner": "caller"
@@ -3750,6 +3835,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "free_pattern": "C_string_free",
@@ -3762,6 +3848,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "free_pattern": "C_string_free",
                                 "intent": "function",
                                 "owner": "caller"
@@ -3850,6 +3937,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -3912,6 +4000,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "deref": "pointer",
                                 "intent": "function",
@@ -3923,6 +4012,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             }
@@ -4001,6 +4091,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4038,6 +4129,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -4063,6 +4155,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4106,6 +4199,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -4115,11 +4209,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4199,6 +4295,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4236,6 +4333,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             },
                             "stmt": "c_out_string&"
@@ -4261,6 +4359,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4302,6 +4401,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "intent": "out"
                             },
@@ -4311,11 +4411,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             }
                         }
@@ -4395,6 +4497,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4432,6 +4535,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string&"
@@ -4457,6 +4561,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4501,6 +4606,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "intent": "inout"
                             },
@@ -4510,11 +4616,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             }
                         }
@@ -4591,6 +4699,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4628,6 +4737,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string*"
@@ -4653,6 +4763,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4696,6 +4807,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -4705,11 +4817,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "in"
                             }
                         }
@@ -4786,6 +4900,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -4823,6 +4938,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string*"
@@ -4848,6 +4964,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4892,6 +5009,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "intent": "inout"
                             },
@@ -4901,11 +5019,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             }
                         }
@@ -4985,6 +5105,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5022,6 +5143,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_string*"
@@ -5047,6 +5169,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5088,6 +5211,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "intent": "out"
                             },
@@ -5097,11 +5221,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             }
                         }
@@ -5197,6 +5323,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5234,6 +5361,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string*"
@@ -5270,6 +5398,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -5295,6 +5424,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5339,6 +5469,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "intent": "inout"
                             },
@@ -5377,6 +5508,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -5385,16 +5517,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             }
                         },
                         "nlen": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5492,6 +5627,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5529,6 +5665,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_string*"
@@ -5565,6 +5702,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -5590,6 +5728,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5631,6 +5770,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cfi",
                                 "intent": "out"
                             },
@@ -5669,6 +5809,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -5677,16 +5818,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             }
                         },
                         "nlen": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -5781,6 +5925,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5816,6 +5961,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string"
@@ -5867,6 +6013,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5910,6 +6057,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -5919,11 +6067,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "in"
                             }
                         }
@@ -6003,16 +6153,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             }
                         }
@@ -6108,6 +6261,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6144,6 +6298,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6184,6 +6339,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -6215,6 +6371,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6251,6 +6408,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6297,6 +6455,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "api": "cfi",
                                 "deref": "copy",
                                 "dim_ast": [
@@ -6313,16 +6472,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nstrs": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "strs": {
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -6428,6 +6590,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6464,6 +6627,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6504,6 +6668,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -6535,6 +6700,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6571,6 +6737,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6618,6 +6785,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -6634,16 +6802,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nstrs": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "strs": {
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -6750,6 +6921,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6786,6 +6958,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6828,6 +7001,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -6860,6 +7034,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6896,6 +7071,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -6945,6 +7121,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "api": "cfi",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -6962,16 +7139,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nstrs": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "strs": {
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -7041,11 +7221,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -7123,6 +7305,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7158,6 +7341,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -7183,6 +7367,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7225,6 +7410,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -7234,11 +7420,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -7319,6 +7507,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7356,6 +7545,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out",
                                 "len": "AAtrim"
                             },
@@ -7382,6 +7572,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7425,6 +7616,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "out",
                                 "len": "AAtrim"
@@ -7435,11 +7627,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out",
                                 "len": "AAtrim"
                             }
@@ -7506,6 +7700,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7535,6 +7730,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7560,6 +7756,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7597,6 +7794,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7606,11 +7804,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "status": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7677,6 +7877,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char"
@@ -7723,6 +7924,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "f_function_char"
@@ -7731,6 +7933,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             }
                         }
@@ -7835,6 +8038,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7870,6 +8074,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -7905,6 +8110,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -7930,6 +8136,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7971,6 +8178,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "out"
                             },
@@ -8015,6 +8223,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "blanknull": true,
                                 "intent": "in"
@@ -8025,16 +8234,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "dest": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -8135,6 +8347,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8170,6 +8383,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -8205,6 +8419,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -8230,6 +8445,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8271,6 +8487,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "out"
                             },
@@ -8315,6 +8532,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "blanknull": true,
                                 "intent": "in"
@@ -8325,16 +8543,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "dest": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -8432,6 +8653,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8473,6 +8695,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -8511,6 +8734,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string&"
@@ -8536,6 +8760,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8582,6 +8807,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cfi",
                                 "intent": "in",
                                 "rank": 1
@@ -8628,6 +8854,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cfi",
                                 "intent": "inout"
                             },
@@ -8637,17 +8864,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             }
                         }
@@ -8752,6 +8982,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -8787,6 +9018,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -8838,6 +9070,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -8880,6 +9113,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -8889,11 +9123,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -8997,6 +9233,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -9026,6 +9263,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             },
@@ -9055,6 +9293,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -9105,6 +9344,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -9143,6 +9383,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             },
@@ -9180,6 +9421,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "in"
                             },
@@ -9189,17 +9431,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -9322,6 +9567,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -9357,6 +9603,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -9392,6 +9639,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -9443,6 +9691,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -9485,6 +9734,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cfi",
                                 "intent": "in"
                             },
@@ -9522,6 +9772,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "in"
                             },
@@ -9531,16 +9782,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -52,6 +52,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -74,6 +75,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -85,6 +87,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -93,6 +96,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -168,6 +172,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -197,6 +202,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -222,6 +228,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -259,6 +266,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -271,6 +279,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -295,6 +304,7 @@
                                 "value_var": "SHValue_status"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -304,11 +314,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "status": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             }
@@ -392,6 +404,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -421,6 +434,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -446,6 +460,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -483,6 +498,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -492,11 +508,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "status": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             }
@@ -562,6 +580,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char"
@@ -608,6 +627,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "f_function_char"
@@ -631,6 +651,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "py_function_char"
@@ -639,6 +660,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             }
                         }
@@ -752,6 +774,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -787,6 +810,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -822,6 +846,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -847,6 +872,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -887,6 +913,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -924,6 +951,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -936,6 +964,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -961,6 +990,7 @@
                                 "value_var": "SHValue_dest"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -985,6 +1015,7 @@
                                 "value_var": "SHValue_src"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -993,17 +1024,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "dest": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "40",
                                 "intent": "out"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -1103,6 +1137,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1138,6 +1173,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_char*"
@@ -1163,6 +1199,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1207,6 +1244,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -1219,6 +1257,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1243,6 +1282,7 @@
                                 "value_var": "SHValue_s"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_char*"
@@ -1251,11 +1291,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "s": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "inout"
                             }
                         }
@@ -1369,6 +1411,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1424,6 +1467,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -1450,6 +1494,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_char*"
@@ -1458,6 +1503,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -1565,6 +1611,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -1621,6 +1668,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -1648,6 +1696,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -1657,6 +1706,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function",
                                 "len": "30"
                             }
@@ -1763,6 +1813,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1815,6 +1866,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "deref": "arg",
                                 "intent": "function"
@@ -1841,6 +1893,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_char*"
@@ -1849,6 +1902,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -1937,6 +1991,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -1984,6 +2039,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "deref": "raw",
                                 "intent": "function"
                             },
@@ -1993,6 +2049,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -2090,6 +2147,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char*"
@@ -2143,6 +2201,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -2153,6 +2212,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "function"
                             }
                         }
@@ -2246,6 +2306,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -2310,6 +2371,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -2335,6 +2397,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string"
@@ -2343,6 +2406,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         }
@@ -2446,6 +2510,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -2502,6 +2567,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -2528,6 +2594,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -2537,6 +2604,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -2639,6 +2707,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -2691,6 +2760,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "buf",
                                 "deref": "arg",
                                 "intent": "function"
@@ -2716,6 +2786,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string"
@@ -2724,6 +2795,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         }
@@ -2826,6 +2898,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -2890,6 +2963,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -2915,6 +2989,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string"
@@ -2923,6 +2998,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         }
@@ -3033,6 +3109,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -3095,6 +3172,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -3121,6 +3199,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string&"
@@ -3129,6 +3208,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -3237,6 +3317,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -3293,6 +3374,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -3320,6 +3402,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -3329,6 +3412,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -3436,6 +3520,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -3488,6 +3573,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "arg",
                                 "intent": "function"
@@ -3514,6 +3600,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string&"
@@ -3522,6 +3609,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -3630,6 +3718,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -3686,6 +3775,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -3713,6 +3803,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -3722,6 +3813,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -3828,6 +3920,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string&"
@@ -3890,6 +3983,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -3916,6 +4010,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string&"
@@ -3924,6 +4019,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function"
                             }
                         }
@@ -4038,6 +4134,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -4095,6 +4192,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "string*",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -4122,6 +4220,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "len": 30
                             },
@@ -4131,6 +4230,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "len": 30
                             }
@@ -4240,6 +4340,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -4303,6 +4404,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function",
@@ -4330,6 +4432,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -4339,6 +4442,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             }
@@ -4451,6 +4555,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "caller"
                             },
@@ -4514,6 +4619,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function",
@@ -4541,6 +4647,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "caller"
                             },
@@ -4550,6 +4657,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "caller"
                             }
@@ -4663,6 +4771,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "free_pattern": "C_string_free",
                                 "intent": "function",
                                 "owner": "caller"
@@ -4727,6 +4836,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "free_pattern": "C_string_free",
@@ -4755,6 +4865,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "free_pattern": "C_string_free",
                                 "intent": "function",
                                 "owner": "caller"
@@ -4765,6 +4876,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "free_pattern": "C_string_free",
                                 "intent": "function",
                                 "owner": "caller"
@@ -4875,6 +4987,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             },
@@ -4932,6 +5045,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function",
@@ -4943,6 +5057,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "function",
                                 "owner": "library"
                             }
@@ -5022,6 +5137,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5059,6 +5175,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -5084,6 +5201,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5126,6 +5244,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -5138,6 +5257,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -5163,6 +5283,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -5171,11 +5292,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -5272,6 +5395,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5309,6 +5433,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             },
                             "stmt": "c_out_string&"
@@ -5334,6 +5459,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5376,6 +5502,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -5388,6 +5515,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -5413,6 +5541,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_string&"
@@ -5421,11 +5550,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             }
                         }
@@ -5518,6 +5649,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5555,6 +5687,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string&"
@@ -5580,6 +5713,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5623,6 +5757,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -5635,6 +5770,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -5660,6 +5796,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_string&"
@@ -5668,11 +5805,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             }
                         }
@@ -5767,6 +5906,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -5804,6 +5944,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string*"
@@ -5829,6 +5970,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -5871,6 +6013,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -5883,6 +6026,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -5908,6 +6052,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string*"
@@ -5916,11 +6061,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "in"
                             }
                         }
@@ -6014,6 +6161,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6051,6 +6199,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string*"
@@ -6076,6 +6225,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6119,6 +6269,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -6131,6 +6282,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -6156,6 +6308,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_string*"
@@ -6164,11 +6317,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             }
                         }
@@ -6266,6 +6421,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6303,6 +6459,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_string*"
@@ -6328,6 +6485,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6370,6 +6528,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -6382,6 +6541,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -6407,6 +6567,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_string*"
@@ -6415,11 +6576,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             }
                         }
@@ -6528,6 +6691,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6565,6 +6729,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string*"
@@ -6601,6 +6766,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6626,6 +6792,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -6669,6 +6836,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -6707,6 +6875,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -6718,6 +6887,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -6743,6 +6913,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_string*"
@@ -6767,6 +6938,7 @@
                                 "value_var": "SHValue_nlen"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -6775,16 +6947,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "inout"
                             }
                         },
                         "nlen": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -6901,6 +7076,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -6938,6 +7114,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_string*"
@@ -6974,6 +7151,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6999,6 +7177,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7041,6 +7220,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -7079,6 +7259,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -7090,6 +7271,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -7115,6 +7297,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_string*"
@@ -7139,6 +7322,7 @@
                                 "value_var": "SHValue_nlen"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -7147,16 +7331,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string*",
                                 "intent": "out"
                             }
                         },
                         "nlen": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -7265,6 +7452,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -7300,6 +7488,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string"
@@ -7351,6 +7540,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -7395,6 +7585,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -7419,6 +7610,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -7443,6 +7635,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string"
@@ -7451,11 +7644,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "in"
                             }
                         }
@@ -7557,6 +7752,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -7582,6 +7778,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_string&"
@@ -7607,6 +7804,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_string&"
@@ -7615,16 +7813,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "out"
                             }
                         }
@@ -7742,6 +7943,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7778,6 +7980,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -7818,6 +8021,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -7849,6 +8053,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7885,6 +8090,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -7936,6 +8142,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "api": "cdesc",
                                 "deref": "copy",
                                 "dim_ast": [
@@ -7952,16 +8159,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nstrs": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "strs": {
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -8079,6 +8289,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8115,6 +8326,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -8155,6 +8367,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -8186,6 +8399,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8222,6 +8436,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -8282,6 +8497,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -8298,16 +8514,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nstrs": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "strs": {
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -8426,6 +8645,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8462,6 +8682,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -8504,6 +8725,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -8536,6 +8758,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8572,6 +8795,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "hidden": true,
                                 "intent": "out"
                             },
@@ -8633,6 +8857,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string**",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "dim_ast": [
@@ -8650,16 +8875,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "nstrs": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         },
                         "strs": {
                             "meta": {
+                                "abstract": "string**",
                                 "dim_ast": [
                                     {
                                         "name": "nstrs"
@@ -8729,11 +8957,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -8804,6 +9034,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -8832,6 +9063,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -8856,6 +9088,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -8892,6 +9125,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -8904,6 +9138,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -8928,6 +9163,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_char*"
@@ -8936,11 +9172,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -9037,6 +9275,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -9074,6 +9313,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out",
                                 "len": "AAtrim"
                             },
@@ -9100,6 +9340,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -9142,6 +9383,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out",
                                 "len": "AAtrim"
@@ -9152,11 +9394,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out",
                                 "len": "AAtrim"
                             }
@@ -9224,6 +9468,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -9253,6 +9498,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -9278,6 +9524,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -9315,6 +9562,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -9327,6 +9575,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -9351,6 +9600,7 @@
                                 "value_var": "SHValue_status"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             },
@@ -9360,11 +9610,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "status": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "in",
                                 "value": true
                             }
@@ -9448,6 +9700,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "c_function_char"
@@ -9494,6 +9747,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "f_function_char"
@@ -9517,6 +9771,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             },
                             "stmt": "py_function_char"
@@ -9525,6 +9780,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "char",
                                 "intent": "function"
                             }
                         }
@@ -9642,6 +9898,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -9677,6 +9934,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -9712,6 +9970,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -9737,6 +9996,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -9777,6 +10037,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -9822,6 +10083,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "blanknull": true,
                                 "intent": "in"
@@ -9832,16 +10094,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "dest": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -9942,6 +10207,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -9977,6 +10243,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -10012,6 +10279,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -10037,6 +10305,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -10077,6 +10346,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -10122,6 +10392,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "blanknull": true,
                                 "intent": "in"
@@ -10132,16 +10403,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "dest": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -10240,6 +10514,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -10281,6 +10556,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -10319,6 +10595,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_string&"
@@ -10344,6 +10621,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -10386,6 +10664,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -10430,6 +10709,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "inout"
                             },
@@ -10442,6 +10722,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -10468,6 +10749,7 @@
                                 "value_var": "SHValue_count"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -10494,6 +10776,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_string&"
@@ -10502,17 +10785,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "count": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "inout"
                             }
                         }
@@ -10634,6 +10920,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -10669,6 +10956,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -10720,6 +11008,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -10763,6 +11052,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "ftrim_char_in": false,
                                 "intent": "in"
@@ -10773,11 +11063,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -10881,6 +11173,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -10910,6 +11203,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             },
@@ -10939,6 +11233,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -10989,6 +11284,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -11027,6 +11323,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             },
@@ -11064,6 +11361,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "in"
                             },
@@ -11073,17 +11371,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "addr": {
                             "meta": {
+                                "abstract": "void*",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }
@@ -11187,6 +11488,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -11215,6 +11517,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -11243,6 +11546,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_char*"
@@ -11293,6 +11597,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -11329,6 +11634,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "ftrim_char_in": true,
                                 "intent": "in"
                             },
@@ -11366,6 +11672,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "capi",
                                 "intent": "in"
                             },
@@ -11375,16 +11682,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         },
                         "src": {
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "in"
                             }
                         }

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -833,6 +833,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -841,6 +842,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -928,6 +930,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -966,6 +969,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -975,11 +979,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1077,6 +1083,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1085,6 +1092,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1172,6 +1180,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1210,6 +1219,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -1219,11 +1229,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1416,6 +1428,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1424,6 +1437,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1511,6 +1525,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1549,6 +1564,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -1558,11 +1574,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1660,6 +1678,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1668,6 +1687,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1755,6 +1775,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1793,6 +1814,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -1802,11 +1824,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1904,6 +1928,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1912,6 +1937,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1999,6 +2025,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -2037,6 +2064,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -2046,11 +2074,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -2353,6 +2383,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2392,6 +2423,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2401,11 +2433,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2506,6 +2540,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2544,6 +2579,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -2552,11 +2588,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2682,6 +2720,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2722,6 +2761,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -2761,6 +2801,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -2769,17 +2810,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2879,6 +2923,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2917,6 +2962,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -2925,11 +2971,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -3026,6 +3074,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3064,6 +3113,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_struct*"
@@ -3102,6 +3152,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3141,6 +3192,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3150,22 +3202,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3240,6 +3296,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3278,6 +3335,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -3286,11 +3344,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -3392,6 +3452,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "f_function_struct"
@@ -3430,6 +3491,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3469,6 +3531,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3478,17 +3541,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3613,6 +3679,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -3653,6 +3720,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3692,6 +3760,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3701,17 +3770,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3856,6 +3928,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -3896,6 +3969,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3935,6 +4009,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3976,6 +4051,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -3985,23 +4061,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -4116,6 +4196,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -4132,6 +4213,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -4235,6 +4317,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -4245,6 +4328,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -4339,6 +4423,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -4348,6 +4433,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -4463,6 +4549,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -4502,6 +4589,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4541,6 +4629,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4550,17 +4639,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4654,6 +4746,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -4663,6 +4756,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -4777,6 +4871,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -4816,6 +4911,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4855,6 +4951,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4864,17 +4961,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4983,6 +5083,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5024,6 +5125,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_shadow*"
@@ -5032,11 +5134,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -5162,6 +5266,7 @@
                                 "typemap_name": "Cstruct_as_subclass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5201,6 +5306,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5240,6 +5346,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5279,6 +5386,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5288,23 +5396,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5430,6 +5542,7 @@
                                 "typemap_name": "Cstruct_as_subclass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5469,6 +5582,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5508,6 +5622,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5547,6 +5662,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5556,23 +5672,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5690,6 +5810,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "getter"
                             },
@@ -5729,6 +5850,7 @@
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -5737,11 +5859,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "getter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -5846,6 +5970,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -5884,6 +6009,7 @@
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -5921,6 +6047,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter_native*"
@@ -5929,16 +6056,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter"
                             }
                         }
@@ -6081,6 +6211,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6133,6 +6264,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -6141,6 +6273,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "left": {
@@ -6158,6 +6291,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -6262,6 +6396,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -6300,6 +6435,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -6342,6 +6478,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -6351,16 +6488,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             }
@@ -6504,6 +6644,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -6556,6 +6697,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -6564,6 +6706,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "left": {
@@ -6581,6 +6724,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -6685,6 +6829,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -6723,6 +6868,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -6765,6 +6911,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -6774,16 +6921,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             }

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -95,6 +95,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -120,6 +121,7 @@
                                         "value_var": "SHValue_dfield"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -146,6 +148,7 @@
                                         "value_var": "SHValue_ifield"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -155,17 +158,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dfield": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -397,6 +403,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -425,6 +432,7 @@
                                         "value_var": "SHValue_cfield"
                                     },
                                     "meta": {
+                                        "abstract": "char*",
                                         "intent": "in"
                                     },
                                     "stmt": "py_ctor_char*_numpy"
@@ -453,6 +461,7 @@
                                         "value_var": "SHValue_const_dvalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "in"
                                     },
                                     "stmt": "py_ctor_native*_numpy"
@@ -461,16 +470,19 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "cfield": {
                                     "meta": {
+                                        "abstract": "char*",
                                         "intent": "in"
                                     }
                                 },
                                 "const_dvalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "in"
                                     }
                                 }
@@ -751,6 +763,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -784,6 +797,7 @@
                                         "value_var": "SHValue_dvalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -829,6 +843,7 @@
                                         "value_var": "SHValue_ivalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -866,6 +881,7 @@
                                         "value_var": "SHValue_nitems"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -900,6 +916,7 @@
                                         "value_var": "SHValue_svalue"
                                     },
                                     "meta": {
+                                        "abstract": "char**",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -914,11 +931,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dvalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -936,6 +955,7 @@
                                 },
                                 "ivalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -953,12 +973,14 @@
                                 },
                                 "nitems": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "svalue": {
                                     "meta": {
+                                        "abstract": "char**",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1342,6 +1364,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -1375,6 +1398,7 @@
                                         "value_var": "SHValue_dvalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1414,6 +1438,7 @@
                                         "value_var": "SHValue_ivalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1445,6 +1470,7 @@
                                         "value_var": "SHValue_nitems"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1454,11 +1480,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dvalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1470,6 +1498,7 @@
                                 },
                                 "ivalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1481,6 +1510,7 @@
                                 },
                                 "nitems": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1776,6 +1806,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -1804,6 +1835,7 @@
                                         "value_var": "SHValue_count"
                                     },
                                     "meta": {
+                                        "abstract": "native[]",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1833,6 +1865,7 @@
                                         "value_var": "SHValue_name"
                                     },
                                     "meta": {
+                                        "abstract": "char[]",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1842,17 +1875,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "count": {
                                     "meta": {
+                                        "abstract": "native[]",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
+                                        "abstract": "char[]",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2315,6 +2351,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2343,6 +2380,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2352,11 +2390,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2444,6 +2484,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2473,6 +2514,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -2481,11 +2523,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2592,6 +2636,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2617,6 +2662,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2646,6 +2692,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -2654,17 +2701,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2752,6 +2802,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2781,6 +2832,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -2789,11 +2841,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2891,6 +2945,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2919,6 +2974,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_struct*_class"
@@ -2942,6 +2998,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2966,6 +3023,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2975,22 +3033,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3066,6 +3128,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3095,6 +3158,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_class"
@@ -3103,11 +3167,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -3202,6 +3268,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct_class"
@@ -3225,6 +3292,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3249,6 +3317,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3258,17 +3327,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3373,6 +3445,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_class"
@@ -3396,6 +3469,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3420,6 +3494,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3429,17 +3504,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3563,6 +3641,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_class"
@@ -3586,6 +3665,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3610,6 +3690,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3636,6 +3717,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -3644,23 +3726,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -3752,6 +3838,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -3766,6 +3853,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -3845,6 +3933,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_class"
@@ -3853,6 +3942,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -3908,6 +3998,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -3970,17 +4061,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4023,6 +4117,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -4085,17 +4180,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4156,11 +4254,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -4234,23 +4334,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4324,23 +4428,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -95,6 +95,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -120,6 +121,7 @@
                                         "value_var": "SHValue_dfield"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -146,6 +148,7 @@
                                         "value_var": "SHValue_ifield"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -155,17 +158,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dfield": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -397,6 +403,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -425,6 +432,7 @@
                                         "value_var": "SHValue_cfield"
                                     },
                                     "meta": {
+                                        "abstract": "char*",
                                         "intent": "in"
                                     },
                                     "stmt": "py_ctor_char*_numpy"
@@ -453,6 +461,7 @@
                                         "value_var": "SHValue_const_dvalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "in"
                                     },
                                     "stmt": "py_ctor_native*_numpy"
@@ -461,16 +470,19 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "cfield": {
                                     "meta": {
+                                        "abstract": "char*",
                                         "intent": "in"
                                     }
                                 },
                                 "const_dvalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "intent": "in"
                                     }
                                 }
@@ -751,6 +763,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -784,6 +797,7 @@
                                         "value_var": "SHValue_dvalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -829,6 +843,7 @@
                                         "value_var": "SHValue_ivalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -866,6 +881,7 @@
                                         "value_var": "SHValue_nitems"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -900,6 +916,7 @@
                                         "value_var": "SHValue_svalue"
                                     },
                                     "meta": {
+                                        "abstract": "char**",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -914,11 +931,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dvalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -936,6 +955,7 @@
                                 },
                                 "ivalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "left": {
@@ -953,12 +973,14 @@
                                 },
                                 "nitems": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "svalue": {
                                     "meta": {
+                                        "abstract": "char**",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1342,6 +1364,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -1375,6 +1398,7 @@
                                         "value_var": "SHValue_dvalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1414,6 +1438,7 @@
                                         "value_var": "SHValue_ivalue"
                                     },
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1445,6 +1470,7 @@
                                         "value_var": "SHValue_nitems"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1454,11 +1480,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "dvalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1470,6 +1498,7 @@
                                 },
                                 "ivalue": {
                                     "meta": {
+                                        "abstract": "native*",
                                         "dim_ast": [
                                             {
                                                 "name": "nitems"
@@ -1481,6 +1510,7 @@
                                 },
                                 "nitems": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1776,6 +1806,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -1804,6 +1835,7 @@
                                         "value_var": "SHValue_count"
                                     },
                                     "meta": {
+                                        "abstract": "native[]",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1833,6 +1865,7 @@
                                         "value_var": "SHValue_name"
                                     },
                                     "meta": {
+                                        "abstract": "char[]",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1842,17 +1875,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "count": {
                                     "meta": {
+                                        "abstract": "native[]",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
+                                        "abstract": "char[]",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2315,6 +2351,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2343,6 +2380,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2352,11 +2390,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2444,6 +2484,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2473,6 +2514,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -2481,11 +2523,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2592,6 +2636,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2617,6 +2662,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2646,6 +2692,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -2654,17 +2701,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2752,6 +2802,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2781,6 +2832,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -2789,11 +2841,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2891,6 +2945,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2919,6 +2974,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_struct*_class"
@@ -2942,6 +2998,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2966,6 +3023,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2975,22 +3033,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3066,6 +3128,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3095,6 +3158,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_class"
@@ -3103,11 +3167,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -3202,6 +3268,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct_class"
@@ -3225,6 +3292,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3249,6 +3317,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3258,17 +3327,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3373,6 +3445,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_class"
@@ -3396,6 +3469,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3420,6 +3494,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3429,17 +3504,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3563,6 +3641,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_class"
@@ -3586,6 +3665,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3610,6 +3690,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3636,6 +3717,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -3644,23 +3726,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -3752,6 +3838,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -3766,6 +3853,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -3845,6 +3933,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_class"
@@ -3853,6 +3942,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -3908,6 +3998,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -3970,17 +4061,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4023,6 +4117,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -4085,17 +4180,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4156,11 +4254,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -4234,23 +4334,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4324,23 +4428,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -851,6 +851,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -859,6 +860,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -946,6 +948,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -984,6 +987,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -993,11 +997,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1095,6 +1101,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1103,6 +1110,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1190,6 +1198,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1228,6 +1237,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -1237,11 +1247,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1437,6 +1449,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1445,6 +1458,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1532,6 +1546,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1570,6 +1585,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -1579,11 +1595,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1681,6 +1699,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1689,6 +1708,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -1776,6 +1796,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -1814,6 +1835,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -1823,11 +1845,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -1925,6 +1949,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     },
                                     "stmt": "f_getter_native"
@@ -1933,6 +1958,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "getter"
                                     }
                                 }
@@ -2020,6 +2046,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     },
                                     "stmt": "f_setter"
@@ -2058,6 +2085,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     },
@@ -2067,11 +2095,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "setter"
                                     }
                                 },
                                 "val": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "setter",
                                         "value": true
                                     }
@@ -2362,6 +2392,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2391,6 +2422,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2442,6 +2474,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2481,6 +2514,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2490,11 +2524,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2577,6 +2613,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2605,6 +2642,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_struct*"
@@ -2655,6 +2693,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2693,6 +2732,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -2701,11 +2741,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -2825,6 +2867,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2860,6 +2903,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -2897,6 +2941,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_struct*"
@@ -2948,6 +2993,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2988,6 +3034,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -3027,6 +3074,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -3035,17 +3083,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -3127,6 +3178,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3155,6 +3207,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_struct*"
@@ -3205,6 +3258,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3243,6 +3297,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -3251,11 +3306,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -3347,6 +3404,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3375,6 +3433,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_struct*"
@@ -3404,6 +3463,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3434,6 +3494,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3459,6 +3520,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3497,6 +3559,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_struct*"
@@ -3535,6 +3598,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3574,6 +3638,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3583,22 +3648,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3668,6 +3737,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3696,6 +3766,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_struct*"
@@ -3720,6 +3791,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3758,6 +3830,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -3766,11 +3839,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -3853,6 +3928,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "c_function_struct"
@@ -3882,6 +3958,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3912,6 +3989,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3962,6 +4040,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "f_function_struct"
@@ -4000,6 +4079,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4039,6 +4119,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4048,17 +4129,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4174,6 +4258,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_struct*"
@@ -4211,6 +4296,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4249,6 +4335,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4305,6 +4392,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -4345,6 +4433,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4384,6 +4473,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4393,17 +4483,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4539,6 +4632,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_struct*"
@@ -4576,6 +4670,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4614,6 +4709,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4650,6 +4746,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_char*"
@@ -4705,6 +4802,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -4745,6 +4843,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4784,6 +4883,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4825,6 +4925,7 @@
                                 "typemap_name": "char"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "api": "buf",
                                 "intent": "out"
                             },
@@ -4834,23 +4935,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -4952,6 +5057,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -5022,6 +5128,7 @@
                                 "typemap_name": "Cstruct1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -5038,6 +5145,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -5132,6 +5240,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "c_function_struct*"
@@ -5186,6 +5295,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "intent": "function"
@@ -5196,6 +5306,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -5285,6 +5396,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -5341,6 +5453,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5350,6 +5463,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -5460,6 +5574,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -5498,6 +5613,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5536,6 +5652,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5593,6 +5710,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5632,6 +5750,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5671,6 +5790,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5680,17 +5800,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5763,6 +5886,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5817,6 +5941,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5826,6 +5951,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -5919,6 +6045,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -5949,6 +6076,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5979,6 +6107,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6034,6 +6163,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -6073,6 +6203,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6112,6 +6243,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6121,17 +6253,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6221,6 +6356,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -6250,6 +6386,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "c_in_shadow*"
@@ -6300,6 +6437,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6341,6 +6479,7 @@
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_shadow*"
@@ -6349,11 +6488,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -6474,6 +6615,7 @@
                                 "typemap_name": "Cstruct_as_subclass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -6512,6 +6654,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6550,6 +6693,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6588,6 +6732,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6645,6 +6790,7 @@
                                 "typemap_name": "Cstruct_as_subclass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -6684,6 +6830,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6723,6 +6870,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6762,6 +6910,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6771,23 +6920,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6892,6 +7045,7 @@
                                 "typemap_name": "Cstruct_as_subclass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -6922,6 +7076,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6952,6 +7107,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6982,6 +7138,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7037,6 +7194,7 @@
                                 "typemap_name": "Cstruct_as_subclass"
                             },
                             "meta": {
+                                "abstract": "shadow*",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -7076,6 +7234,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7115,6 +7274,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7154,6 +7314,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7163,23 +7324,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7297,6 +7462,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "deref": "pointer",
                                 "intent": "getter"
                             },
@@ -7336,6 +7502,7 @@
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -7344,11 +7511,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "getter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -7453,6 +7622,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -7491,6 +7661,7 @@
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -7528,6 +7699,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter_native*"
@@ -7536,16 +7708,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter"
                             }
                         }
@@ -7688,6 +7863,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -7740,6 +7916,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -7748,6 +7925,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "left": {
@@ -7765,6 +7943,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -7869,6 +8048,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -7907,6 +8087,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -7949,6 +8130,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -7958,16 +8140,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             }
@@ -8111,6 +8296,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "api": "cdesc",
                                 "deref": "pointer",
                                 "dim_ast": [
@@ -8163,6 +8349,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "f_in_struct*"
@@ -8171,6 +8358,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native*",
                                 "dim_ast": [
                                     {
                                         "left": {
@@ -8188,6 +8376,7 @@
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -8292,6 +8481,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             },
                             "stmt": "f_setter"
@@ -8330,6 +8520,7 @@
                                 "typemap_name": "Cstruct_list"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -8372,6 +8563,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             },
@@ -8381,16 +8573,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "setter"
                             }
                         },
                         "SH_this": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         },
                         "val": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "setter",
                                 "rank": 1
                             }

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -988,6 +988,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1016,6 +1017,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1025,11 +1027,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1117,6 +1121,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1146,6 +1151,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_list"
@@ -1154,11 +1160,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1265,6 +1273,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1290,6 +1299,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -1319,6 +1329,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_list"
@@ -1327,17 +1338,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1425,6 +1439,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1454,6 +1469,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_list"
@@ -1462,11 +1478,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1564,6 +1582,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1594,6 +1613,7 @@
                                 "vargs": "arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_struct*_list"
@@ -1617,6 +1637,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1641,6 +1662,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1650,22 +1672,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1741,6 +1767,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1772,6 +1799,7 @@
                                 "vargs": "arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_list"
@@ -1780,11 +1808,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -1879,6 +1909,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct_list"
@@ -1902,6 +1933,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1926,6 +1958,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1935,17 +1968,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2052,6 +2088,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_list"
@@ -2075,6 +2112,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2099,6 +2137,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2108,17 +2147,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2244,6 +2286,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_list"
@@ -2267,6 +2310,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2291,6 +2335,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2317,6 +2362,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2325,23 +2371,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -2435,6 +2485,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -2449,6 +2500,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -2530,6 +2582,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_list"
@@ -2538,6 +2591,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -2593,6 +2647,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -2655,17 +2710,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2708,6 +2766,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -2770,17 +2829,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2841,11 +2903,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -2919,23 +2983,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3009,23 +3077,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -988,6 +988,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1016,6 +1017,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1025,11 +1027,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1117,6 +1121,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1146,6 +1151,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -1154,11 +1160,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1265,6 +1273,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1290,6 +1299,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -1319,6 +1329,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -1327,17 +1338,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1425,6 +1439,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1454,6 +1469,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -1462,11 +1478,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1564,6 +1582,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1592,6 +1611,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_struct*_numpy"
@@ -1615,6 +1635,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1639,6 +1660,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1648,22 +1670,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1739,6 +1765,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1768,6 +1795,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_numpy"
@@ -1776,11 +1804,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -1877,6 +1907,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct_numpy"
@@ -1900,6 +1931,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1924,6 +1956,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1933,17 +1966,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2048,6 +2084,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_numpy"
@@ -2071,6 +2108,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2095,6 +2133,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2104,17 +2143,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2238,6 +2280,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_numpy"
@@ -2261,6 +2304,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2285,6 +2329,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2311,6 +2356,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2319,23 +2365,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -2427,6 +2477,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -2441,6 +2492,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -2520,6 +2572,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_numpy"
@@ -2528,6 +2581,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -2583,6 +2637,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -2645,17 +2700,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2698,6 +2756,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -2760,17 +2819,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2831,11 +2893,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -2909,23 +2973,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2999,23 +3067,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -988,6 +988,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1016,6 +1017,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1025,11 +1027,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1117,6 +1121,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1146,6 +1151,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -1154,11 +1160,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1265,6 +1273,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1290,6 +1299,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -1319,6 +1329,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -1327,17 +1338,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1425,6 +1439,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1454,6 +1469,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -1462,11 +1478,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }
@@ -1564,6 +1582,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1592,6 +1611,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_struct*_numpy"
@@ -1615,6 +1635,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1639,6 +1660,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1648,22 +1670,26 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "out"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1739,6 +1765,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1768,6 +1795,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_numpy"
@@ -1776,11 +1804,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -1877,6 +1907,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct_numpy"
@@ -1900,6 +1931,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1924,6 +1956,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1933,17 +1966,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2048,6 +2084,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_numpy"
@@ -2071,6 +2108,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2095,6 +2133,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2104,17 +2143,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2238,6 +2280,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_numpy"
@@ -2261,6 +2304,7 @@
                                 "value_var": "SHValue_d"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2285,6 +2329,7 @@
                                 "value_var": "SHValue_i"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2311,6 +2356,7 @@
                                 "value_var": "SHValue_outbuf"
                             },
                             "meta": {
+                                "abstract": "char*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_char*_charlen"
@@ -2319,23 +2365,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         },
                         "d": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "outbuf": {
                             "meta": {
+                                "abstract": "char*",
                                 "charlen": "LENOUTBUF",
                                 "intent": "out"
                             }
@@ -2427,6 +2477,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -2441,6 +2492,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "dim_ast": [
                                     {
                                         "constant": "2"
@@ -2520,6 +2572,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             },
                             "stmt": "py_function_struct*_numpy"
@@ -2528,6 +2581,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "function"
                             }
                         }
@@ -2583,6 +2637,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -2645,17 +2700,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2698,6 +2756,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         }
@@ -2760,17 +2819,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2831,11 +2893,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "point": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "in"
                             }
                         }
@@ -2909,23 +2973,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2999,23 +3067,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow*",
                                 "intent": "function"
                             }
                         },
                         "x": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "y": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "z": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -89,6 +89,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -114,6 +115,7 @@
                                         "value_var": "SHValue_x1"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -140,6 +142,7 @@
                                         "value_var": "SHValue_y1"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -149,17 +152,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "x1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "y1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -472,6 +478,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -501,6 +508,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -530,6 +538,7 @@
                                 "value_var": "SHValue_s2"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -538,16 +547,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         },
                         "s2": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -89,6 +89,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -114,6 +115,7 @@
                                         "value_var": "SHValue_x1"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -140,6 +142,7 @@
                                         "value_var": "SHValue_y1"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -149,17 +152,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "x1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "y1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -472,6 +478,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -501,6 +508,7 @@
                                 "value_var": "SHValue_s1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_class"
@@ -530,6 +538,7 @@
                                 "value_var": "SHValue_s2"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             },
                             "stmt": "py_in_struct*_numpy"
@@ -538,16 +547,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "s1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         },
                         "s2": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "in"
                             }
                         }

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -98,6 +98,7 @@
                                         "vargs": "SHCXX_rv"
                                     },
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     },
                                     "stmt": "py_ctor_struct"
@@ -126,6 +127,7 @@
                                         "value_var": "SHValue_count"
                                     },
                                     "meta": {
+                                        "abstract": "native[]",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -155,6 +157,7 @@
                                         "value_var": "SHValue_name"
                                     },
                                     "meta": {
+                                        "abstract": "char[]",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -164,17 +167,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "struct",
                                         "intent": "ctor"
                                     }
                                 },
                                 "count": {
                                     "meta": {
+                                        "abstract": "native[]",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
+                                        "abstract": "char[]",
                                         "intent": "in",
                                         "value": true
                                     }

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -122,17 +122,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "template",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
+                                        "abstract": "template",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -230,6 +233,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -259,6 +263,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -289,6 +294,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -314,6 +320,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -352,6 +359,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -391,6 +399,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -403,6 +412,7 @@
                                         "stmt": "py_subroutine"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "py_subroutine"
@@ -426,6 +436,7 @@
                                         "value_var": "SHValue_arg1"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -450,6 +461,7 @@
                                         "value_var": "SHValue_arg2"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -459,17 +471,20 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "arg1": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -637,6 +652,7 @@
                                         "typemap_name": "structAsClass_int"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -689,6 +705,7 @@
                                         "typemap_name": "structAsClass_int"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -698,6 +715,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -759,6 +777,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -788,6 +807,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -813,6 +833,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -851,6 +872,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -860,11 +882,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "n": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -932,6 +956,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -981,6 +1006,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -989,6 +1015,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -1042,11 +1069,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "v": {
                                     "meta": {
+                                        "abstract": "template",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1112,6 +1141,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -1141,6 +1171,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1166,6 +1197,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -1204,6 +1236,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1213,11 +1246,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "v": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1261,6 +1296,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "template",
                                         "intent": "function"
                                     }
                                 }
@@ -1328,6 +1364,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -1377,6 +1414,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -1385,6 +1423,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -1541,6 +1580,7 @@
                                         "typemap_name": "structAsClass_double"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capptr",
                                         "intent": "ctor"
                                     },
@@ -1593,6 +1633,7 @@
                                         "typemap_name": "structAsClass_double"
                                     },
                                     "meta": {
+                                        "abstract": "shadow",
                                         "api": "capsule",
                                         "intent": "ctor"
                                     },
@@ -1602,6 +1643,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "shadow",
                                         "intent": "ctor"
                                     }
                                 }
@@ -1663,6 +1705,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -1692,6 +1735,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1717,6 +1761,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -1755,6 +1800,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -1764,11 +1810,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "n": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -1836,6 +1884,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -1885,6 +1934,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -1893,6 +1943,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -1946,11 +1997,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "v": {
                                     "meta": {
+                                        "abstract": "template",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2016,6 +2069,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "c_subroutine"
@@ -2045,6 +2099,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2070,6 +2125,7 @@
                                         "typemap_name": "void"
                                     },
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     },
                                     "stmt": "f_subroutine"
@@ -2108,6 +2164,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     },
@@ -2117,11 +2174,13 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "void",
                                         "intent": "subroutine"
                                     }
                                 },
                                 "v": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "in",
                                         "value": true
                                     }
@@ -2165,6 +2224,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "template",
                                         "intent": "function"
                                     }
                                 }
@@ -2232,6 +2292,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "c_function_native"
@@ -2281,6 +2342,7 @@
                                         "typemap_name": "double"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -2289,6 +2351,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }
@@ -2470,6 +2533,7 @@
                                 "typemap_name": "user_int"
                             },
                             "meta": {
+                                "abstract": "shadow<native>",
                                 "api": "capptr",
                                 "intent": "function"
                             },
@@ -2532,6 +2596,7 @@
                                 "typemap_name": "user_int"
                             },
                             "meta": {
+                                "abstract": "shadow<native>",
                                 "api": "capsule",
                                 "intent": "function"
                             },
@@ -2541,6 +2606,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "shadow<native>",
                                 "intent": "function"
                             }
                         }
@@ -2649,17 +2715,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2781,6 +2850,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2810,6 +2880,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2840,6 +2911,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2865,6 +2937,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2903,6 +2976,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2942,6 +3016,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2954,6 +3029,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2977,6 +3053,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3001,6 +3078,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3010,17 +3088,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3169,6 +3250,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3198,6 +3280,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3228,6 +3311,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3253,6 +3337,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3291,6 +3376,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3330,6 +3416,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3342,6 +3429,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3365,6 +3453,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3389,6 +3478,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3398,17 +3488,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3504,6 +3597,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3602,6 +3696,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3650,6 +3745,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3673,6 +3769,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3681,6 +3778,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3800,6 +3898,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3848,6 +3947,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3871,6 +3971,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3879,6 +3980,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3990,6 +4092,7 @@
                                                 "typemap_name": "std::vector_int"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "api": "capptr",
                                                 "intent": "ctor"
                                             },
@@ -4042,6 +4145,7 @@
                                                 "typemap_name": "std::vector_int"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "api": "capsule",
                                                 "intent": "ctor"
                                             },
@@ -4072,6 +4176,7 @@
                                                 "vargs": "SHCXX_rv"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "intent": "ctor"
                                             },
                                             "stmt": "py_ctor_shadow"
@@ -4080,6 +4185,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "intent": "ctor"
                                             }
                                         }
@@ -4147,6 +4253,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             },
                                             "stmt": "c_dtor"
@@ -4170,6 +4277,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             },
                                             "stmt": "f_dtor"
@@ -4178,6 +4286,7 @@
                                     "py": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             }
                                         }
@@ -4185,6 +4294,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             }
                                         }
@@ -4254,11 +4364,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "value": {
                                             "meta": {
+                                                "abstract": "template&",
                                                 "intent": "in"
                                             }
                                         }
@@ -4333,6 +4445,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -4361,6 +4474,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             },
                                             "stmt": "c_in_native&"
@@ -4385,6 +4499,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -4422,6 +4537,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             },
                                             "stmt": "f_in_native&"
@@ -4433,6 +4549,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -4457,6 +4574,7 @@
                                                 "value_var": "SHValue_value"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             },
                                             "stmt": "py_in_native&"
@@ -4465,11 +4583,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "value": {
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             }
                                         }
@@ -4545,11 +4665,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "template&",
                                                 "intent": "function"
                                             }
                                         },
                                         "n": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -4649,6 +4771,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "function"
                                             },
                                             "stmt": "c_function_native&"
@@ -4686,6 +4809,7 @@
                                                 "typemap_name": "std::vector<int>::size_type"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -4739,6 +4863,7 @@
                                                 "typemap_name": "int"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "deref": "pointer",
                                                 "intent": "function"
                                             },
@@ -4778,6 +4903,7 @@
                                                 "typemap_name": "std::vector<int>::size_type"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -4803,6 +4929,7 @@
                                                 "value_var": "SHValue_rv"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "function"
                                             },
                                             "stmt": "py_function_native&_numpy"
@@ -4826,6 +4953,7 @@
                                                 "value_var": "SHValue_n"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -4835,11 +4963,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "function"
                                             }
                                         },
                                         "n": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -5041,6 +5171,7 @@
                                                 "typemap_name": "std::vector_double"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "api": "capptr",
                                                 "intent": "ctor"
                                             },
@@ -5093,6 +5224,7 @@
                                                 "typemap_name": "std::vector_double"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "api": "capsule",
                                                 "intent": "ctor"
                                             },
@@ -5123,6 +5255,7 @@
                                                 "vargs": "SHCXX_rv"
                                             },
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "intent": "ctor"
                                             },
                                             "stmt": "py_ctor_shadow"
@@ -5131,6 +5264,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "shadow",
                                                 "intent": "ctor"
                                             }
                                         }
@@ -5198,6 +5332,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             },
                                             "stmt": "c_dtor"
@@ -5221,6 +5356,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             },
                                             "stmt": "f_dtor"
@@ -5229,6 +5365,7 @@
                                     "py": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             }
                                         }
@@ -5236,6 +5373,7 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "dtor"
                                             }
                                         }
@@ -5305,11 +5443,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "value": {
                                             "meta": {
+                                                "abstract": "template&",
                                                 "intent": "in"
                                             }
                                         }
@@ -5384,6 +5524,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "c_subroutine"
@@ -5412,6 +5553,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             },
                                             "stmt": "c_in_native&"
@@ -5436,6 +5578,7 @@
                                                 "typemap_name": "void"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "f_subroutine"
@@ -5473,6 +5616,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             },
                                             "stmt": "f_in_native&"
@@ -5484,6 +5628,7 @@
                                                 "stmt": "py_subroutine"
                                             },
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             },
                                             "stmt": "py_subroutine"
@@ -5508,6 +5653,7 @@
                                                 "value_var": "SHValue_value"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             },
                                             "stmt": "py_in_native&"
@@ -5516,11 +5662,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "void",
                                                 "intent": "subroutine"
                                             }
                                         },
                                         "value": {
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "in"
                                             }
                                         }
@@ -5596,11 +5744,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "template&",
                                                 "intent": "function"
                                             }
                                         },
                                         "n": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }
@@ -5700,6 +5850,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "function"
                                             },
                                             "stmt": "c_function_native&"
@@ -5737,6 +5888,7 @@
                                                 "typemap_name": "std::vector<double>::size_type"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -5790,6 +5942,7 @@
                                                 "typemap_name": "double"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "deref": "pointer",
                                                 "intent": "function"
                                             },
@@ -5829,6 +5982,7 @@
                                                 "typemap_name": "std::vector<double>::size_type"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -5854,6 +6008,7 @@
                                                 "value_var": "SHValue_rv"
                                             },
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "function"
                                             },
                                             "stmt": "py_function_native&_numpy"
@@ -5877,6 +6032,7 @@
                                                 "value_var": "SHValue_n"
                                             },
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             },
@@ -5886,11 +6042,13 @@
                                     "share": {
                                         "+result": {
                                             "meta": {
+                                                "abstract": "native&",
                                                 "intent": "function"
                                             }
                                         },
                                         "n": {
                                             "meta": {
+                                                "abstract": "native",
                                                 "intent": "in",
                                                 "value": true
                                             }

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -119,6 +119,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -141,6 +142,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -152,6 +154,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -162,6 +165,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -170,6 +174,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -273,6 +278,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -302,6 +308,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -332,6 +339,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -383,6 +391,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -421,6 +430,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -460,6 +470,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -478,6 +489,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -496,6 +508,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -515,6 +528,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -538,6 +552,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -561,6 +576,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -585,6 +601,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -594,17 +611,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -761,6 +781,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "c_function_string"
@@ -798,6 +819,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -835,6 +857,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -900,6 +923,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function"
@@ -944,6 +968,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -987,6 +1012,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -1006,6 +1032,7 @@
                                 "stmt": "lua_function_string"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         },
@@ -1024,6 +1051,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
@@ -1042,6 +1070,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -1064,6 +1093,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             },
                             "stmt": "py_function_string"
@@ -1089,6 +1119,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -1114,6 +1145,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -1122,16 +1154,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -1233,6 +1268,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1281,6 +1317,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1289,6 +1326,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -1377,6 +1415,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1406,6 +1445,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1457,6 +1497,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1495,6 +1536,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1504,11 +1546,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1615,6 +1659,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1644,6 +1689,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1674,6 +1720,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1725,6 +1772,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1763,6 +1811,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1801,6 +1850,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1819,6 +1869,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -1837,6 +1888,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1856,6 +1908,7 @@
                                 "stmt": "lua_in_bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1879,6 +1932,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1902,6 +1956,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1928,6 +1983,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1937,17 +1993,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2059,6 +2118,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2096,6 +2156,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -2121,6 +2182,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2163,6 +2225,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -2175,6 +2238,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -2193,6 +2257,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -2203,6 +2268,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2228,6 +2294,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -2236,11 +2303,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -2335,6 +2404,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2364,6 +2434,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2389,6 +2460,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2427,6 +2499,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2439,6 +2512,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -2457,6 +2531,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2468,6 +2543,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2491,6 +2567,7 @@
                                 "value_var": "SHValue_indx"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2500,11 +2577,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "indx": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2605,11 +2684,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2705,6 +2786,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2734,6 +2816,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2759,6 +2842,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2797,6 +2881,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2809,6 +2894,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -2827,6 +2913,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2838,6 +2925,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -2861,6 +2949,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2870,11 +2959,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3006,6 +3097,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3035,6 +3127,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3060,6 +3153,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3098,6 +3192,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3110,6 +3205,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -3128,6 +3224,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3139,6 +3236,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3162,6 +3260,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3171,11 +3270,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3269,6 +3370,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "template",
                                 "intent": "function"
                             }
                         }
@@ -3366,6 +3468,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3414,6 +3517,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3422,6 +3526,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3528,6 +3633,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3576,6 +3682,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3584,6 +3691,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         }
@@ -3637,6 +3745,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3659,6 +3768,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3670,6 +3780,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -3680,6 +3791,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -3688,6 +3800,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         }
@@ -3864,6 +3977,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3901,6 +4015,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3939,6 +4054,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "c_in_string&"
@@ -3950,6 +4066,7 @@
                                 "stmt": "lua_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
@@ -3968,6 +4085,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3987,6 +4105,7 @@
                                 "stmt": "lua_in_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -3997,6 +4116,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -4020,6 +4140,7 @@
                                 "value_var": "SHValue_arg2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4046,6 +4167,7 @@
                                 "value_var": "SHValue_name"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             },
                             "stmt": "py_in_string&"
@@ -4054,17 +4176,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4176,6 +4301,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4214,6 +4340,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4257,6 +4384,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -4266,17 +4394,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4375,6 +4506,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -4413,6 +4545,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4456,6 +4589,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "intent": "in"
                             },
@@ -4465,17 +4599,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg2": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "name": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "in"
                             }
                         }
@@ -4561,6 +4698,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4590,6 +4728,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4641,6 +4780,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4679,6 +4819,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4688,11 +4829,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4790,6 +4933,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4819,6 +4963,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4849,6 +4994,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4900,6 +5046,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4938,6 +5085,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4977,6 +5125,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4986,17 +5135,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5111,6 +5263,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5140,6 +5293,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5170,6 +5324,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5200,6 +5355,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5251,6 +5407,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5289,6 +5446,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5328,6 +5486,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5367,6 +5526,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5385,6 +5545,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -5403,6 +5564,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5422,6 +5584,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5441,6 +5604,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5464,6 +5628,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -5487,6 +5652,7 @@
                                 "value_var": "SHValue_num"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5511,6 +5677,7 @@
                                 "value_var": "SHValue_offset"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5535,6 +5702,7 @@
                                 "value_var": "SHValue_stride"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5544,23 +5712,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5683,6 +5855,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5712,6 +5885,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5742,6 +5916,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5793,6 +5968,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5831,6 +6007,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5870,6 +6047,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5879,17 +6057,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5992,6 +6173,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -6021,6 +6203,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6051,6 +6234,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6081,6 +6265,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6132,6 +6317,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6170,6 +6356,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6209,6 +6396,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6248,6 +6436,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6257,23 +6446,27 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6393,6 +6586,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -6422,6 +6616,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6452,6 +6647,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6482,6 +6678,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6512,6 +6709,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6563,6 +6761,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -6601,6 +6800,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6640,6 +6840,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6679,6 +6880,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6718,6 +6920,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6736,6 +6939,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -6754,6 +6958,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6773,6 +6978,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6792,6 +6998,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6811,6 +7018,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6834,6 +7042,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -6857,6 +7066,7 @@
                                 "value_var": "SHValue_num"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6881,6 +7091,7 @@
                                 "value_var": "SHValue_offset"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6905,6 +7116,7 @@
                                 "value_var": "SHValue_stride"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6929,6 +7141,7 @@
                                 "value_var": "SHValue_type"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6938,29 +7151,34 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "offset": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "stride": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "type": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7056,6 +7274,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -7085,6 +7304,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7136,6 +7356,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -7174,6 +7395,7 @@
                                 "typemap_name": "tutorial::TypeID"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7192,6 +7414,7 @@
                                 "stmt": "lua_function_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
@@ -7210,6 +7433,7 @@
                                 "stmt": "lua_in_native"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7233,6 +7457,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -7256,6 +7481,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7265,11 +7491,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7389,6 +7617,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -7427,6 +7656,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7482,6 +7712,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -7521,6 +7752,7 @@
                                 "typemap_name": "tutorial::Color"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7540,6 +7772,7 @@
                                 "stmt": "lua_function_enum"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
@@ -7559,6 +7792,7 @@
                                 "stmt": "lua_in_enum"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7582,6 +7816,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -7606,6 +7841,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -7615,11 +7851,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -7741,6 +7979,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -7769,6 +8008,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native&"
@@ -7797,6 +8037,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native&"
@@ -7821,6 +8062,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -7858,6 +8100,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native&"
@@ -7895,6 +8138,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native&"
@@ -7903,16 +8147,19 @@
                     "lua": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "max": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         },
                         "min": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         }
@@ -7923,6 +8170,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -7947,6 +8195,7 @@
                                 "value_var": "SHValue_max"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native&"
@@ -7971,6 +8220,7 @@
                                 "value_var": "SHValue_min"
                             },
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native&"
@@ -7979,16 +8229,19 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "max": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         },
                         "min": {
                             "meta": {
+                                "abstract": "native&",
                                 "intent": "out"
                             }
                         }
@@ -8112,6 +8365,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -8141,6 +8395,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8171,6 +8426,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -8220,6 +8476,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -8241,6 +8498,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -8250,11 +8508,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -8318,6 +8578,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -8356,6 +8617,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -8396,6 +8658,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -8445,6 +8708,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -8466,6 +8730,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -8475,11 +8740,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -8501,17 +8768,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "incr": {
                             "meta": {
+                                "abstract": "procedure",
                                 "fptr": {
                                     "<FUNCTION>": "incr  None ****************************************",
                                     "ast": {
@@ -8561,6 +8831,7 @@
                                                     "sh_type": "SH_TYPE_INT"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 },
                                                 "stmt": "f_function_native"
@@ -8582,6 +8853,7 @@
                                                     "typemap_name": "int"
                                                 },
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 },
@@ -8591,11 +8863,13 @@
                                         "share": {
                                             "+result": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "function"
                                                 }
                                             },
                                             "arg1": {
                                                 "meta": {
+                                                    "abstract": "native",
                                                     "intent": "none",
                                                     "value": true
                                                 }
@@ -8701,6 +8975,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -8757,6 +9032,7 @@
                                 "typemap_name": "std::string"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "function",
@@ -8778,6 +9054,7 @@
                                 "stmt": "lua_function_string&"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }
@@ -8802,6 +9079,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             },
@@ -8811,6 +9089,7 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "string&",
                                 "intent": "function",
                                 "len": "30"
                             }

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -382,6 +382,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -420,6 +421,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -444,6 +446,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -467,6 +470,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -476,11 +480,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -599,6 +605,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -637,6 +644,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -646,11 +654,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -748,6 +758,7 @@
                                 "typemap_name": "iColor"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -787,6 +798,7 @@
                                 "typemap_name": "iColor"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -811,6 +823,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -835,6 +848,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -844,11 +858,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -963,6 +979,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -1002,6 +1019,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1026,6 +1044,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -1050,6 +1069,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1059,11 +1079,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1153,6 +1175,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1191,6 +1214,7 @@
                                 "typemap_name": "Struct1Rename"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -1202,6 +1226,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1229,6 +1254,7 @@
                                 "vargs": "arg1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_list"
@@ -1237,11 +1263,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -1352,6 +1380,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1390,6 +1419,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1399,11 +1429,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1518,6 +1550,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1556,6 +1589,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1599,6 +1633,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1608,17 +1643,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "ndims": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "shape": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1713,6 +1751,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1751,6 +1790,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1760,11 +1800,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1879,6 +1921,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1917,6 +1960,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1960,6 +2004,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -1969,17 +2014,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "ndims": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "shape": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -369,6 +369,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -398,6 +399,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -449,6 +451,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -487,6 +490,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -511,6 +515,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -534,6 +539,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -543,11 +549,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -647,6 +655,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -676,6 +685,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -727,6 +737,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -765,6 +776,7 @@
                                 "typemap_name": "Alias"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -774,11 +786,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -870,6 +884,7 @@
                                 "typemap_name": "iColor"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -908,6 +923,7 @@
                                 "typemap_name": "iColor"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -963,6 +979,7 @@
                                 "typemap_name": "iColor"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -1002,6 +1019,7 @@
                                 "typemap_name": "iColor"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1026,6 +1044,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -1050,6 +1069,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1059,11 +1079,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1172,6 +1194,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "c_function_enum"
@@ -1210,6 +1233,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1265,6 +1289,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "f_function_enum"
@@ -1304,6 +1329,7 @@
                                 "typemap_name": "TypeID"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1328,6 +1354,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             },
                             "stmt": "py_function_enum"
@@ -1352,6 +1379,7 @@
                                 "value_var": "SHValue_in"
                             },
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1361,11 +1389,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "function"
                             }
                         },
                         "in": {
                             "meta": {
+                                "abstract": "enum",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1450,6 +1480,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1478,6 +1509,7 @@
                                 "typemap_name": "Struct1Rename"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "c_inout_struct*"
@@ -1502,6 +1534,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1540,6 +1573,7 @@
                                 "typemap_name": "Struct1Rename"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "f_inout_struct*"
@@ -1551,6 +1585,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -1578,6 +1613,7 @@
                                 "vargs": "arg1"
                             },
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             },
                             "stmt": "py_inout_struct*_list"
@@ -1586,11 +1622,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "struct*",
                                 "intent": "inout"
                             }
                         }
@@ -1683,6 +1721,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1712,6 +1751,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1763,6 +1803,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1801,6 +1842,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1810,11 +1852,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1911,6 +1955,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1940,6 +1985,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1969,6 +2015,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2020,6 +2067,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2058,6 +2106,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2101,6 +2150,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2110,17 +2160,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "ndims": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "shape": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2197,6 +2250,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2226,6 +2280,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2277,6 +2332,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2315,6 +2371,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2324,11 +2381,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2425,6 +2484,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2454,6 +2514,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2483,6 +2544,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2534,6 +2596,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2572,6 +2635,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2615,6 +2679,7 @@
                                 "typemap_name": "IndexType2"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -2624,17 +2689,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "ndims": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "shape": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 1
                             }

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -171,6 +171,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "c_function_bool"
@@ -208,6 +209,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -245,6 +247,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -253,17 +256,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "i1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i2": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -376,6 +382,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -414,6 +421,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -452,6 +460,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -460,17 +469,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "i1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i2": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -587,6 +599,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -625,6 +638,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -663,6 +677,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -671,17 +686,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "i1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
                         },
                         "i2": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }
@@ -779,6 +797,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -816,6 +835,7 @@
                                 "typemap_name": "IndexType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -825,11 +845,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "i1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -898,6 +920,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -935,6 +958,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -944,11 +968,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "i1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1021,6 +1047,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1058,6 +1085,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1067,11 +1095,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "i1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1170,6 +1200,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1207,6 +1238,7 @@
                                 "typemap_name": "FloatType"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1216,11 +1248,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "f1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1289,6 +1323,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1326,6 +1361,7 @@
                                 "typemap_name": "float"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1335,11 +1371,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "f1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1412,6 +1450,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1449,6 +1488,7 @@
                                 "typemap_name": "double"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1458,11 +1498,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "f1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -73,6 +73,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -102,6 +103,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -153,6 +155,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -191,6 +194,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -215,6 +219,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -238,6 +243,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -247,11 +253,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -344,6 +352,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -373,6 +382,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -424,6 +434,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -462,6 +473,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -486,6 +498,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -509,6 +522,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -518,11 +532,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -615,6 +631,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -644,6 +661,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -695,6 +713,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -733,6 +752,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -757,6 +777,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -780,6 +801,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -789,11 +811,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -888,6 +912,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -917,6 +942,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -968,6 +994,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1006,6 +1033,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1032,6 +1060,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1055,6 +1084,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1064,11 +1094,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1163,6 +1195,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1192,6 +1225,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1243,6 +1277,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1281,6 +1316,7 @@
                                 "typemap_name": "short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1305,6 +1341,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1328,6 +1365,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1337,11 +1375,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1436,6 +1476,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1465,6 +1506,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1516,6 +1558,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1554,6 +1597,7 @@
                                 "typemap_name": "long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1578,6 +1622,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1601,6 +1646,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1610,11 +1656,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1711,6 +1759,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -1740,6 +1789,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1791,6 +1841,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -1829,6 +1880,7 @@
                                 "typemap_name": "long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1855,6 +1907,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1878,6 +1931,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1887,11 +1941,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1984,6 +2040,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2013,6 +2070,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2064,6 +2122,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2102,6 +2161,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2126,6 +2186,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2149,6 +2210,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2158,11 +2220,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2257,6 +2321,7 @@
                                 "typemap_name": "unsigned_short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2286,6 +2351,7 @@
                                 "typemap_name": "unsigned_short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2337,6 +2403,7 @@
                                 "typemap_name": "unsigned_short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2375,6 +2442,7 @@
                                 "typemap_name": "unsigned_short"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2399,6 +2467,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2422,6 +2491,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2431,11 +2501,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2530,6 +2602,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2559,6 +2632,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2610,6 +2684,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2648,6 +2723,7 @@
                                 "typemap_name": "unsigned_int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2672,6 +2748,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2695,6 +2772,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2704,11 +2782,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2803,6 +2883,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2832,6 +2913,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2883,6 +2965,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2921,6 +3004,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2945,6 +3029,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -2968,6 +3053,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2977,11 +3063,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3078,6 +3166,7 @@
                                 "typemap_name": "unsigned_long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3107,6 +3196,7 @@
                                 "typemap_name": "unsigned_long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3158,6 +3248,7 @@
                                 "typemap_name": "unsigned_long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3196,6 +3287,7 @@
                                 "typemap_name": "unsigned_long_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3222,6 +3314,7 @@
                                 "vargs": "SHCXX_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3245,6 +3338,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3254,11 +3348,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3355,6 +3451,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3384,6 +3481,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3435,6 +3533,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3473,6 +3572,7 @@
                                 "typemap_name": "unsigned_long"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3497,6 +3597,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3520,6 +3621,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3529,11 +3631,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3626,6 +3730,7 @@
                                 "typemap_name": "int8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3655,6 +3760,7 @@
                                 "typemap_name": "int8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3706,6 +3812,7 @@
                                 "typemap_name": "int8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3744,6 +3851,7 @@
                                 "typemap_name": "int8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3768,6 +3876,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -3791,6 +3900,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3800,11 +3910,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3897,6 +4009,7 @@
                                 "typemap_name": "int16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3926,6 +4039,7 @@
                                 "typemap_name": "int16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3977,6 +4091,7 @@
                                 "typemap_name": "int16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4015,6 +4130,7 @@
                                 "typemap_name": "int16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4039,6 +4155,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -4062,6 +4179,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4071,11 +4189,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4168,6 +4288,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4197,6 +4318,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4248,6 +4370,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4286,6 +4409,7 @@
                                 "typemap_name": "int32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4310,6 +4434,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -4333,6 +4458,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4342,11 +4468,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4439,6 +4567,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4468,6 +4597,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4519,6 +4649,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4557,6 +4688,7 @@
                                 "typemap_name": "int64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4581,6 +4713,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -4604,6 +4737,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4613,11 +4747,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4710,6 +4846,7 @@
                                 "typemap_name": "uint8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -4739,6 +4876,7 @@
                                 "typemap_name": "uint8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4790,6 +4928,7 @@
                                 "typemap_name": "uint8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -4828,6 +4967,7 @@
                                 "typemap_name": "uint8_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4852,6 +4992,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -4875,6 +5016,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4884,11 +5026,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -4981,6 +5125,7 @@
                                 "typemap_name": "uint16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5010,6 +5155,7 @@
                                 "typemap_name": "uint16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5061,6 +5207,7 @@
                                 "typemap_name": "uint16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5099,6 +5246,7 @@
                                 "typemap_name": "uint16_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5123,6 +5271,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -5146,6 +5295,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5155,11 +5305,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5252,6 +5404,7 @@
                                 "typemap_name": "uint32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5281,6 +5434,7 @@
                                 "typemap_name": "uint32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5332,6 +5486,7 @@
                                 "typemap_name": "uint32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5370,6 +5525,7 @@
                                 "typemap_name": "uint32_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5394,6 +5550,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -5417,6 +5574,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5426,11 +5584,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5523,6 +5683,7 @@
                                 "typemap_name": "uint64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5552,6 +5713,7 @@
                                 "typemap_name": "uint64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5603,6 +5765,7 @@
                                 "typemap_name": "uint64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5641,6 +5804,7 @@
                                 "typemap_name": "uint64_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5665,6 +5829,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -5688,6 +5853,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5697,11 +5863,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -5794,6 +5962,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -5823,6 +5992,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5874,6 +6044,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -5912,6 +6083,7 @@
                                 "typemap_name": "size_t"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5936,6 +6108,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -5959,6 +6132,7 @@
                                 "value_var": "SHValue_arg1"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -5968,11 +6142,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6065,6 +6241,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "c_function_bool"
@@ -6094,6 +6271,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6143,6 +6321,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -6180,6 +6359,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6205,6 +6385,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "py_function_bool"
@@ -6230,6 +6411,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             },
@@ -6239,11 +6421,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "in",
                                 "value": true
                             }
@@ -6349,6 +6533,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "c_function_bool"
@@ -6377,6 +6562,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "c_out_native*"
@@ -6425,6 +6611,7 @@
                                 "typemap_name": "bool"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "f_function_bool"
@@ -6462,6 +6649,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "f_out_native*"
@@ -6486,6 +6674,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             },
                             "stmt": "py_function_bool"
@@ -6510,6 +6699,7 @@
                                 "value_var": "SHValue_flag"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             },
                             "stmt": "py_out_native*"
@@ -6518,11 +6708,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "bool",
                                 "intent": "function"
                             }
                         },
                         "flag": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "out"
                             }
                         }

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -83,6 +83,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -121,6 +122,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -130,11 +132,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -227,6 +231,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -264,6 +269,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             },
@@ -273,11 +279,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -390,11 +398,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -483,11 +493,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -567,11 +579,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -651,11 +665,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -720,11 +736,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -799,6 +817,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -836,6 +855,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             },
@@ -845,11 +865,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -948,17 +970,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "vector<native*>&",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1027,11 +1052,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1103,11 +1130,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -1176,11 +1205,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -1250,11 +1281,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "len": "20",
                                 "rank": 1
@@ -1328,11 +1361,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1428,6 +1463,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "vector<native>",
                                 "intent": "function",
                                 "rank": 1
                             },
@@ -1452,6 +1488,7 @@
                                 "value_var": "SHValue_n"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1461,12 +1498,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "vector<native>",
                                 "intent": "function",
                                 "rank": 1
                             }
                         },
                         "n": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1569,6 +1608,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1595,6 +1635,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -1620,6 +1661,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(arg,2)",
                                 "intent": "in",
                                 "value": true
@@ -1630,17 +1672,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -83,6 +83,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -120,6 +121,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "in",
                                 "rank": 1
                             },
@@ -129,11 +131,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -226,6 +230,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -265,6 +270,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             },
@@ -274,11 +280,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -391,11 +399,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -484,11 +494,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -568,11 +580,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -652,11 +666,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -721,11 +737,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -800,6 +818,7 @@
                                 "stmt": "py_subroutine"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "py_subroutine"
@@ -839,6 +858,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             },
@@ -848,11 +868,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -951,17 +973,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "vector<native*>&",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1030,11 +1055,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -1106,11 +1133,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -1179,11 +1208,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -1253,11 +1284,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "len": "20",
                                 "rank": 1
@@ -1331,11 +1364,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1435,6 +1470,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "vector<native>",
                                 "intent": "function",
                                 "rank": 1
                             },
@@ -1459,6 +1495,7 @@
                                 "value_var": "SHValue_n"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -1468,12 +1505,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "vector<native>",
                                 "intent": "function",
                                 "rank": 1
                             }
                         },
                         "n": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -1576,6 +1615,7 @@
                                 "value_var": "SHValue_rv"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "py_function_native"
@@ -1601,6 +1641,7 @@
                                 "value_var": "SHValue_arg"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -1626,6 +1667,7 @@
                                 "value_var": "SHValue_len"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "implied": "size(arg,2)",
                                 "intent": "in",
                                 "value": true
@@ -1636,17 +1678,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -92,6 +92,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -129,6 +130,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -181,6 +183,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -228,6 +231,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -238,11 +242,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -340,6 +346,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -388,6 +395,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -416,6 +424,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -467,6 +476,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 1
@@ -477,11 +487,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -612,6 +624,7 @@
                             },
                             "fstmts": "c",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -660,6 +673,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -704,6 +718,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -755,6 +770,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 1
@@ -765,11 +781,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -885,6 +903,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -933,6 +952,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -975,6 +995,7 @@
                             },
                             "fstmts": "f",
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1026,6 +1047,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 1
@@ -1036,11 +1058,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -1139,6 +1163,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1187,6 +1212,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "malloc",
                                 "intent": "out",
@@ -1215,6 +1241,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1268,6 +1295,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "out",
@@ -1279,11 +1307,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -1385,6 +1415,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1433,6 +1464,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "malloc",
                                 "intent": "inout",
@@ -1461,6 +1493,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1518,6 +1551,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "inout",
@@ -1529,11 +1563,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1627,6 +1663,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1673,6 +1710,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "inout",
@@ -1701,6 +1739,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1756,6 +1795,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "intent": "inout",
                                 "rank": 1
@@ -1766,11 +1806,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -1867,6 +1909,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -1915,6 +1958,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -1943,6 +1987,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -1994,6 +2039,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 1
@@ -2004,11 +2050,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<native>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -2124,6 +2172,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2162,6 +2211,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native*>&",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2193,6 +2243,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2244,6 +2295,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2293,6 +2345,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native*>&",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2333,6 +2386,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -2342,17 +2396,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg1": {
                             "meta": {
+                                "abstract": "vector<native*>&",
                                 "intent": "in",
                                 "rank": 1
                             }
                         },
                         "num": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -2455,6 +2512,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -2497,6 +2555,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2549,6 +2608,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -2605,6 +2665,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "buf",
                                 "intent": "in",
                                 "rank": 1
@@ -2615,11 +2676,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "in",
                                 "rank": 1
                             }
@@ -2718,6 +2781,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2760,6 +2824,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -2788,6 +2853,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -2837,6 +2903,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "cdesc",
                                 "intent": "out",
                                 "rank": 1
@@ -2847,11 +2914,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -2950,6 +3019,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -2992,6 +3062,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -3020,6 +3091,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3080,6 +3152,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "out",
@@ -3091,11 +3164,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "rank": 1
                             }
@@ -3195,6 +3270,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "c_subroutine"
@@ -3239,6 +3315,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "buf",
                                 "deref": "copy",
                                 "intent": "out",
@@ -3268,6 +3345,7 @@
                                 "typemap_name": "void"
                             },
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             },
                             "stmt": "f_subroutine"
@@ -3329,6 +3407,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "out",
@@ -3341,11 +3420,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "out",
                                 "len": "20",
                                 "rank": 1
@@ -3422,11 +3503,13 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "void",
                                 "intent": "subroutine"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "vector<string>&",
                                 "intent": "inout",
                                 "rank": 1
                             }
@@ -3546,6 +3629,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>",
                                 "deref": "malloc",
                                 "intent": "function",
                                 "rank": 1
@@ -3585,6 +3669,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3650,6 +3735,7 @@
                                 "typemap_name": "std::vector"
                             },
                             "meta": {
+                                "abstract": "vector<native>",
                                 "api": "cdesc",
                                 "deref": "allocatable",
                                 "intent": "function",
@@ -3691,6 +3777,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3700,12 +3787,14 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "vector<native>",
                                 "intent": "function",
                                 "rank": 1
                             }
                         },
                         "n": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }
@@ -3802,6 +3891,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "c_function_native"
@@ -3830,6 +3920,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -3860,6 +3951,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -3911,6 +4003,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             },
                             "stmt": "f_function_native"
@@ -3953,6 +4046,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             },
@@ -3993,6 +4087,7 @@
                                 "typemap_name": "int"
                             },
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             },
@@ -4002,17 +4097,20 @@
                     "share": {
                         "+result": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "function"
                             }
                         },
                         "arg": {
                             "meta": {
+                                "abstract": "native*",
                                 "intent": "in",
                                 "rank": 2
                             }
                         },
                         "len": {
                             "meta": {
+                                "abstract": "native",
                                 "intent": "in",
                                 "value": true
                             }

--- a/regression/reference/wrap-c/wrap.json
+++ b/regression/reference/wrap-c/wrap.json
@@ -77,6 +77,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -85,6 +86,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }

--- a/regression/reference/wrap-cxx/wrap.json
+++ b/regression/reference/wrap-cxx/wrap.json
@@ -77,6 +77,7 @@
                                         "typemap_name": "int"
                                     },
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     },
                                     "stmt": "f_function_native"
@@ -85,6 +86,7 @@
                             "share": {
                                 "+result": {
                                     "meta": {
+                                        "abstract": "native",
                                         "intent": "function"
                                     }
                                 }

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -659,6 +659,7 @@ def main_with_args(args):
             whelpers.write_f_helpers(fp)
 
     if args.write_statements:
+        os.chdir(args.logdir)
         hfile = os.path.join(args.logdir, args.write_statements)
 
         lang = newlibrary.language

--- a/shroud/metaattrs.py
+++ b/shroud/metaattrs.py
@@ -22,6 +22,7 @@ This file sets some meta attributes based on language specific
 wrappings.
 
 Shared:
+   abstract Computed from declaration  ex  'native', 'native*'
    charlen  attrs
 
 Fortran:
@@ -126,6 +127,12 @@ class FillMeta(object):
                     "used on pointer and references"
                 )
             self.parse_dim_attrs(dim, meta)
+
+    def set_func_abstract_type(self, node, meta):
+        meta["abstract"] = statements.find_abstract_declarator(node.ast)
+
+    def set_arg_abstract_type(self, node, arg, meta):
+        meta["abstract"] = statements.find_abstract_declarator(arg)
         
     def set_func_intent(self, node, meta):
         declarator = node.ast.declarator
@@ -655,7 +662,7 @@ class FillMeta(object):
         if not meta["intent"]:
             meta["intent"] = share_meta["intent"]
         for attr in [
-                "assumedtype",
+                "abstract", "assumedtype",
                 "dimension", "dim_ast",
                 "free_pattern", "hidden", "len", "owner", "rank",
         ]:
@@ -668,7 +675,7 @@ class FillMeta(object):
         if not meta["intent"]:
             meta["intent"] = share_meta["intent"]
         for attr in [
-                "assumedtype",
+                "abstract", "assumedtype",
                 "dimension", "dim_ast",
                 "fptr", "free_pattern", "hidden", "len", "owner", "rank",
                 "value", "optional",
@@ -718,6 +725,7 @@ class FillMetaShare(FillMeta):
         r_meta = r_bind.meta
         
         self.check_func_attrs(node, r_meta)
+        self.set_func_abstract_type(node, r_meta)
         self.set_func_intent(node, r_meta)
         self.meta_function_params(node, is_fptr)
 
@@ -735,6 +743,7 @@ class FillMetaShare(FillMeta):
             meta = a_bind.meta
 
             self.check_arg_attrs(node, arg, meta)
+            self.set_arg_abstract_type(node, arg, meta)
             self.set_arg_intent(arg, meta, is_fptr)
             self.check_value(arg, meta)
 

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -761,6 +761,13 @@ def print_tree_statements(fp, statements, defaults):
         complete[name] = all
     yaml.safe_dump(complete, fp, sort_keys=False)
 
+    return
+    # Dump each group to a file
+    # This makes it easier to compare one finalized group to another using diff.
+    for name, group in complete.items():
+        with open(name, "w") as fp:
+            yaml.safe_dump(group, fp, sort_keys=False)
+
 
 # Listed in the order they are used in the wrapper.
 # This order is preserved with option --write-statements.

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -207,8 +207,7 @@ def lookup_c_function_stmt(node):
         result_stmt = lookup_fc_stmts(stmts)
     else:
         # intent will be "function", "ctor", "getter"
-        abstract = find_abstract_declarator(ast)
-        stmts = ["c", sintent, abstract,
+        stmts = ["c", sintent, r_meta["abstract"],
                  r_meta["api"], r_meta["deref"], r_meta["owner"]]
     result_stmt = lookup_fc_stmts(stmts)
     return result_stmt
@@ -226,8 +225,7 @@ def lookup_f_function_stmt(node):
         result_stmt = lookup_fc_stmts(stmts)
     else:
         # intent will be "function", "ctor", "getter"
-        abstract = find_abstract_declarator(ast)
-        stmts = ["f", sintent, abstract,
+        stmts = ["f", sintent, r_meta["abstract"],
                  r_meta["api"], r_meta["deref"], r_meta["owner"]]
     result_stmt = lookup_fc_stmts(stmts)
     return result_stmt
@@ -235,9 +233,8 @@ def lookup_f_function_stmt(node):
 def lookup_c_arg_stmt(node, arg):
     """Lookup the C statements for an argument."""
     c_meta = get_arg_bind(node, arg, "c").meta
-    abstract = find_abstract_declarator(arg)
     sapi = c_meta["api"]
-    stmts = ["c", c_meta["intent"], abstract,
+    stmts = ["c", c_meta["intent"], c_meta["abstract"],
              sapi, c_meta["deref"], c_meta["owner"]]
     arg_stmt = lookup_fc_stmts(stmts)
     return arg_stmt
@@ -245,11 +242,10 @@ def lookup_c_arg_stmt(node, arg):
 def lookup_f_arg_stmt(node, arg):
     """Lookup the Fortran statements for an argument."""
     c_meta = get_arg_bind(node, arg, "f").meta
-    abstract = find_abstract_declarator(arg)
     sapi = c_meta["api"]
     if c_meta["hidden"]:
         sapi = "hidden"
-    stmts = ["f", c_meta["intent"], abstract,
+    stmts = ["f", c_meta["intent"], c_meta["abstract"],
              sapi, c_meta["deref"], c_meta["owner"]]
     arg_stmt = lookup_fc_stmts(stmts)
     return arg_stmt

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -677,11 +677,11 @@ def write_cf_tree(fp):
     ----------
     fp : file
     """
+    print_tree_statements(fp, fc_dict, default_stmts)
     tree = update_stmt_tree(fc_dict)
     lines = []
     print_tree_index(tree, lines)
     fp.writelines(lines)
-    print_tree_statements(fp, fc_dict, default_stmts)
 
 
 def print_tree_index(tree, lines, indent=""):

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -987,11 +987,11 @@ def write_stmts_tree(fp):
     ----------
     fp : file
     """
+    statements.print_tree_statements(fp, lua_dict, default_stmts)
     tree = statements.update_stmt_tree(lua_dict)
     lines = []
     statements.print_tree_index(tree, lines)
     fp.writelines(lines)
-    statements.print_tree_statements(fp, lua_dict, default_stmts)
     
 
 def lookup_stmts(path):

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3465,11 +3465,11 @@ def write_stmts_tree(fp):
     ----------
     fp : file
     """
+    statements.print_tree_statements(fp, py_dict, default_stmts)
     tree = statements.update_stmt_tree(py_dict)
     lines = []
     statements.print_tree_index(tree, lines)
     fp.writelines(lines)
-    statements.print_tree_statements(fp, py_dict, default_stmts)
 
 
 def lookup_stmts(path):


### PR DESCRIPTION
The abstract type from the declaration, ex. `native` or `native*`. Before it was computed right before it was used to look up the statements.  By storing it in meta attributes, it's easier to change it if necessary. For example, with `std::shared_ptr`. This changes all of the JSON files which dump the meta attributes.

Reorder output from --write-statements option.