### PR TITLE
Add fmt.c_arglist and f_arglist

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -592,7 +592,7 @@ C_name_template
 C_name_shared_api_template
     Name of the smart pointer object created by group *smart_pointer*.
     The format field *smart_pointer* is taken from the Typemap for the smart pointer.
-     ``{C_name_api}_{smart_pointer}``
+    ``{C_name_api}_{smart_pointer}``
     
 C_name_typedef_template
     ``{C_prefix}{C_name_scope}{typedef_name}``
@@ -1185,6 +1185,13 @@ F_value
 Class
 ^^^^^
 
+c_arglist
+    An array of format fields for the C wrapper of the function and
+    its arguments.  Entry 0 is the function, 1 is the first argument,
+    and so on.  Allows the statement group of an argument to access
+    another argument's format fields to coordinate behavior.
+    For example, ``c_arglist[1].c_local_cxx``.
+
 C_header_filename
     Name of generated header file for the class.
     Defaulted from expansion of option *C_header_filename_class_template*.
@@ -1198,6 +1205,13 @@ baseclass
     class' *typemap*.  Used in format fields as
     ``{baseclass.cxx_type}``.
     
+f_arglist
+    An array of format fields for the Fortran wrapper of the function and
+    its arguments.  Entry 0 is the function, 1 is the first argument,
+    and so on.  Allows the statement group of an argument to access
+    another argument's format fields to coordinate behavior.
+    For example, ``c_arglist[1].c_local_cxx``.
+
 F_derived_name
     Name of Fortran derived type for this class.
     Computed from option *F_derived_name_template*.

--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -301,6 +301,16 @@ See the sgroup.yaml test.
 Format fields
 -------------
 
+Each statement group is evaluated in the context of a format
+dictionary created for the function result or argument.
+
+* c_arglist, f_arglist
+
+  An array of format fields for all arguments to the function.  Entry
+  0 is the function, 1 is the first argument, and so on.  This allows
+  a statement group to access other variable using a value such as
+  ``c_arglist[1].c_local_cxx``.
+
 Several format fields are defined to help use a set of statements with both
 pointers and references.
 

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -187,6 +187,12 @@
                             "PY_name_impl": "PY_ArrayWrapper_tp_init",
                             "PY_type_impl": "PY_ArrayWrapper_tp_init",
                             "PY_type_method": "tp_init",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         },
@@ -412,10 +418,18 @@
                             "F_name_generic": "setSize",
                             "F_name_impl": "ArrayWrapper_setSize",
                             "PY_name_impl": "PY_setSize",
+                            "c_arglist": [
+                                "self",
+                                "size"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "size"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "setSize"
                         },
@@ -582,10 +596,16 @@
                             "F_name_generic": "getSize",
                             "F_name_impl": "ArrayWrapper_getSize",
                             "PY_name_impl": "PY_getSize",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "const ",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(IN)",
                             "function_name": "getSize"
                         },
@@ -814,10 +834,18 @@
                             "F_name_generic": "fillSize",
                             "F_name_impl": "ArrayWrapper_fillSize",
                             "PY_name_impl": "PY_fillSize",
+                            "c_arglist": [
+                                "self",
+                                "size"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "size"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fillSize"
                         },
@@ -927,10 +955,16 @@
                             "F_name_generic": "allocate",
                             "F_name_impl": "ArrayWrapper_allocate",
                             "PY_name_impl": "PY_allocate",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "allocate"
                         },
@@ -1175,10 +1209,16 @@
                             "F_name_generic": "getArray",
                             "F_name_impl": "ArrayWrapper_getArray",
                             "PY_name_impl": "PY_getArray",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "getArray"
                         },
@@ -1427,10 +1467,16 @@
                             "F_name_generic": "getArrayConst",
                             "F_name_impl": "ArrayWrapper_getArrayConst",
                             "PY_name_impl": "PY_getArrayConst",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "const ",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(IN)",
                             "function_name": "getArrayConst"
                         },
@@ -1678,10 +1724,16 @@
                             "F_name_generic": "getArrayC",
                             "F_name_impl": "ArrayWrapper_getArrayC",
                             "PY_name_impl": "PY_getArrayC",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "getArrayC"
                         },
@@ -1931,10 +1983,16 @@
                             "F_name_generic": "getArrayConstC",
                             "F_name_impl": "ArrayWrapper_getArrayConstC",
                             "PY_name_impl": "PY_getArrayConstC",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "const ",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(IN)",
                             "function_name": "getArrayConstC"
                         },
@@ -2365,10 +2423,20 @@
                             "F_name_generic": "fetchArrayPtr",
                             "F_name_impl": "ArrayWrapper_fetchArrayPtr",
                             "PY_name_impl": "PY_fetchArrayPtr",
+                            "c_arglist": [
+                                "self",
+                                "array",
+                                "isize"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "array",
+                                "isize"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fetchArrayPtr"
                         },
@@ -2798,10 +2866,20 @@
                             "F_name_generic": "fetchArrayRef",
                             "F_name_impl": "ArrayWrapper_fetchArrayRef",
                             "PY_name_impl": "PY_fetchArrayRef",
+                            "c_arglist": [
+                                "self",
+                                "array",
+                                "isize"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "array",
+                                "isize"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fetchArrayRef"
                         },
@@ -3232,10 +3310,20 @@
                             "F_name_generic": "fetchArrayPtrConst",
                             "F_name_impl": "ArrayWrapper_fetchArrayPtrConst",
                             "PY_name_impl": "PY_fetchArrayPtrConst",
+                            "c_arglist": [
+                                "self",
+                                "array",
+                                "isize"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "array",
+                                "isize"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fetchArrayPtrConst"
                         },
@@ -3666,10 +3754,20 @@
                             "F_name_generic": "fetchArrayRefConst",
                             "F_name_impl": "ArrayWrapper_fetchArrayRefConst",
                             "PY_name_impl": "PY_fetchArrayRefConst",
+                            "c_arglist": [
+                                "self",
+                                "array",
+                                "isize"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "array",
+                                "isize"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fetchArrayRefConst"
                         },
@@ -3901,10 +3999,18 @@
                             "F_name_generic": "fetchVoidPtr",
                             "F_name_impl": "ArrayWrapper_fetchVoidPtr",
                             "PY_name_impl": "PY_fetchVoidPtr",
+                            "c_arglist": [
+                                "self",
+                                "array"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "array"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fetchVoidPtr"
                         },
@@ -4136,10 +4242,18 @@
                             "F_name_generic": "fetchVoidRef",
                             "F_name_impl": "ArrayWrapper_fetchVoidRef",
                             "PY_name_impl": "PY_fetchVoidRef",
+                            "c_arglist": [
+                                "self",
+                                "array"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "array"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "fetchVoidRef"
                         },
@@ -4422,10 +4536,18 @@
                             "F_name_generic": "checkPtr",
                             "F_name_impl": "ArrayWrapper_checkPtr",
                             "PY_name_impl": "PY_checkPtr",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "array"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "array"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "checkPtr"
                         },
@@ -4592,10 +4714,16 @@
                             "F_name_generic": "sumArray",
                             "F_name_impl": "ArrayWrapper_sumArray",
                             "PY_name_impl": "PY_sumArray",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "sumArray"
                         },

--- a/regression/reference/ccomplex/ccomplex.json
+++ b/regression/reference/ccomplex/ccomplex.json
@@ -137,6 +137,10 @@
                     "F_name_function": "accept_float_complex_inout_ptr",
                     "F_name_generic": "accept_float_complex_inout_ptr",
                     "F_name_impl": "accept_float_complex_inout_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptFloatComplexInoutPtr"
                 }
             },
@@ -304,6 +308,10 @@
                     "F_name_generic": "accept_double_complex_inout_ptr",
                     "F_name_impl": "accept_double_complex_inout_ptr",
                     "PY_name_impl": "PY_acceptDoubleComplexInoutPtr",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptDoubleComplexInoutPtr"
                 },
                 "zz_fmtlang": {
@@ -489,6 +497,10 @@
                     "F_name_generic": "accept_double_complex_out_ptr",
                     "F_name_impl": "accept_double_complex_out_ptr",
                     "PY_name_impl": "PY_acceptDoubleComplexOutPtr",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptDoubleComplexOutPtr"
                 },
                 "zz_fmtlang": {
@@ -931,6 +943,11 @@
                     "F_name_generic": "accept_double_complex_out_ptr_flag",
                     "F_name_impl": "accept_double_complex_out_ptr_flag",
                     "PY_name_impl": "PY_acceptDoubleComplexOutPtrFlag",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "flag"
+                    ],
                     "function_name": "acceptDoubleComplexOutPtrFlag"
                 },
                 "zz_fmtlang": {

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -228,6 +228,14 @@
                     "F_name_function": "rank2_in",
                     "F_name_generic": "rank2_in",
                     "F_name_impl": "rank2_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "Rank2In"
                 }
             },
@@ -545,6 +553,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "GetScalar1",
                     "F_name_api": "get_scalar1",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "value"
+                    ],
                     "function_name": "GetScalar1"
                 }
             },
@@ -798,6 +811,11 @@
                     "F_name_function": "get_scalar1_0",
                     "F_name_generic": "get_scalar1",
                     "F_name_impl": "get_scalar1_0",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "value"
+                    ],
                     "function_name": "GetScalar1",
                     "function_suffix": "_0"
                 }
@@ -1052,6 +1070,11 @@
                     "F_name_function": "get_scalar1_1",
                     "F_name_generic": "get_scalar1",
                     "F_name_impl": "get_scalar1_1",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "value"
+                    ],
                     "function_name": "GetScalar1",
                     "function_suffix": "_1"
                 }
@@ -1286,6 +1309,12 @@
                     "F_name_function": "get_data_int",
                     "F_name_generic": "get_data",
                     "F_name_impl": "get_data_int",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getData",
                     "template_suffix": "_int"
                 }
@@ -1452,6 +1481,12 @@
                     "F_name_function": "get_data_double",
                     "F_name_generic": "get_data",
                     "F_name_impl": "get_data_double",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getData",
                     "template_suffix": "_double"
                 }
@@ -1879,6 +1914,11 @@
                     "F_name_function": "get_scalar2_0",
                     "F_name_generic": "get_scalar2",
                     "F_name_impl": "get_scalar2_0",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "value"
+                    ],
                     "function_name": "GetScalar2",
                     "function_suffix": "_0",
                     "stype": "int"
@@ -2108,6 +2148,11 @@
                     "F_name_function": "get_scalar2_1",
                     "F_name_generic": "get_scalar2",
                     "F_name_impl": "get_scalar2_1",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "value"
+                    ],
                     "function_name": "GetScalar2",
                     "function_suffix": "_1",
                     "stype": "double"

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -298,6 +298,12 @@
                             "PY_name_impl": "PY_Class1_tp_init_default",
                             "PY_type_impl": "PY_Class1_tp_init_default",
                             "PY_type_method": "tp_init",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor",
                             "function_suffix": "_default"
@@ -667,6 +673,14 @@
                             "PY_name_impl": "PY_Class1_tp_init_flag",
                             "PY_type_impl": "PY_Class1_tp_init_flag",
                             "PY_type_method": "tp_init",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "flag"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv",
+                                "flag"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor",
                             "function_suffix": "_flag"
@@ -797,10 +811,16 @@
                             "LUA_name": "delete",
                             "LUA_name_api": "delete",
                             "LUA_name_impl": "l_Class1_delete",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "delete"
                         },
@@ -987,10 +1007,16 @@
                             "LUA_name_api": "Method1",
                             "LUA_name_impl": "l_Class1_Method1",
                             "PY_name_impl": "PY_Method1",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "Method1"
                         },
@@ -1305,10 +1331,18 @@
                             "F_name_generic": "equivalent",
                             "F_name_impl": "class1_equivalent",
                             "PY_name_impl": "PY_equivalent",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "obj2"
+                            ],
                             "c_const": "const ",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "obj2"
+                            ],
                             "f_intent_attr": ", intent(IN)",
                             "function_name": "equivalent"
                         },
@@ -1465,10 +1499,16 @@
                             "F_name_function": "return_this",
                             "F_name_generic": "return_this",
                             "F_name_impl": "class1_return_this",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "returnThis"
                         }
@@ -1835,10 +1875,20 @@
                             "F_name_function": "return_this_buffer",
                             "F_name_generic": "return_this_buffer",
                             "F_name_impl": "class1_return_this_buffer",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "name",
+                                "flag"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "name",
+                                "flag"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "returnThisBuffer"
                         }
@@ -2036,10 +2086,16 @@
                             "F_name_generic": "getclass3",
                             "F_name_impl": "class1_getclass3",
                             "PY_name_impl": "PY_getclass3",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "const ",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(IN)",
                             "function_name": "getclass3"
                         },
@@ -2273,10 +2329,16 @@
                             "LUA_name_api": "getName",
                             "LUA_name_impl": "l_Class1_getName",
                             "PY_name_impl": "PY_getName",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "getName"
                         },
@@ -2635,10 +2697,18 @@
                             "LUA_name_api": "directionFunc",
                             "LUA_name_impl": "l_Class1_directionFunc",
                             "PY_name_impl": "PY_directionFunc",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "arg"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "arg"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "directionFunc"
                         },
@@ -2768,6 +2838,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_flag",
                             "function_name": "get_m_flag",
@@ -2875,6 +2948,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_test",
                             "function_name": "get_test",
@@ -3020,6 +3096,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_test",
                             "function_name": "set_test",
@@ -3125,6 +3205,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_bool",
                             "function_name": "get_m_bool",
@@ -3269,6 +3352,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_bool",
                             "function_name": "set_m_bool",
@@ -3396,6 +3483,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_name",
                             "function_name": "get_m_name",
@@ -3541,6 +3631,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_name",
                             "function_name": "set_m_name",
@@ -3954,10 +4048,16 @@
                             "LUA_name_api": "getName",
                             "LUA_name_impl": "l_Class2_getName",
                             "PY_name_impl": "PY_getName",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "getName"
                         },
@@ -4224,10 +4324,16 @@
                             "F_name_impl": "singleton_get_reference",
                             "PY_name_impl": "PY_getReference",
                             "PY_this_call": "classes::Singleton::",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "getReference"
                         },
@@ -4494,6 +4600,12 @@
                             "PY_name_impl": "PY_Shape_tp_init",
                             "PY_type_impl": "PY_Shape_tp_init",
                             "PY_type_method": "tp_init",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         },
@@ -4684,10 +4796,16 @@
                             "LUA_name_api": "get_ivar",
                             "LUA_name_impl": "l_Shape_get_ivar",
                             "PY_name_impl": "PY_get_ivar",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "const ",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(IN)",
                             "function_name": "get_ivar"
                         },
@@ -4967,6 +5085,12 @@
                             "PY_name_impl": "PY_Circle_tp_init",
                             "PY_type_impl": "PY_Circle_tp_init",
                             "PY_type_method": "tp_init",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         },
@@ -5213,10 +5337,18 @@
                             "F_name_function": "allocate",
                             "F_name_generic": "allocate",
                             "F_name_impl": "data_allocate",
+                            "c_arglist": [
+                                "self",
+                                "n"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "n"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "allocate"
                         }
@@ -5300,10 +5432,16 @@
                             "F_name_function": "free",
                             "F_name_generic": "free",
                             "F_name_impl": "data_free",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "free"
                         }
@@ -5452,6 +5590,12 @@
                             "F_name_function": "ctor",
                             "F_name_generic": "data",
                             "F_name_impl": "data_ctor",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         }
@@ -5537,10 +5681,16 @@
                             "F_name_function": "dtor",
                             "F_name_generic": "dtor",
                             "F_name_impl": "data_dtor",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "dtor"
                         }
@@ -5645,6 +5795,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "nitems",
                             "function_name": "get_nitems",
@@ -5790,6 +5943,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "nitems",
                             "function_name": "set_nitems",
@@ -5940,6 +6097,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "items",
                             "function_name": "get_items",
@@ -6095,6 +6255,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "items",
                             "function_name": "set_items",
@@ -6564,6 +6728,14 @@
                     "LUA_name_api": "directionFunc",
                     "LUA_name_impl": "l_directionFunc",
                     "PY_name_impl": "PY_directionFunc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "directionFunc"
                 },
                 "zz_fmtlang": {
@@ -6828,6 +7000,14 @@
                     "F_name_generic": "pass_class_by_value",
                     "F_name_impl": "pass_class_by_value",
                     "PY_name_impl": "PY_passClassByValue",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "passClassByValue"
                 },
                 "zz_fmtlang": {
@@ -7132,6 +7312,14 @@
                     "F_name_generic": "useclass",
                     "F_name_impl": "useclass",
                     "PY_name_impl": "PY_useclass",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "useclass"
                 },
                 "zz_fmtlang": {
@@ -7307,6 +7495,12 @@
                     "F_name_function": "getclass2",
                     "F_name_generic": "getclass2",
                     "F_name_impl": "getclass2",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getclass2"
                 }
             },
@@ -7502,6 +7696,12 @@
                     "F_name_generic": "getclass3",
                     "F_name_impl": "getclass3",
                     "PY_name_impl": "PY_getclass3",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getclass3"
                 },
                 "zz_fmtlang": {
@@ -7656,6 +7856,12 @@
                     "F_name_function": "getclass2_void",
                     "F_name_generic": "getclass2_void",
                     "F_name_impl": "getclass2_void",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getclass2_void"
                 }
             },
@@ -7797,6 +8003,12 @@
                     "F_name_function": "getclass3_void",
                     "F_name_generic": "getclass3_void",
                     "F_name_impl": "getclass3_void",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getclass3_void"
                 }
             },
@@ -7953,6 +8165,12 @@
                     "F_name_function": "get_const_class_reference",
                     "F_name_generic": "get_const_class_reference",
                     "F_name_impl": "get_const_class_reference",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstClassReference"
                 }
             },
@@ -8145,6 +8363,12 @@
                     "F_name_generic": "get_class_reference",
                     "F_name_impl": "get_class_reference",
                     "PY_name_impl": "PY_getClassReference",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getClassReference"
                 },
                 "zz_fmtlang": {
@@ -8409,6 +8633,14 @@
                     "F_name_function": "get_class_copy",
                     "F_name_generic": "get_class_copy",
                     "F_name_impl": "get_class_copy",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "getClassCopy"
                 }
             },
@@ -8656,6 +8888,14 @@
                     "LUA_name_api": "set_global_flag",
                     "LUA_name_impl": "l_set_global_flag",
                     "PY_name_impl": "PY_set_global_flag",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "set_global_flag"
                 },
                 "zz_fmtlang": {
@@ -8843,6 +9083,12 @@
                     "LUA_name_api": "get_global_flag",
                     "LUA_name_impl": "l_get_global_flag",
                     "PY_name_impl": "PY_get_global_flag",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "get_global_flag"
                 },
                 "zz_fmtlang": {
@@ -9073,6 +9319,12 @@
                     "LUA_name_api": "LastFunctionCalled",
                     "LUA_name_impl": "l_LastFunctionCalled",
                     "PY_name_impl": "PY_LastFunctionCalled",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "LastFunctionCalled"
                 },
                 "zz_fmtlang": {

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -162,6 +162,9 @@
                     "F_name_generic": "no_return_no_arguments",
                     "F_name_impl": "no_return_no_arguments",
                     "PY_name_impl": "PY_NoReturnNoArguments",
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "NoReturnNoArguments"
                 },
                 "zz_fmtlang": {
@@ -455,6 +458,11 @@
                     "F_name_generic": "pass_by_value",
                     "F_name_impl": "pass_by_value",
                     "PY_name_impl": "PY_PassByValue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "PassByValue"
                 },
                 "zz_fmtlang": {
@@ -726,6 +734,11 @@
                     "F_name_generic": "pass_by_reference",
                     "F_name_impl": "pass_by_reference",
                     "PY_name_impl": "PY_PassByReference",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "PassByReference"
                 },
                 "zz_fmtlang": {
@@ -947,6 +960,10 @@
                     "F_name_generic": "pass_by_value_macro",
                     "F_name_impl": "pass_by_value_macro",
                     "PY_name_impl": "PY_PassByValueMacro",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg2"
+                    ],
                     "function_name": "PassByValueMacro"
                 },
                 "zz_fmtlang": {
@@ -1306,6 +1323,12 @@
                     "F_name_generic": "check_bool",
                     "F_name_impl": "check_bool",
                     "PY_name_impl": "PY_checkBool",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2",
+                        "arg3"
+                    ],
                     "function_name": "checkBool"
                 },
                 "zz_fmtlang": {
@@ -1635,6 +1658,11 @@
                     "F_name_generic": "function4a",
                     "F_name_impl": "function4a",
                     "PY_name_impl": "PY_Function4a",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "Function4a"
                 },
                 "zz_fmtlang": {
@@ -1817,6 +1845,10 @@
                     "F_name_generic": "accept_name",
                     "F_name_impl": "accept_name",
                     "PY_name_impl": "PY_acceptName",
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "acceptName"
                 },
                 "zz_fmtlang": {
@@ -2018,6 +2050,10 @@
                     "F_name_generic": "pass_char_ptr_in_out",
                     "F_name_impl": "pass_char_ptr_in_out",
                     "PY_name_impl": "PY_passCharPtrInOut",
+                    "f_arglist": [
+                        "f_var",
+                        "s"
+                    ],
                     "function_name": "passCharPtrInOut"
                 },
                 "zz_fmtlang": {
@@ -2288,6 +2324,12 @@
                     "F_name_function": "pass_char_ptr_capi",
                     "F_name_generic": "pass_char_ptr_capi",
                     "F_name_impl": "pass_char_ptr_capi",
+                    "f_arglist": [
+                        "f_var",
+                        "n",
+                        "in",
+                        "out"
+                    ],
                     "function_name": "passCharPtrCAPI"
                 }
             },
@@ -2473,6 +2515,10 @@
                     "F_name_generic": "return_one_name",
                     "F_name_impl": "return_one_name",
                     "PY_name_impl": "PY_returnOneName",
+                    "f_arglist": [
+                        "f_var",
+                        "name1"
+                    ],
                     "function_name": "returnOneName"
                 },
                 "zz_fmtlang": {
@@ -2761,6 +2807,11 @@
                     "F_name_generic": "return_two_names",
                     "F_name_impl": "return_two_names",
                     "PY_name_impl": "PY_returnTwoNames",
+                    "f_arglist": [
+                        "f_var",
+                        "name1",
+                        "name2"
+                    ],
                     "function_name": "returnTwoNames"
                 },
                 "zz_fmtlang": {
@@ -3045,6 +3096,11 @@
                     "F_name_generic": "implied_text_len",
                     "F_name_impl": "implied_text_len",
                     "PY_name_impl": "PY_ImpliedTextLen",
+                    "f_arglist": [
+                        "f_var",
+                        "text",
+                        "ltext"
+                    ],
                     "function_name": "ImpliedTextLen"
                 },
                 "zz_fmtlang": {
@@ -3441,6 +3497,12 @@
                     "F_name_generic": "implied_len",
                     "F_name_impl": "implied_len",
                     "PY_name_impl": "PY_ImpliedLen",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "text",
+                        "ltext",
+                        "flag"
+                    ],
                     "function_name": "ImpliedLen"
                 },
                 "zz_fmtlang": {
@@ -3842,6 +3904,12 @@
                     "F_name_generic": "implied_len_trim",
                     "F_name_impl": "implied_len_trim",
                     "PY_name_impl": "PY_ImpliedLenTrim",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "text",
+                        "ltext",
+                        "flag"
+                    ],
                     "function_name": "ImpliedLenTrim"
                 },
                 "zz_fmtlang": {
@@ -4065,6 +4133,10 @@
                     "F_name_generic": "implied_bool_true",
                     "F_name_impl": "implied_bool_true",
                     "PY_name_impl": "PY_ImpliedBoolTrue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "ImpliedBoolTrue"
                 },
                 "zz_fmtlang": {
@@ -4284,6 +4356,10 @@
                     "F_name_generic": "implied_bool_false",
                     "F_name_impl": "implied_bool_false",
                     "PY_name_impl": "PY_ImpliedBoolFalse",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "ImpliedBoolFalse"
                 },
                 "zz_fmtlang": {
@@ -4368,6 +4444,9 @@
                     "F_name_function": "bind_c1",
                     "F_name_generic": "bind_c1",
                     "F_name_impl": "Fortran_bindC1a",
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "bindC1",
                     "i_name_function": "Fortran_bindC1b"
                 }
@@ -4515,6 +4594,10 @@
                     "F_name_function": "bind_c2",
                     "F_name_generic": "bind_c2",
                     "F_name_impl": "Fortran_bindC2a",
+                    "f_arglist": [
+                        "f_var",
+                        "outbuf"
+                    ],
                     "function_name": "bindC2"
                 }
             },
@@ -4717,6 +4800,11 @@
                     "F_name_function": "pass_void_star_star",
                     "F_name_generic": "pass_void_star_star",
                     "F_name_impl": "pass_void_star_star",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out"
+                    ],
                     "function_name": "passVoidStarStar"
                 }
             },
@@ -4879,6 +4967,10 @@
                     "F_name_function": "pass_assumed_type",
                     "F_name_generic": "pass_assumed_type",
                     "F_name_impl": "pass_assumed_type",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "passAssumedType"
                 }
             },
@@ -5022,6 +5114,10 @@
                     "F_name_function": "pass_assumed_type_rank",
                     "F_name_generic": "pass_assumed_type_rank",
                     "F_name_impl": "pass_assumed_type_rank",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "passAssumedTypeRank"
                 }
             },
@@ -5255,6 +5351,11 @@
                     "F_name_function": "pass_assumed_type_buf",
                     "F_name_generic": "pass_assumed_type_buf",
                     "F_name_impl": "pass_assumed_type_buf",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg",
+                        "outbuf"
+                    ],
                     "function_name": "passAssumedTypeBuf"
                 }
             },
@@ -5828,6 +5929,12 @@
                     "F_name_function": "callback_set_alloc",
                     "F_name_generic": "callback_set_alloc",
                     "F_name_impl": "callback_set_alloc",
+                    "f_arglist": [
+                        "f_var",
+                        "tc",
+                        "arr",
+                        "alloc"
+                    ],
                     "function_name": "callback_set_alloc"
                 }
             }

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -712,6 +712,12 @@
                             "F_name_function": "ctor",
                             "F_name_generic": "class1",
                             "F_name_impl": "class1_ctor",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         }
@@ -843,10 +849,16 @@
                             "F_name_function": "check_length_0",
                             "F_name_generic": "check_length",
                             "F_name_impl": "class1_check_length_0",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "check_length",
                             "function_suffix": "_0"
@@ -1036,6 +1048,10 @@
                         "zz_fmtdict": {
                             "C_name_api": "check_length",
                             "F_name_api": "check_length",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "length"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
@@ -1207,6 +1223,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "length"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "check_length",
                             "function_suffix": "_1_int"
@@ -1375,6 +1395,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "length"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "check_length",
                             "function_suffix": "_1_long"
@@ -1605,10 +1629,18 @@
                             "F_name_function": "declare_0",
                             "F_name_generic": "declare",
                             "F_name_impl": "class1_declare_0",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "flag"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "flag"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "declare",
                             "function_suffix": "_0"
@@ -1880,6 +1912,11 @@
                         "zz_fmtdict": {
                             "C_name_api": "declare",
                             "F_name_api": "declare",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "flag",
+                                "length"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
@@ -2103,6 +2140,11 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "flag",
+                                "length"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "declare",
                             "function_suffix": "_1_int"
@@ -2323,6 +2365,11 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "flag",
+                                "length"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "declare",
                             "function_suffix": "_1_long"
@@ -2428,6 +2475,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_length",
                             "function_name": "get_length",
@@ -3130,6 +3180,12 @@
                     "F_name_function": "default_ptr_is_null_0",
                     "F_name_generic": "default_ptr_is_null",
                     "F_name_impl": "default_ptr_is_null_0",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "defaultPtrIsNULL",
                     "function_suffix": "_0"
                 }
@@ -3418,6 +3474,14 @@
                     "F_name_impl": "default_ptr_is_null_1",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_defaultPtrIsNULL_1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "data"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "data"
+                    ],
                     "function_name": "defaultPtrIsNULL",
                     "function_suffix": "_1"
                 },
@@ -3796,6 +3860,18 @@
                     "F_name_function": "default_args_in_out_0",
                     "F_name_generic": "default_args_in_out",
                     "F_name_impl": "default_args_in_out_0",
+                    "c_arglist": [
+                        "c_var",
+                        "in1",
+                        "out1",
+                        "out2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "in1",
+                        "out1",
+                        "out2"
+                    ],
                     "function_name": "defaultArgsInOut",
                     "function_suffix": "_0"
                 }
@@ -4366,6 +4442,20 @@
                     "F_name_impl": "default_args_in_out_1",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_defaultArgsInOut_1",
+                    "c_arglist": [
+                        "c_var",
+                        "in1",
+                        "out1",
+                        "out2",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "in1",
+                        "out1",
+                        "out2",
+                        "flag"
+                    ],
                     "function_name": "defaultArgsInOut",
                     "function_suffix": "_1"
                 },
@@ -4579,6 +4669,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getGroupName",
                     "F_name_api": "get_group_name",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "idx"
+                    ],
                     "function_name": "getGroupName"
                 }
             },
@@ -4764,6 +4858,10 @@
                     "F_name_function": "get_group_name_int32_t",
                     "F_name_generic": "get_group_name",
                     "F_name_impl": "get_group_name_int32_t",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "idx"
+                    ],
                     "function_name": "getGroupName",
                     "function_suffix": "_int32_t"
                 }
@@ -4950,6 +5048,10 @@
                     "F_name_function": "get_group_name_int64_t",
                     "F_name_generic": "get_group_name",
                     "F_name_impl": "get_group_name_int64_t",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "idx"
+                    ],
                     "function_name": "getGroupName",
                     "function_suffix": "_int64_t"
                 }
@@ -5137,6 +5239,10 @@
                     "F_name_function": "nested_get_parent",
                     "F_name_generic": "nested_get_parent",
                     "F_name_impl": "nested_get_parent",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "parent",
                     "function_name": "nested_get_parent",
                     "struct_name": "nested",
@@ -5340,6 +5446,11 @@
                     "F_name_function": "nested_set_parent",
                     "F_name_generic": "nested_set_parent",
                     "F_name_impl": "nested_set_parent",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "parent",
                     "function_name": "nested_set_parent",
                     "struct_name": "nested",
@@ -5555,6 +5666,10 @@
                     "F_name_function": "nested_get_child",
                     "F_name_generic": "nested_get_child",
                     "F_name_impl": "nested_get_child",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "child",
                     "function_name": "nested_get_child",
                     "struct_name": "nested",
@@ -5769,6 +5884,11 @@
                     "F_name_function": "nested_set_child",
                     "F_name_generic": "nested_set_child",
                     "F_name_impl": "nested_set_child",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "child",
                     "function_name": "nested_set_child",
                     "struct_name": "nested",
@@ -5981,6 +6101,10 @@
                     "F_name_function": "nested_get_array",
                     "F_name_generic": "nested_get_array",
                     "F_name_impl": "nested_get_array",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "array",
                     "function_name": "nested_get_array",
                     "struct_name": "nested",
@@ -6192,6 +6316,11 @@
                     "F_name_function": "nested_set_array",
                     "F_name_generic": "nested_set_array",
                     "F_name_impl": "nested_set_array",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "array",
                     "function_name": "nested_set_array",
                     "struct_name": "nested",
@@ -6589,6 +6718,14 @@
                             "F_name_generic": "pass_struct_by_reference",
                             "F_name_impl": "pass_struct_by_reference",
                             "PY_name_impl": "PY_passStructByReference",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "arg"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv",
+                                "arg"
+                            ],
                             "function_name": "passStructByReference"
                         },
                         "zz_fmtlang": {
@@ -6879,6 +7016,14 @@
                             "F_name_generic": "pass_struct_by_reference_in",
                             "F_name_impl": "pass_struct_by_reference_in",
                             "PY_name_impl": "PY_passStructByReferenceIn",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "arg"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv",
+                                "arg"
+                            ],
                             "function_name": "passStructByReferenceIn"
                         },
                         "zz_fmtlang": {
@@ -7116,6 +7261,14 @@
                             "F_name_generic": "pass_struct_by_reference_inout",
                             "F_name_impl": "pass_struct_by_reference_inout",
                             "PY_name_impl": "PY_passStructByReferenceInout",
+                            "c_arglist": [
+                                "c_var",
+                                "arg"
+                            ],
+                            "f_arglist": [
+                                "f_var",
+                                "arg"
+                            ],
                             "function_name": "passStructByReferenceInout"
                         },
                         "zz_fmtlang": {
@@ -7352,6 +7505,14 @@
                             "F_name_generic": "pass_struct_by_reference_out",
                             "F_name_impl": "pass_struct_by_reference_out",
                             "PY_name_impl": "PY_passStructByReferenceOut",
+                            "c_arglist": [
+                                "c_var",
+                                "arg"
+                            ],
+                            "f_arglist": [
+                                "f_var",
+                                "arg"
+                            ],
                             "function_name": "passStructByReferenceOut"
                         },
                         "zz_fmtlang": {

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -190,6 +190,12 @@
                     "LUA_name_api": "NoReturnNoArguments",
                     "LUA_name_impl": "l_NoReturnNoArguments",
                     "PY_name_impl": "PY_NoReturnNoArguments",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "NoReturnNoArguments"
                 },
                 "zz_fmtlang": {
@@ -641,6 +647,16 @@
                     "LUA_name_api": "PassByValue",
                     "LUA_name_impl": "l_PassByValue",
                     "PY_name_impl": "PY_PassByValue",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "PassByValue"
                 },
                 "zz_fmtlang": {
@@ -1182,6 +1198,16 @@
                     "LUA_name_api": "ConcatenateStrings",
                     "LUA_name_impl": "l_ConcatenateStrings",
                     "PY_name_impl": "PY_ConcatenateStrings",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "ConcatenateStrings"
                 },
                 "zz_fmtlang": {
@@ -1338,6 +1364,12 @@
                     "F_name_function": "use_default_arguments",
                     "F_name_generic": "use_default_arguments",
                     "F_name_impl": "use_default_arguments",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "UseDefaultArguments",
                     "function_suffix": ""
                 }
@@ -1565,6 +1597,14 @@
                     "F_name_function": "use_default_arguments_arg1",
                     "F_name_generic": "use_default_arguments",
                     "F_name_impl": "use_default_arguments_arg1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "UseDefaultArguments",
                     "function_suffix": "_arg1"
                 }
@@ -2024,6 +2064,16 @@
                     "LUA_name_impl": "l_UseDefaultArguments",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_UseDefaultArguments_arg1_arg2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "UseDefaultArguments",
                     "function_suffix": "_arg1_arg2"
                 },
@@ -2325,6 +2375,14 @@
                     "LUA_name_api": "OverloadedFunction",
                     "LUA_name_impl": "l_OverloadedFunction",
                     "PY_name_impl": "PY_OverloadedFunction_from_name",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "OverloadedFunction",
                     "function_suffix": "_from_name"
                 },
@@ -2597,6 +2655,14 @@
                     "F_name_generic": "overloaded_function",
                     "F_name_impl": "overloaded_function_from_index",
                     "PY_name_impl": "PY_OverloadedFunction_from_index",
+                    "c_arglist": [
+                        "c_var",
+                        "indx"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "indx"
+                    ],
                     "function_name": "OverloadedFunction",
                     "function_suffix": "_from_index"
                 },
@@ -2983,6 +3049,14 @@
                     "LUA_name_api": "TemplateArgument",
                     "LUA_name_impl": "l_TemplateArgument",
                     "PY_name_impl": "PY_TemplateArgument_int",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "TemplateArgument",
                     "template_suffix": "_int"
                 },
@@ -3291,6 +3365,14 @@
                     "F_name_generic": "template_argument",
                     "F_name_impl": "template_argument_double",
                     "PY_name_impl": "PY_TemplateArgument_double",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "TemplateArgument",
                     "template_suffix": "_double"
                 },
@@ -3539,6 +3621,12 @@
                     "F_name_function": "template_return_int",
                     "F_name_generic": "template_return",
                     "F_name_impl": "template_return_int",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "TemplateReturn",
                     "template_suffix": "_int"
                 }
@@ -3704,6 +3792,12 @@
                     "F_name_function": "template_return_double",
                     "F_name_generic": "template_return",
                     "F_name_impl": "template_return_double",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "TemplateReturn",
                     "template_suffix": "_double"
                 }
@@ -3816,6 +3910,12 @@
                     "LUA_name_api": "FortranGenericOverloaded",
                     "LUA_name_impl": "l_FortranGenericOverloaded",
                     "PY_name_impl": "PY_FortranGenericOverloaded_0",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_0"
                 },
@@ -4199,6 +4299,11 @@
                     "C_name_api": "FortranGenericOverloaded",
                     "F_name_api": "fortran_generic_overloaded",
                     "PY_name_impl": "PY_FortranGenericOverloaded_1",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "arg2"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_1"
                 },
@@ -4419,6 +4524,11 @@
                     "F_name_function": "fortran_generic_overloaded_1_float",
                     "F_name_generic": "fortran_generic_overloaded",
                     "F_name_impl": "fortran_generic_overloaded_1_float",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "arg2"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_1_float"
                 }
@@ -4624,6 +4734,11 @@
                     "F_name_function": "fortran_generic_overloaded_1_double",
                     "F_name_generic": "fortran_generic_overloaded",
                     "F_name_impl": "fortran_generic_overloaded_1_double",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "arg2"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_1_double"
                 }
@@ -4848,6 +4963,14 @@
                     "F_name_function": "use_default_overload_num",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_num",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "num"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "num"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_num"
                 }
@@ -5161,6 +5284,16 @@
                     "F_name_function": "use_default_overload_num_offset",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_num_offset",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "num",
+                        "offset"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "num",
+                        "offset"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_num_offset"
                 }
@@ -5750,6 +5883,18 @@
                     "LUA_name_impl": "l_UseDefaultOverload",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_UseDefaultOverload_num_offset_stride",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_num_offset_stride"
                 },
@@ -6083,6 +6228,16 @@
                     "F_name_function": "use_default_overload_3",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_3",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "type",
+                        "num"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "type",
+                        "num"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_3"
                 }
@@ -6479,6 +6634,18 @@
                     "F_name_function": "use_default_overload_4",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_4",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "type",
+                        "num",
+                        "offset"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "type",
+                        "num",
+                        "offset"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_4"
                 }
@@ -7193,6 +7360,20 @@
                     "F_name_impl": "use_default_overload_5",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_UseDefaultOverload_5",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "type",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "type",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_5"
                 },
@@ -7514,6 +7695,14 @@
                     "LUA_name_api": "typefunc",
                     "LUA_name_impl": "l_typefunc",
                     "PY_name_impl": "PY_typefunc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "typefunc"
                 },
                 "zz_fmtlang": {
@@ -7874,6 +8063,14 @@
                     "LUA_name_api": "colorfunc",
                     "LUA_name_impl": "l_colorfunc",
                     "PY_name_impl": "PY_colorfunc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "colorfunc"
                 },
                 "zz_fmtlang": {
@@ -8254,6 +8451,16 @@
                     "F_name_generic": "get_min_max",
                     "F_name_impl": "get_min_max",
                     "PY_name_impl": "PY_getMinMax",
+                    "c_arglist": [
+                        "c_var",
+                        "min",
+                        "max"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "min",
+                        "max"
+                    ],
                     "function_name": "getMinMax"
                 },
                 "zz_fmtlang": {
@@ -8894,6 +9101,16 @@
                     "F_name_function": "callback1",
                     "F_name_generic": "callback1",
                     "F_name_impl": "callback1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in",
+                        "incr"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in",
+                        "incr"
+                    ],
                     "function_name": "callback1"
                 }
             },
@@ -9106,6 +9323,12 @@
                     "LUA_name_api": "LastFunctionCalled",
                     "LUA_name_impl": "l_LastFunctionCalled",
                     "PY_name_impl": "PY_LastFunctionCalled",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "LastFunctionCalled"
                 },
                 "zz_fmtlang": {

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -263,6 +263,14 @@
                             "F_name_function": "new_0",
                             "F_name_generic": "class1",
                             "F_name_impl": "class1_new_0",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "arg1"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv",
+                                "arg1"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "new",
                             "function_suffix": "_0"
@@ -619,6 +627,16 @@
                             "F_name_function": "new_1",
                             "F_name_generic": "class1",
                             "F_name_impl": "class1_new_1",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "arg1",
+                                "arg2"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv",
+                                "arg1",
+                                "arg2"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "new",
                             "function_suffix": "_1"
@@ -1076,6 +1094,18 @@
                             "F_name_function": "new_2",
                             "F_name_generic": "class1",
                             "F_name_impl": "class1_new_2",
+                            "c_arglist": [
+                                "SHC_rv",
+                                "arg1",
+                                "arg2",
+                                "arg3"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv",
+                                "arg1",
+                                "arg2",
+                                "arg3"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "new",
                             "function_suffix": "_2"
@@ -1165,10 +1195,16 @@
                             "F_name_function": "delete",
                             "F_name_generic": "delete",
                             "F_name_impl": "class1_delete",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "delete"
                         }
@@ -1352,10 +1388,18 @@
                             "F_name_function": "default_arguments_0",
                             "F_name_generic": "default_arguments",
                             "F_name_impl": "class1_default_arguments_0",
+                            "c_arglist": [
+                                "self",
+                                "arg1"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "arg1"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "DefaultArguments",
                             "function_suffix": "_0"
@@ -1629,10 +1673,20 @@
                             "F_name_function": "default_arguments_1",
                             "F_name_generic": "default_arguments",
                             "F_name_impl": "class1_default_arguments_1",
+                            "c_arglist": [
+                                "self",
+                                "arg1",
+                                "arg2"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "arg1",
+                                "arg2"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "DefaultArguments",
                             "function_suffix": "_1"
@@ -1999,10 +2053,22 @@
                             "F_name_function": "default_arguments_2",
                             "F_name_generic": "default_arguments",
                             "F_name_impl": "class1_default_arguments_2",
+                            "c_arglist": [
+                                "self",
+                                "arg1",
+                                "arg2",
+                                "arg3"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "arg1",
+                                "arg2",
+                                "arg3"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "DefaultArguments",
                             "function_suffix": "_2"
@@ -2108,6 +2174,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_field1",
                             "function_name": "get_field1",
@@ -2215,6 +2284,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_field2",
                             "function_name": "get_field2",
@@ -2322,6 +2394,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_field3",
                             "function_name": "get_field3",
@@ -2651,6 +2726,14 @@
                     "F_name_function": "apply_generic_nelems",
                     "F_name_generic": "apply_generic",
                     "F_name_impl": "apply_generic_nelems",
+                    "c_arglist": [
+                        "c_var",
+                        "num_elems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "num_elems"
+                    ],
                     "function_name": "apply_generic",
                     "function_suffix": "_nelems"
                 }
@@ -2927,6 +3010,16 @@
                     "F_name_function": "apply_generic_nelems_offset",
                     "F_name_generic": "apply_generic",
                     "F_name_impl": "apply_generic_nelems_offset",
+                    "c_arglist": [
+                        "c_var",
+                        "num_elems",
+                        "offset"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "num_elems",
+                        "offset"
+                    ],
                     "function_name": "apply_generic",
                     "function_suffix": "_nelems_offset"
                 }
@@ -3296,6 +3389,18 @@
                     "F_name_function": "apply_generic_nelems_offset_stride",
                     "F_name_generic": "apply_generic",
                     "F_name_impl": "apply_generic_nelems_offset_stride",
+                    "c_arglist": [
+                        "c_var",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "apply_generic",
                     "function_suffix": "_nelems_offset_stride"
                 }
@@ -3575,6 +3680,16 @@
                     "F_name_function": "apply_generic_type_nelems",
                     "F_name_generic": "apply_generic",
                     "F_name_impl": "apply_generic_type_nelems",
+                    "c_arglist": [
+                        "c_var",
+                        "type",
+                        "num_elems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "num_elems"
+                    ],
                     "function_name": "apply_generic",
                     "function_suffix": "_type_nelems"
                 }
@@ -3943,6 +4058,18 @@
                     "F_name_function": "apply_generic_type_nelems_offset",
                     "F_name_generic": "apply_generic",
                     "F_name_impl": "apply_generic_type_nelems_offset",
+                    "c_arglist": [
+                        "c_var",
+                        "type",
+                        "num_elems",
+                        "offset"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "num_elems",
+                        "offset"
+                    ],
                     "function_name": "apply_generic",
                     "function_suffix": "_type_nelems_offset"
                 }
@@ -4404,6 +4531,20 @@
                     "F_name_function": "apply_generic_type_nelems_offset_stride",
                     "F_name_generic": "apply_generic",
                     "F_name_impl": "apply_generic_type_nelems_offset_stride",
+                    "c_arglist": [
+                        "c_var",
+                        "type",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "apply_generic",
                     "function_suffix": "_type_nelems_offset_stride"
                 }
@@ -4763,6 +4904,18 @@
                     "F_name_function": "apply_require_0",
                     "F_name_generic": "apply_require",
                     "F_name_impl": "apply_require_0",
+                    "c_arglist": [
+                        "c_var",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "apply_require",
                     "function_suffix": "_0"
                 }
@@ -5214,6 +5367,20 @@
                     "F_name_function": "apply_require_1",
                     "F_name_generic": "apply_require",
                     "F_name_impl": "apply_require_1",
+                    "c_arglist": [
+                        "c_var",
+                        "type",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "apply_require",
                     "function_suffix": "_1"
                 }
@@ -5585,6 +5752,18 @@
                     "F_name_function": "apply_optional_0",
                     "F_name_generic": "apply_optional",
                     "F_name_impl": "apply_optional_0",
+                    "c_arglist": [
+                        "c_var",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "apply_optional",
                     "function_suffix": "_0"
                 }
@@ -6048,6 +6227,20 @@
                     "F_name_function": "apply_optional_1",
                     "F_name_generic": "apply_optional",
                     "F_name_impl": "apply_optional_1",
+                    "c_arglist": [
+                        "c_var",
+                        "type",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "num_elems",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "apply_optional",
                     "function_suffix": "_1"
                 }

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -415,6 +415,10 @@
                     "F_name_generic": "convert_to_int",
                     "F_name_impl": "convert_to_int",
                     "PY_name_impl": "PY_convert_to_int",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "convert_to_int"
                 },
                 "zz_fmtlang": {
@@ -636,6 +640,10 @@
                     "F_name_generic": "return_enum",
                     "F_name_impl": "return_enum",
                     "PY_name_impl": "PY_returnEnum",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "returnEnum"
                 },
                 "zz_fmtlang": {
@@ -785,6 +793,10 @@
                     "F_name_function": "return_enum_out_arg",
                     "F_name_generic": "return_enum_out_arg",
                     "F_name_impl": "return_enum_out_arg",
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "returnEnumOutArg"
                 }
             },
@@ -947,6 +959,10 @@
                     "F_name_function": "return_enum_in_out_arg",
                     "F_name_generic": "return_enum_in_out_arg",
                     "F_name_impl": "return_enum_in_out_arg",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "inout"
+                    ],
                     "function_name": "returnEnumInOutArg"
                 }
             }

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -503,6 +503,14 @@
                     "F_name_generic": "convert_to_int",
                     "F_name_impl": "convert_to_int",
                     "PY_name_impl": "PY_convert_to_int",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "convert_to_int"
                 },
                 "zz_fmtlang": {
@@ -813,6 +821,14 @@
                     "F_name_generic": "return_enum",
                     "F_name_impl": "return_enum",
                     "PY_name_impl": "PY_returnEnum",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "returnEnum"
                 },
                 "zz_fmtlang": {
@@ -1024,6 +1040,14 @@
                     "F_name_function": "return_enum_out_arg",
                     "F_name_generic": "return_enum_out_arg",
                     "F_name_impl": "return_enum_out_arg",
+                    "c_arglist": [
+                        "c_var",
+                        "out"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "returnEnumOutArg"
                 }
             },
@@ -1275,6 +1299,14 @@
                     "F_name_function": "return_enum_in_out_arg",
                     "F_name_generic": "return_enum_in_out_arg",
                     "F_name_impl": "return_enum_in_out_arg",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "inout"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "inout"
+                    ],
                     "function_name": "returnEnumInOutArg"
                 }
             }

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -3317,6 +3317,10 @@
                     "F_name_function": "struct1_get_arg2",
                     "F_name_generic": "struct1_get_arg2",
                     "F_name_impl": "struct1_get_arg2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "arg2",
                     "function_name": "struct1_get_arg2",
                     "struct_name": "struct1",
@@ -3527,6 +3531,11 @@
                     "F_name_function": "struct1_set_arg2",
                     "F_name_generic": "struct1_set_arg2",
                     "F_name_impl": "struct1_set_arg2",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "arg2",
                     "function_name": "struct1_set_arg2",
                     "struct_name": "struct1",

--- a/regression/reference/error/error.json
+++ b/regression/reference/error/error.json
@@ -109,6 +109,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "get_x1",
@@ -254,6 +257,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "set_x1",
@@ -361,6 +368,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "get_y1",
@@ -506,6 +516,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "set_y1",
@@ -613,6 +627,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "z1",
                             "function_name": "get_z1",
@@ -758,6 +775,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "z1",
                             "function_name": "set_z1",
@@ -1030,6 +1051,12 @@
                     "F_name_generic": "bad_fstatements",
                     "F_name_impl": "bad_fstatements",
                     "PY_name_impl": "PY_BadFstatements",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "BadFstatements"
                 },
                 "zz_fmtlang": {
@@ -1271,6 +1298,10 @@
                     "C_name_api": "AssumedRank",
                     "F_name_api": "assumed_rank",
                     "PY_name_impl": "PY_AssumedRank",
+                    "c_arglist": [
+                        "c_var",
+                        "data"
+                    ],
                     "function_name": "AssumedRank"
                 },
                 "zz_fmtlang": {
@@ -1428,6 +1459,10 @@
                     "F_name_function": "assumed_rank_0d",
                     "F_name_generic": "assumed_rank",
                     "F_name_impl": "assumed_rank_0d",
+                    "f_arglist": [
+                        "f_var",
+                        "data"
+                    ],
                     "function_name": "AssumedRank",
                     "function_suffix": "_0d"
                 }
@@ -1573,6 +1608,10 @@
                     "F_name_function": "assumed_rank_1d",
                     "F_name_generic": "assumed_rank",
                     "F_name_impl": "assumed_rank_1d",
+                    "f_arglist": [
+                        "f_var",
+                        "data"
+                    ],
                     "function_name": "AssumedRank",
                     "function_suffix": "_1d"
                 }
@@ -1718,6 +1757,10 @@
                     "F_name_function": "assumed_rank_2d",
                     "F_name_generic": "assumed_rank",
                     "F_name_impl": "assumed_rank_2d",
+                    "f_arglist": [
+                        "f_var",
+                        "data"
+                    ],
                     "function_name": "AssumedRank",
                     "function_suffix": "_2d"
                 }

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -227,6 +227,12 @@
                                             "PY_name_impl": "PP_ExClass1_tp_init_0",
                                             "PY_type_impl": "PP_ExClass1_tp_init_0",
                                             "PY_type_method": "tp_init",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "ctor",
                                             "function_suffix": "_0"
@@ -611,6 +617,14 @@
                                             "PY_name_impl": "PP_ExClass1_tp_init_1",
                                             "PY_type_impl": "PP_ExClass1_tp_init_1",
                                             "PY_type_method": "tp_init",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "name"
+                                            ],
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "name"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "ctor",
                                             "function_suffix": "_1"
@@ -745,10 +759,16 @@
                                             "LUA_name": "dtor",
                                             "LUA_name_api": "dtor",
                                             "LUA_name_impl": "l_example_nested_ExClass1_dtor",
+                                            "c_arglist": [
+                                                "self"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "dtor"
                                         },
@@ -1068,10 +1088,18 @@
                                             "LUA_name_api": "incrementCount",
                                             "LUA_name_impl": "l_example_nested_ExClass1_incrementCount",
                                             "PY_name_impl": "PP_incrementCount",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "incr"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "incr"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "incrementCount"
                                         },
@@ -1316,10 +1344,16 @@
                                             "LUA_name_api": "getNameErrorCheck",
                                             "LUA_name_impl": "l_example_nested_ExClass1_getNameErrorCheck",
                                             "PY_name_impl": "PP_getNameErrorCheck",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "const ",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(IN)",
                                             "function_name": "getNameErrorCheck"
                                         },
@@ -1546,10 +1580,16 @@
                                             "LUA_name_api": "getNameArg",
                                             "LUA_name_impl": "l_example_nested_ExClass1_getNameArg",
                                             "PY_name_impl": "PP_getNameArg",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "const ",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "name"
+                                            ],
                                             "f_intent_attr": ", intent(IN)",
                                             "function_name": "getNameArg"
                                         },
@@ -1879,10 +1919,18 @@
                                             "LUA_name_api": "getValue",
                                             "LUA_name_impl": "l_example_nested_ExClass1_getValue",
                                             "PY_name_impl": "PP_getValue_from_int",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "value"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "value"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "getValue",
                                             "function_suffix": "_from_int"
@@ -2215,10 +2263,18 @@
                                             "F_name_generic": "get_value",
                                             "F_name_impl": "ex_class1_get_value_1",
                                             "PY_name_impl": "PP_getValue_1",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "value"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "value"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "getValue",
                                             "function_suffix": "_1"
@@ -2542,10 +2598,18 @@
                                             "LUA_name_api": "hasAddr",
                                             "LUA_name_impl": "l_example_nested_ExClass1_hasAddr",
                                             "PY_name_impl": "PP_hasAddr",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "in"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "in"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "hasAddr"
                                         },
@@ -2684,10 +2748,16 @@
                                             "LUA_name_api": "SplicerSpecial",
                                             "LUA_name_impl": "l_example_nested_ExClass1_SplicerSpecial",
                                             "PY_name_impl": "PP_SplicerSpecial",
+                                            "c_arglist": [
+                                                "self"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "SplicerSpecial"
                                         },
@@ -3163,6 +3233,14 @@
                                             "PY_name_impl": "PP_ExClass2_tp_init",
                                             "PY_type_impl": "PP_ExClass2_tp_init",
                                             "PY_type_method": "tp_init",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "name"
+                                            ],
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "name"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "ctor"
                                         },
@@ -3302,10 +3380,16 @@
                                             "LUA_name": "dtor",
                                             "LUA_name_api": "dtor",
                                             "LUA_name_impl": "l_example_nested_ExClass2_dtor",
+                                            "c_arglist": [
+                                                "self"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "dtor"
                                         },
@@ -3535,10 +3619,16 @@
                                             "LUA_name_api": "getName",
                                             "LUA_name_impl": "l_example_nested_ExClass2_getName",
                                             "PY_name_impl": "PP_getName",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "const ",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(IN)",
                                             "function_name": "getName"
                                         },
@@ -3776,10 +3866,16 @@
                                             "LUA_name_api": "getName2",
                                             "LUA_name_impl": "l_example_nested_ExClass2_getName2",
                                             "PY_name_impl": "PP_getName2",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "getName2"
                                         },
@@ -4018,10 +4114,16 @@
                                             "LUA_name_api": "getName3",
                                             "LUA_name_impl": "l_example_nested_ExClass2_getName3",
                                             "PY_name_impl": "PP_getName3",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "const ",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(IN)",
                                             "function_name": "getName3"
                                         },
@@ -4258,10 +4360,16 @@
                                             "LUA_name_api": "getName4",
                                             "LUA_name_impl": "l_example_nested_ExClass2_getName4",
                                             "PY_name_impl": "PP_getName4",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "getName4"
                                         },
@@ -4461,10 +4569,16 @@
                                             "LUA_name_api": "GetNameLength",
                                             "LUA_name_impl": "l_example_nested_ExClass2_GetNameLength",
                                             "PY_name_impl": "PP_GetNameLength",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "const ",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(IN)",
                                             "function_name": "GetNameLength"
                                         },
@@ -4847,10 +4961,18 @@
                                             "LUA_name_api": "get_class1",
                                             "LUA_name_impl": "l_example_nested_ExClass2_get_class1",
                                             "PY_name_impl": "PP_get_class1",
+                                            "c_arglist": [
+                                                "SHC_rv",
+                                                "in"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv",
+                                                "in"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "get_class1"
                                         },
@@ -4989,10 +5111,16 @@
                                             "LUA_name_api": "destroyall",
                                             "LUA_name_impl": "l_example_nested_ExClass2_destroyall",
                                             "PY_name_impl": "PP_destroyall",
+                                            "c_arglist": [
+                                                "self"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "destroyall"
                                         },
@@ -5427,10 +5555,18 @@
                                             "LUA_name_api": "setValue",
                                             "LUA_name_impl": "l_example_nested_ExClass2_setValue",
                                             "PY_name_impl": "PP_setValue_int",
+                                            "c_arglist": [
+                                                "self",
+                                                "value"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var",
+                                                "value"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "setValue",
                                             "template_suffix": "_int"
@@ -5760,10 +5896,18 @@
                                             "F_name_generic": "set_value",
                                             "F_name_impl": "ex_class2_set_value_long",
                                             "PY_name_impl": "PP_setValue_long",
+                                            "c_arglist": [
+                                                "self",
+                                                "value"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var",
+                                                "value"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "setValue",
                                             "template_suffix": "_long"
@@ -6084,10 +6228,18 @@
                                             "F_name_generic": "set_value",
                                             "F_name_impl": "ex_class2_set_value_float",
                                             "PY_name_impl": "PP_setValue_float",
+                                            "c_arglist": [
+                                                "self",
+                                                "value"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var",
+                                                "value"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "setValue",
                                             "template_suffix": "_float"
@@ -6414,10 +6566,18 @@
                                             "F_name_generic": "set_value",
                                             "F_name_impl": "ex_class2_set_value_double",
                                             "PY_name_impl": "PP_setValue_double",
+                                            "c_arglist": [
+                                                "self",
+                                                "value"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "f_var",
+                                                "value"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "setValue",
                                             "template_suffix": "_double"
@@ -6711,10 +6871,16 @@
                                             "LUA_name_api": "getValue",
                                             "LUA_name_impl": "l_example_nested_ExClass2_getValue",
                                             "PY_name_impl": "PP_getValue_int",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "getValue",
                                             "template_suffix": "_int"
@@ -6944,10 +7110,16 @@
                                             "F_name_generic": "get_value",
                                             "F_name_impl": "ex_class2_get_value_double",
                                             "PY_name_impl": "PP_getValue_double",
+                                            "c_arglist": [
+                                                "SHC_rv"
+                                            ],
                                             "c_const": "",
                                             "c_deref": "*",
                                             "c_member": "->",
                                             "c_var": "self",
+                                            "f_arglist": [
+                                                "SHT_rv"
+                                            ],
                                             "f_intent_attr": ", intent(INOUT)",
                                             "function_name": "getValue",
                                             "template_suffix": "_double"
@@ -7140,6 +7312,12 @@
                                     "LUA_name_api": "local_function1",
                                     "LUA_name_impl": "l_example_nested_local_function1",
                                     "PY_name_impl": "PP_local_function1",
+                                    "c_arglist": [
+                                        "c_var"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "function_name": "local_function1"
                                 },
                                 "zz_fmtlang": {
@@ -7501,6 +7679,14 @@
                                     "LUA_name_api": "isNameValid",
                                     "LUA_name_impl": "l_example_nested_isNameValid",
                                     "PY_name_impl": "PP_isNameValid",
+                                    "c_arglist": [
+                                        "SHC_rv",
+                                        "name"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv",
+                                        "name"
+                                    ],
                                     "function_name": "isNameValid"
                                 },
                                 "zz_fmtlang": {
@@ -7691,6 +7877,12 @@
                                     "LUA_name_api": "isInitialized",
                                     "LUA_name_impl": "l_example_nested_isInitialized",
                                     "PY_name_impl": "PP_isInitialized",
+                                    "c_arglist": [
+                                        "SHC_rv"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv"
+                                    ],
                                     "function_name": "isInitialized"
                                 },
                                 "zz_fmtlang": {
@@ -7985,6 +8177,14 @@
                                     "LUA_name_api": "test_names",
                                     "LUA_name_impl": "l_example_nested_test_names",
                                     "PY_name_impl": "PP_test_names",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "name"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "name"
+                                    ],
                                     "function_name": "test_names",
                                     "function_suffix": ""
                                 },
@@ -8422,6 +8622,16 @@
                                     "F_name_generic": "test_names",
                                     "F_name_impl": "test_names_flag",
                                     "PY_name_impl": "PP_test_names_flag",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "name",
+                                        "flag"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "name",
+                                        "flag"
+                                    ],
                                     "function_name": "test_names",
                                     "function_suffix": "_flag"
                                 },
@@ -8525,6 +8735,12 @@
                                     "F_name_function": "testoptional_0",
                                     "F_name_generic": "testoptional",
                                     "F_name_impl": "testoptional_0",
+                                    "c_arglist": [
+                                        "c_var"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "function_name": "testoptional",
                                     "function_suffix": "_0"
                                 }
@@ -8706,6 +8922,14 @@
                                     "F_name_function": "testoptional_1",
                                     "F_name_generic": "testoptional",
                                     "F_name_impl": "testoptional_1",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "i"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "i"
+                                    ],
                                     "function_name": "testoptional",
                                     "function_suffix": "_1"
                                 }
@@ -9100,6 +9324,16 @@
                                     "LUA_name_impl": "l_example_nested_testoptional",
                                     "PY_cleanup_decref": "Py_XDECREF",
                                     "PY_name_impl": "PP_testoptional_2",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "i",
+                                        "j"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "i",
+                                        "j"
+                                    ],
                                     "function_name": "testoptional",
                                     "function_suffix": "_2"
                                 },
@@ -9290,6 +9524,12 @@
                                     "LUA_name_api": "test_size_t",
                                     "LUA_name_impl": "l_example_nested_test_size_t",
                                     "PY_name_impl": "PP_test_size_t",
+                                    "c_arglist": [
+                                        "SHC_rv"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv"
+                                    ],
                                     "function_name": "test_size_t"
                                 },
                                 "zz_fmtlang": {
@@ -9568,6 +9808,14 @@
                                     "LUA_name_api": "testmpi",
                                     "LUA_name_impl": "l_example_nested_testmpi",
                                     "PY_name_impl": "PP_testmpi_mpi",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "comm"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "comm"
+                                    ],
                                     "function_name": "testmpi",
                                     "function_suffix": "_mpi"
                                 },
@@ -9703,6 +9951,12 @@
                                     "F_name_generic": "testmpi",
                                     "F_name_impl": "testmpi_serial",
                                     "PY_name_impl": "PP_testmpi_serial",
+                                    "c_arglist": [
+                                        "c_var"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "function_name": "testmpi",
                                     "function_suffix": "_serial"
                                 },
@@ -10225,6 +10479,14 @@
                                     "LUA_name_api": "FuncPtr1",
                                     "LUA_name_impl": "l_example_nested_FuncPtr1",
                                     "PY_name_impl": "PP_FuncPtr1",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "get"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "get"
+                                    ],
                                     "function_name": "FuncPtr1"
                                 },
                                 "zz_fmtlang": {
@@ -10844,6 +11106,14 @@
                                     "LUA_name_api": "FuncPtr2",
                                     "LUA_name_impl": "l_example_nested_FuncPtr2",
                                     "PY_name_impl": "PP_FuncPtr2",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "get"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "get"
+                                    ],
                                     "function_name": "FuncPtr2"
                                 },
                                 "zz_fmtlang": {
@@ -11856,6 +12126,14 @@
                                     "LUA_name_api": "FuncPtr3",
                                     "LUA_name_impl": "l_example_nested_FuncPtr3",
                                     "PY_name_impl": "PP_FuncPtr3",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "get"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "get"
+                                    ],
                                     "function_name": "FuncPtr3"
                                 },
                                 "zz_fmtlang": {
@@ -12504,6 +12782,14 @@
                                     "F_name_function": "func_ptr4",
                                     "F_name_generic": "func_ptr4",
                                     "F_name_impl": "func_ptr4",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "get"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "get"
+                                    ],
                                     "function_name": "FuncPtr4"
                                 }
                             },
@@ -15118,6 +15404,14 @@
                                     "LUA_name_api": "FuncPtr5",
                                     "LUA_name_impl": "l_example_nested_FuncPtr5",
                                     "PY_name_impl": "PP_FuncPtr5",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "get"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "get"
+                                    ],
                                     "function_name": "FuncPtr5"
                                 },
                                 "zz_fmtlang": {
@@ -16603,6 +16897,32 @@
                                     "LUA_name_api": "verylongfunctionname1",
                                     "LUA_name_impl": "l_example_nested_verylongfunctionname1",
                                     "PY_name_impl": "PP_verylongfunctionname1",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "verylongname1",
+                                        "verylongname2",
+                                        "verylongname3",
+                                        "verylongname4",
+                                        "verylongname5",
+                                        "verylongname6",
+                                        "verylongname7",
+                                        "verylongname8",
+                                        "verylongname9",
+                                        "verylongname10"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "verylongname1",
+                                        "verylongname2",
+                                        "verylongname3",
+                                        "verylongname4",
+                                        "verylongname5",
+                                        "verylongname6",
+                                        "verylongname7",
+                                        "verylongname8",
+                                        "verylongname9",
+                                        "verylongname10"
+                                    ],
                                     "function_name": "verylongfunctionname1"
                                 },
                                 "zz_fmtlang": {
@@ -18130,6 +18450,32 @@
                                     "LUA_name_api": "verylongfunctionname2",
                                     "LUA_name_impl": "l_example_nested_verylongfunctionname2",
                                     "PY_name_impl": "PP_verylongfunctionname2",
+                                    "c_arglist": [
+                                        "SHC_rv",
+                                        "verylongname1",
+                                        "verylongname2",
+                                        "verylongname3",
+                                        "verylongname4",
+                                        "verylongname5",
+                                        "verylongname6",
+                                        "verylongname7",
+                                        "verylongname8",
+                                        "verylongname9",
+                                        "verylongname10"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv",
+                                        "verylongname1",
+                                        "verylongname2",
+                                        "verylongname3",
+                                        "verylongname4",
+                                        "verylongname5",
+                                        "verylongname6",
+                                        "verylongname7",
+                                        "verylongname8",
+                                        "verylongname9",
+                                        "verylongname10"
+                                    ],
                                     "function_name": "verylongfunctionname2"
                                 },
                                 "zz_fmtlang": {
@@ -18761,6 +19107,18 @@
                                     "LUA_name_api": "cos_doubles",
                                     "LUA_name_impl": "l_example_nested_cos_doubles",
                                     "PY_name_impl": "PP_cos_doubles",
+                                    "c_arglist": [
+                                        "c_var",
+                                        "in",
+                                        "out",
+                                        "sizein"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var",
+                                        "in",
+                                        "out",
+                                        "sizein"
+                                    ],
                                     "function_name": "cos_doubles"
                                 },
                                 "zz_fmtlang": {

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -260,6 +260,12 @@
                             "PY_name_impl": "PY_Class2_tp_init",
                             "PY_type_impl": "PY_Class2_tp_init",
                             "PY_type_method": "tp_init",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         },
@@ -388,10 +394,16 @@
                             "LUA_name": "dtor",
                             "LUA_name_api": "dtor",
                             "LUA_name_impl": "l_Class2_dtor",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "dtor"
                         },
@@ -664,10 +676,18 @@
                             "LUA_name_api": "func1",
                             "LUA_name_impl": "l_Class2_func1",
                             "PY_name_impl": "PY_func1",
+                            "c_arglist": [
+                                "self",
+                                "arg"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "arg"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "func1"
                         },
@@ -950,10 +970,18 @@
                             "LUA_name_api": "acceptClass3",
                             "LUA_name_impl": "l_Class2_acceptClass3",
                             "PY_name_impl": "PY_acceptClass3",
+                            "c_arglist": [
+                                "self",
+                                "arg"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "arg"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "acceptClass3"
                         },
@@ -1253,6 +1281,14 @@
                     "F_name_function": "pass_struct1",
                     "F_name_generic": "pass_struct1",
                     "F_name_impl": "pass_struct1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "passStruct1"
                 }
             }

--- a/regression/reference/funptr-c/funptr.json
+++ b/regression/reference/funptr-c/funptr.json
@@ -240,6 +240,10 @@
                     "F_name_function": "callback1",
                     "F_name_generic": "callback1",
                     "F_name_impl": "callback1",
+                    "f_arglist": [
+                        "f_var",
+                        "incr1"
+                    ],
                     "function_name": "callback1"
                 }
             },
@@ -473,6 +477,10 @@
                     "F_name_function": "callback1_wrap",
                     "F_name_generic": "callback1_wrap",
                     "F_name_impl": "callback1_wrap",
+                    "f_arglist": [
+                        "f_var",
+                        "incr1_wrap"
+                    ],
                     "function_name": "callback1_wrap"
                 }
             },
@@ -713,6 +721,10 @@
                     "F_name_function": "callback1_external",
                     "F_name_generic": "callback1_external",
                     "F_name_impl": "callback1_external",
+                    "f_arglist": [
+                        "f_var",
+                        "incr1_external"
+                    ],
                     "function_name": "callback1_external"
                 }
             },
@@ -955,6 +967,10 @@
                     "F_name_function": "callback1_funptr",
                     "F_name_generic": "callback1_funptr",
                     "F_name_impl": "callback1_funptr",
+                    "f_arglist": [
+                        "f_var",
+                        "incr1_funptr"
+                    ],
                     "function_name": "callback1_funptr"
                 }
             },
@@ -1198,6 +1214,12 @@
                     "F_name_function": "callback2",
                     "F_name_generic": "callback2",
                     "F_name_impl": "callback2",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
                     "function_name": "callback2"
                 }
             },
@@ -1445,6 +1467,12 @@
                     "F_name_function": "callback2_external",
                     "F_name_generic": "callback2_external",
                     "F_name_impl": "callback2_external",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
                     "function_name": "callback2_external"
                 }
             },
@@ -1693,6 +1721,12 @@
                     "F_name_function": "callback2_funptr",
                     "F_name_generic": "callback2_funptr",
                     "F_name_impl": "callback2_funptr",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
                     "function_name": "callback2_funptr"
                 }
             },
@@ -2054,6 +2088,12 @@
                     "F_name_function": "callback3",
                     "F_name_generic": "callback3",
                     "F_name_impl": "callback3",
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "in",
+                        "incr3"
+                    ],
                     "function_name": "callback3"
                 }
             },
@@ -2700,6 +2740,12 @@
                     "F_name_function": "callback4",
                     "F_name_generic": "callback4",
                     "F_name_impl": "callback4",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "ilow",
+                        "nargs",
+                        "actor"
+                    ],
                     "function_name": "callback4"
                 }
             },
@@ -2969,6 +3015,10 @@
                     "F_name_function": "callback_ptr",
                     "F_name_generic": "callback_ptr",
                     "F_name_impl": "callback_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "get_ptr"
+                    ],
                     "function_name": "callback_ptr"
                 }
             },
@@ -3406,6 +3456,10 @@
                     "F_name_function": "callback_double",
                     "F_name_generic": "callback_double",
                     "F_name_impl": "callback_double",
+                    "f_arglist": [
+                        "f_var",
+                        "get"
+                    ],
                     "function_name": "callback_double"
                 }
             },
@@ -3924,6 +3978,11 @@
                     "F_name_function": "abstract1",
                     "F_name_generic": "abstract1",
                     "F_name_impl": "abstract1",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "input",
+                        "get_abs"
+                    ],
                     "function_name": "abstract1"
                 }
             },
@@ -4259,6 +4318,10 @@
                     "F_name_function": "callback_void_ptr",
                     "F_name_generic": "callback_void_ptr",
                     "F_name_impl": "callback_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "void_ptr_arg"
+                    ],
                     "function_name": "callback_void_ptr"
                 }
             },
@@ -5052,6 +5115,10 @@
                     "F_name_function": "callback_all_types",
                     "F_name_generic": "callback_all_types",
                     "F_name_impl": "callback_all_types",
+                    "f_arglist": [
+                        "f_var",
+                        "all_types"
+                    ],
                     "function_name": "callback_all_types"
                 }
             }

--- a/regression/reference/funptr-cxx/funptr.json
+++ b/regression/reference/funptr-cxx/funptr.json
@@ -341,6 +341,14 @@
                     "F_name_function": "callback1",
                     "F_name_generic": "callback1",
                     "F_name_impl": "callback1",
+                    "c_arglist": [
+                        "c_var",
+                        "incr1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "incr1"
+                    ],
                     "function_name": "callback1"
                 }
             },
@@ -675,6 +683,14 @@
                     "F_name_function": "callback1_wrap",
                     "F_name_generic": "callback1_wrap",
                     "F_name_impl": "callback1_wrap",
+                    "c_arglist": [
+                        "c_var",
+                        "incr1_wrap"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "incr1_wrap"
+                    ],
                     "function_name": "callback1_wrap"
                 }
             },
@@ -1020,6 +1036,14 @@
                     "F_name_function": "callback1_external",
                     "F_name_generic": "callback1_external",
                     "F_name_impl": "callback1_external",
+                    "c_arglist": [
+                        "c_var",
+                        "incr1_external"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "incr1_external"
+                    ],
                     "function_name": "callback1_external"
                 }
             },
@@ -1367,6 +1391,14 @@
                     "F_name_function": "callback1_funptr",
                     "F_name_generic": "callback1_funptr",
                     "F_name_impl": "callback1_funptr",
+                    "c_arglist": [
+                        "c_var",
+                        "incr1_funptr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "incr1_funptr"
+                    ],
                     "function_name": "callback1_funptr"
                 }
             },
@@ -1721,6 +1753,18 @@
                     "F_name_function": "callback2",
                     "F_name_generic": "callback2",
                     "F_name_impl": "callback2",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
                     "function_name": "callback2"
                 }
             },
@@ -2080,6 +2124,18 @@
                     "F_name_function": "callback2_external",
                     "F_name_generic": "callback2_external",
                     "F_name_impl": "callback2_external",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
                     "function_name": "callback2_external"
                 }
             },
@@ -2440,6 +2496,18 @@
                     "F_name_function": "callback2_funptr",
                     "F_name_generic": "callback2_funptr",
                     "F_name_impl": "callback2_funptr",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "ival",
+                        "incr"
+                    ],
                     "function_name": "callback2_funptr"
                 }
             },
@@ -2967,6 +3035,18 @@
                     "F_name_function": "callback3",
                     "F_name_generic": "callback3",
                     "F_name_impl": "callback3",
+                    "c_arglist": [
+                        "c_var",
+                        "type",
+                        "in",
+                        "incr3"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "type",
+                        "in",
+                        "incr3"
+                    ],
                     "function_name": "callback3"
                 }
             },
@@ -3901,6 +3981,18 @@
                     "F_name_function": "callback4",
                     "F_name_generic": "callback4",
                     "F_name_impl": "callback4",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "ilow",
+                        "nargs",
+                        "actor"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "ilow",
+                        "nargs",
+                        "actor"
+                    ],
                     "function_name": "callback4"
                 }
             },
@@ -4287,6 +4379,14 @@
                     "F_name_function": "callback_ptr",
                     "F_name_generic": "callback_ptr",
                     "F_name_impl": "callback_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "get_ptr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "get_ptr"
+                    ],
                     "function_name": "callback_ptr"
                 }
             },
@@ -4917,6 +5017,14 @@
                     "F_name_function": "callback_double",
                     "F_name_generic": "callback_double",
                     "F_name_impl": "callback_double",
+                    "c_arglist": [
+                        "c_var",
+                        "get"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "get"
+                    ],
                     "function_name": "callback_double"
                 }
             },
@@ -5671,6 +5779,16 @@
                     "F_name_function": "abstract1",
                     "F_name_generic": "abstract1",
                     "F_name_impl": "abstract1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "input",
+                        "get_abs"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "input",
+                        "get_abs"
+                    ],
                     "function_name": "abstract1"
                 }
             },
@@ -6152,6 +6270,14 @@
                     "F_name_function": "callback_void_ptr",
                     "F_name_generic": "callback_void_ptr",
                     "F_name_impl": "callback_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "void_ptr_arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "void_ptr_arg"
+                    ],
                     "function_name": "callback_void_ptr"
                 }
             },
@@ -7291,6 +7417,14 @@
                     "F_name_function": "callback_all_types",
                     "F_name_generic": "callback_all_types",
                     "F_name_impl": "callback_all_types",
+                    "c_arglist": [
+                        "c_var",
+                        "all_types"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "all_types"
+                    ],
                     "function_name": "callback_all_types"
                 }
             }

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -178,6 +178,10 @@
                     "F_name_function": "update_as_float",
                     "F_name_generic": "update_real",
                     "F_name_impl": "update_as_float",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "UpdateAsFloat"
                 }
             },
@@ -305,6 +309,10 @@
                     "F_name_function": "update_as_double",
                     "F_name_generic": "update_real",
                     "F_name_impl": "update_as_double",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "UpdateAsDouble"
                 }
             },
@@ -393,6 +401,9 @@
                     "F_name_function": "get_global_double",
                     "F_name_generic": "get_global_double",
                     "F_name_impl": "get_global_double",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "GetGlobalDouble"
                 }
             },
@@ -547,6 +558,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "GenericReal",
                     "F_name_api": "generic_real",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "GenericReal"
                 }
             },
@@ -678,6 +693,10 @@
                     "F_name_function": "generic_real_float",
                     "F_name_generic": "generic_real",
                     "F_name_impl": "generic_real_float",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "GenericReal",
                     "function_suffix": "_float"
                 }
@@ -810,6 +829,10 @@
                     "F_name_function": "generic_real_double",
                     "F_name_generic": "generic_real",
                     "F_name_impl": "generic_real_double",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "GenericReal",
                     "function_suffix": "_double"
                 }
@@ -1064,6 +1087,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "GenericReal2",
                     "F_name_api": "generic_real2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "GenericReal2"
                 }
             },
@@ -1274,6 +1302,11 @@
                     "F_name_function": "generic_real2_all_int",
                     "F_name_generic": "generic_real2",
                     "F_name_impl": "generic_real2_all_int",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "GenericReal2",
                     "function_suffix": "_all_int"
                 }
@@ -1485,6 +1518,11 @@
                     "F_name_function": "generic_real2_all_long",
                     "F_name_generic": "generic_real2",
                     "F_name_impl": "generic_real2_all_long",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "GenericReal2",
                     "function_suffix": "_all_long"
                 }
@@ -1721,6 +1759,11 @@
                     "F_name_function": "sum_values",
                     "F_name_generic": "sum_values",
                     "F_name_impl": "sum_values",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "values",
+                        "nvalues"
+                    ],
                     "function_name": "SumValues"
                 }
             },
@@ -2329,6 +2372,13 @@
                     "F_name_function": "assign_values_scalar",
                     "F_name_generic": "assign_values",
                     "F_name_impl": "assign_values_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "from",
+                        "nfrom",
+                        "to",
+                        "nto"
+                    ],
                     "function_name": "AssignValues",
                     "function_suffix": "_scalar"
                 }
@@ -2655,6 +2705,13 @@
                     "F_name_function": "assign_values_broadcast",
                     "F_name_generic": "assign_values",
                     "F_name_impl": "assign_values_broadcast",
+                    "f_arglist": [
+                        "f_var",
+                        "from",
+                        "nfrom",
+                        "to",
+                        "nto"
+                    ],
                     "function_name": "AssignValues",
                     "function_suffix": "_broadcast"
                 }
@@ -2996,6 +3053,13 @@
                     "F_name_function": "assign_values_copy",
                     "F_name_generic": "assign_values",
                     "F_name_impl": "assign_values_copy",
+                    "f_arglist": [
+                        "f_var",
+                        "from",
+                        "nfrom",
+                        "to",
+                        "nto"
+                    ],
                     "function_name": "AssignValues",
                     "function_suffix": "_copy"
                 }
@@ -3467,6 +3531,12 @@
                     "F_name_function": "save_pointer_float1d",
                     "F_name_generic": "save_pointer",
                     "F_name_impl": "save_pointer_float1d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer",
                     "function_suffix": "_float1d"
                 }
@@ -3739,6 +3809,12 @@
                     "F_name_function": "save_pointer_float2d",
                     "F_name_generic": "save_pointer",
                     "F_name_impl": "save_pointer_float2d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer",
                     "function_suffix": "_float2d"
                 }
@@ -4268,6 +4344,12 @@
                     "F_name_function": "save_pointer2_float1d",
                     "F_name_generic": "save_pointer2",
                     "F_name_impl": "save_pointer2_float1d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer2",
                     "function_suffix": "_float1d"
                 }
@@ -4568,6 +4650,12 @@
                     "F_name_function": "save_pointer2_float2d",
                     "F_name_generic": "save_pointer2",
                     "F_name_impl": "save_pointer2_float2d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer2",
                     "function_suffix": "_float2d"
                 }
@@ -4823,6 +4911,12 @@
                     "F_name_function": "get_pointer",
                     "F_name_generic": "get_pointer",
                     "F_name_impl": "get_pointer",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "GetPointer"
                 }
             },
@@ -5365,6 +5459,12 @@
                     "F_name_function": "get_pointer_as_pointer_float1d",
                     "F_name_generic": "get_pointer_as_pointer",
                     "F_name_impl": "get_pointer_as_pointer_float1d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "GetPointerAsPointer",
                     "function_suffix": "_float1d"
                 }
@@ -5659,6 +5759,12 @@
                     "F_name_function": "get_pointer_as_pointer_float2d",
                     "F_name_generic": "get_pointer_as_pointer",
                     "F_name_impl": "get_pointer_as_pointer_float2d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "GetPointerAsPointer",
                     "function_suffix": "_float2d"
                 }
@@ -5763,6 +5869,9 @@
                     "F_name_function": "create_struct_as_class",
                     "F_name_generic": "create_struct_as_class",
                     "F_name_impl": "create_struct_as_class",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "CreateStructAsClass"
                 }
             },
@@ -6121,6 +6230,11 @@
                     "F_name_function": "update_struct_as_class_int",
                     "F_name_generic": "update_struct_as_class",
                     "F_name_impl": "update_struct_as_class_int",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg",
+                        "inew"
+                    ],
                     "function_name": "UpdateStructAsClass",
                     "function_suffix": "_int"
                 }
@@ -6342,6 +6456,11 @@
                     "F_name_function": "update_struct_as_class_long",
                     "F_name_generic": "update_struct_as_class",
                     "F_name_impl": "update_struct_as_class_long",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg",
+                        "inew"
+                    ],
                     "function_name": "UpdateStructAsClass",
                     "function_suffix": "_long"
                 }

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -178,6 +178,10 @@
                     "F_name_function": "update_as_float",
                     "F_name_generic": "update_real",
                     "F_name_impl": "update_as_float",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "UpdateAsFloat"
                 }
             },
@@ -305,6 +309,10 @@
                     "F_name_function": "update_as_double",
                     "F_name_generic": "update_real",
                     "F_name_impl": "update_as_double",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "UpdateAsDouble"
                 }
             },
@@ -393,6 +401,9 @@
                     "F_name_function": "get_global_double",
                     "F_name_generic": "get_global_double",
                     "F_name_impl": "get_global_double",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "GetGlobalDouble"
                 }
             },
@@ -547,6 +558,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "GenericReal",
                     "F_name_api": "generic_real",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "GenericReal"
                 }
             },
@@ -678,6 +693,10 @@
                     "F_name_function": "generic_real_float",
                     "F_name_generic": "generic_real",
                     "F_name_impl": "generic_real_float",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "GenericReal",
                     "function_suffix": "_float"
                 }
@@ -810,6 +829,10 @@
                     "F_name_function": "generic_real_double",
                     "F_name_generic": "generic_real",
                     "F_name_impl": "generic_real_double",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "GenericReal",
                     "function_suffix": "_double"
                 }
@@ -1064,6 +1087,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "GenericReal2",
                     "F_name_api": "generic_real2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "GenericReal2"
                 }
             },
@@ -1274,6 +1302,11 @@
                     "F_name_function": "generic_real2_all_int",
                     "F_name_generic": "generic_real2",
                     "F_name_impl": "generic_real2_all_int",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "GenericReal2",
                     "function_suffix": "_all_int"
                 }
@@ -1485,6 +1518,11 @@
                     "F_name_function": "generic_real2_all_long",
                     "F_name_generic": "generic_real2",
                     "F_name_impl": "generic_real2_all_long",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "GenericReal2",
                     "function_suffix": "_all_long"
                 }
@@ -1904,6 +1942,11 @@
                     "F_name_function": "sum_values_0d",
                     "F_name_generic": "sum_values",
                     "F_name_impl": "sum_values_0d",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "values",
+                        "nvalues"
+                    ],
                     "function_name": "SumValues",
                     "function_suffix": "_0d"
                 }
@@ -2138,6 +2181,11 @@
                     "F_name_function": "sum_values_1d",
                     "F_name_generic": "sum_values",
                     "F_name_impl": "sum_values_1d",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "values",
+                        "nvalues"
+                    ],
                     "function_name": "SumValues",
                     "function_suffix": "_1d"
                 }
@@ -2372,6 +2420,11 @@
                     "F_name_function": "sum_values_2d",
                     "F_name_generic": "sum_values",
                     "F_name_impl": "sum_values_2d",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "values",
+                        "nvalues"
+                    ],
                     "function_name": "SumValues",
                     "function_suffix": "_2d"
                 }
@@ -2981,6 +3034,13 @@
                     "F_name_function": "assign_values_scalar",
                     "F_name_generic": "assign_values",
                     "F_name_impl": "assign_values_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "from",
+                        "nfrom",
+                        "to",
+                        "nto"
+                    ],
                     "function_name": "AssignValues",
                     "function_suffix": "_scalar"
                 }
@@ -3302,6 +3362,13 @@
                     "F_name_function": "assign_values_broadcast",
                     "F_name_generic": "assign_values",
                     "F_name_impl": "assign_values_broadcast",
+                    "f_arglist": [
+                        "f_var",
+                        "from",
+                        "nfrom",
+                        "to",
+                        "nto"
+                    ],
                     "function_name": "AssignValues",
                     "function_suffix": "_broadcast"
                 }
@@ -3633,6 +3700,13 @@
                     "F_name_function": "assign_values_copy",
                     "F_name_generic": "assign_values",
                     "F_name_impl": "assign_values_copy",
+                    "f_arglist": [
+                        "f_var",
+                        "from",
+                        "nfrom",
+                        "to",
+                        "nto"
+                    ],
                     "function_name": "AssignValues",
                     "function_suffix": "_copy"
                 }
@@ -4099,6 +4173,12 @@
                     "F_name_function": "save_pointer_float1d",
                     "F_name_generic": "save_pointer",
                     "F_name_impl": "save_pointer_float1d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer",
                     "function_suffix": "_float1d"
                 }
@@ -4366,6 +4446,12 @@
                     "F_name_function": "save_pointer_float2d",
                     "F_name_generic": "save_pointer",
                     "F_name_impl": "save_pointer_float2d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer",
                     "function_suffix": "_float2d"
                 }
@@ -4890,6 +4976,12 @@
                     "F_name_function": "save_pointer2_float1d",
                     "F_name_generic": "save_pointer2",
                     "F_name_impl": "save_pointer2_float1d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer2",
                     "function_suffix": "_float1d"
                 }
@@ -5185,6 +5277,12 @@
                     "F_name_function": "save_pointer2_float2d",
                     "F_name_generic": "save_pointer2",
                     "F_name_impl": "save_pointer2_float2d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "SavePointer2",
                     "function_suffix": "_float2d"
                 }
@@ -5440,6 +5538,12 @@
                     "F_name_function": "get_pointer",
                     "F_name_generic": "get_pointer",
                     "F_name_impl": "get_pointer",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "GetPointer"
                 }
             },
@@ -5988,6 +6092,12 @@
                     "F_name_function": "get_pointer_as_pointer_float1d",
                     "F_name_generic": "get_pointer_as_pointer",
                     "F_name_impl": "get_pointer_as_pointer_float1d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "GetPointerAsPointer",
                     "function_suffix": "_float1d"
                 }
@@ -6280,6 +6390,12 @@
                     "F_name_function": "get_pointer_as_pointer_float2d",
                     "F_name_generic": "get_pointer_as_pointer",
                     "F_name_impl": "get_pointer_as_pointer_float2d",
+                    "f_arglist": [
+                        "f_var",
+                        "addr",
+                        "type",
+                        "size"
+                    ],
                     "function_name": "GetPointerAsPointer",
                     "function_suffix": "_float2d"
                 }
@@ -6384,6 +6500,9 @@
                     "F_name_function": "create_struct_as_class",
                     "F_name_generic": "create_struct_as_class",
                     "F_name_impl": "create_struct_as_class",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "CreateStructAsClass"
                 }
             },
@@ -6742,6 +6861,11 @@
                     "F_name_function": "update_struct_as_class_int",
                     "F_name_generic": "update_struct_as_class",
                     "F_name_impl": "update_struct_as_class_int",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg",
+                        "inew"
+                    ],
                     "function_name": "UpdateStructAsClass",
                     "function_suffix": "_int"
                 }
@@ -6963,6 +7087,11 @@
                     "F_name_function": "update_struct_as_class_long",
                     "F_name_generic": "update_struct_as_class",
                     "F_name_impl": "update_struct_as_class_long",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg",
+                        "inew"
+                    ],
                     "function_name": "UpdateStructAsClass",
                     "function_suffix": "_long"
                 }

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -186,10 +186,18 @@
                             "F_name_function": "method1",
                             "F_name_generic": "method1",
                             "F_name_impl": "class2_method1",
+                            "c_arglist": [
+                                "self",
+                                "comm"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "comm"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "method1"
                         }
@@ -369,10 +377,18 @@
                             "F_name_function": "method2",
                             "F_name_generic": "method2",
                             "F_name_impl": "class2_method2",
+                            "c_arglist": [
+                                "self",
+                                "c2"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "c2"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "method2"
                         }
@@ -505,6 +521,12 @@
                                     "F_name_function": "function1",
                                     "F_name_generic": "function1",
                                     "F_name_impl": "function1",
+                                    "c_arglist": [
+                                        "c_var"
+                                    ],
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "function_name": "function1"
                                 }
                             }
@@ -747,10 +769,18 @@
                                     "F_name_function": "method1",
                                     "F_name_generic": "method1",
                                     "F_name_impl": "class1_method1",
+                                    "c_arglist": [
+                                        "self",
+                                        "arg1"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var",
+                                        "arg1"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "method1"
                                 }
@@ -899,10 +929,16 @@
                                     "F_name_function": "method",
                                     "F_name_generic": "method",
                                     "F_name_impl": "class0_method",
+                                    "c_arglist": [
+                                        "self"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "method"
                                 }
@@ -1015,6 +1051,12 @@
                             "F_name_function": "outer_func",
                             "F_name_generic": "outer_func",
                             "F_name_impl": "outer_func",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "outer_func"
                         }
                     }
@@ -1137,10 +1179,16 @@
                                     "F_name_function": "method",
                                     "F_name_generic": "method",
                                     "F_name_impl": "class0_method",
+                                    "c_arglist": [
+                                        "self"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "method"
                                 }
@@ -1253,6 +1301,12 @@
                             "F_name_function": "outer_func",
                             "F_name_generic": "outer_func",
                             "F_name_impl": "outer_func",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "outer_func"
                         }
                     }

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -72,6 +72,9 @@
                     "F_name_function": "function1",
                     "F_name_generic": "function1",
                     "F_name_impl": "function1",
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "Function1"
                 }
             },
@@ -277,6 +280,11 @@
                     "F_name_function": "function2",
                     "F_name_generic": "function2",
                     "F_name_impl": "function2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "Function2"
                 }
             }

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -180,6 +180,12 @@
                     "F_name_function": "get_const_string_ptr_alloc",
                     "F_name_generic": "get_const_string_ptr_alloc",
                     "F_name_impl": "get_const_string_ptr_alloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrAlloc"
                 }
             }

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -642,6 +642,14 @@
                     "F_name_generic": "get_name",
                     "F_name_impl": "get_name",
                     "PY_name_impl": "PY_getName",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "getName"
                 },
                 "zz_fmtlang": {
@@ -753,6 +761,12 @@
                     "F_name_generic": "function1",
                     "F_name_impl": "testnames_function1",
                     "PY_name_impl": "PY_function1",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "function1"
                 },
                 "zz_fmtlang": {
@@ -864,6 +878,12 @@
                     "F_name_generic": "function2",
                     "F_name_impl": "f_name_special",
                     "PY_name_impl": "PY_function2",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "function2",
                     "i_name_function": "f_c_name_special"
                 },
@@ -1092,6 +1112,14 @@
                     "F_name_generic": "generic3",
                     "F_name_impl": "F_name_function3a_int",
                     "PY_name_impl": "PY_function3a_0",
+                    "c_arglist": [
+                        "c_var",
+                        "i"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "i"
+                    ],
                     "function_name": "function3a",
                     "function_suffix": "_0"
                 },
@@ -1325,6 +1353,14 @@
                     "F_name_generic": "generic3",
                     "F_name_impl": "F_name_function3a_long",
                     "PY_name_impl": "PY_function3a_1",
+                    "c_arglist": [
+                        "c_var",
+                        "i"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "i"
+                    ],
                     "function_name": "function3a",
                     "function_suffix": "_1"
                 },
@@ -1640,6 +1676,14 @@
                     "F_name_generic": "function4",
                     "F_name_impl": "testnames_function4",
                     "PY_name_impl": "PY_function4",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "rv"
+                    ],
                     "function_name": "function4"
                 },
                 "zz_fmtlang": {
@@ -1754,6 +1798,12 @@
                     "F_name_generic": "fiveplus",
                     "F_name_impl": "testnames_fiveplus",
                     "PY_name_impl": "PY_fiveplus",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "fiveplus"
                 },
                 "zz_fmtlang": {
@@ -2147,6 +2197,16 @@
                     "F_name_generic": "test_multiline_splicer",
                     "F_name_impl": "test_multiline_splicer",
                     "PY_name_impl": "PY_TestMultilineSplicer",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "value"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "value"
+                    ],
                     "function_name": "TestMultilineSplicer"
                 },
                 "zz_fmtlang": {
@@ -2687,6 +2747,16 @@
                     "F_name_generic": "function_tu",
                     "F_name_impl": "f_name_instantiation1",
                     "PY_name_impl": "PY_name_instantiation1",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "FunctionTU",
                     "i_name_function": "f_c_name_instantiation1",
                     "template_suffix": "_0"
@@ -3100,6 +3170,16 @@
                     "F_name_generic": "function_tu",
                     "F_name_impl": "function_tu_instantiation2",
                     "PY_name_impl": "PY_FunctionTU_instantiation2",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "FunctionTU",
                     "template_suffix": "_instantiation2"
                 },
@@ -3350,6 +3430,12 @@
                     "F_name_generic": "use_impl_worker",
                     "F_name_impl": "use_impl_worker_instantiation3",
                     "PY_name_impl": "PY_UseImplWorker_instantiation3",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "UseImplWorker",
                     "template_suffix": "_instantiation3"
                 },
@@ -3640,6 +3726,14 @@
                     "F_name_generic": "cstruct_as_class_sum",
                     "F_name_impl": "cstruct_as_class_sum",
                     "PY_name_impl": "PY_Cstruct_as_class_sum",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "point"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "point"
+                    ],
                     "function_name": "Cstruct_as_class_sum"
                 },
                 "zz_fmtlang": {
@@ -5546,6 +5640,24 @@
                     "F_name_function": "external_funcs",
                     "F_name_generic": "external_funcs",
                     "F_name_impl": "external_funcs",
+                    "c_arglist": [
+                        "c_var",
+                        "rdbase",
+                        "pkg",
+                        "name",
+                        "alloc",
+                        "afree",
+                        "assoc"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "rdbase",
+                        "pkg",
+                        "name",
+                        "alloc",
+                        "afree",
+                        "assoc"
+                    ],
                     "function_name": "external_funcs"
                 }
             },
@@ -5731,6 +5843,14 @@
                     "F_name_function": "bindtest",
                     "F_name_generic": "bindtest",
                     "F_name_impl": "bindtest",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "bindtest"
                 }
             }
@@ -5925,6 +6045,12 @@
                                     "PY_name_impl": "PY_Names_tp_init",
                                     "PY_type_impl": "PY_Names_tp_init",
                                     "PY_type_method": "tp_init",
+                                    "c_arglist": [
+                                        "SHC_rv"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "defaultctor"
                                 },
@@ -6037,10 +6163,16 @@
                                     "F_name_generic": "method1",
                                     "F_name_impl": "names_method1",
                                     "PY_name_impl": "PY_method1",
+                                    "c_arglist": [
+                                        "self"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "method1"
                                 },
@@ -6157,10 +6289,16 @@
                                     "F_name_impl": "names_method2",
                                     "F_this": "obj2",
                                     "PY_name_impl": "PY_method2",
+                                    "c_arglist": [
+                                        "self2"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self2",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "method2"
                                 },
@@ -6455,6 +6593,12 @@
                             "F_name_generic": "init_ns1",
                             "F_name_impl": "testnames_init_ns1",
                             "PY_name_impl": "PY_init_ns1",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "init_ns1"
                         },
                         "zz_fmtlang": {
@@ -7099,10 +7243,16 @@
                                     "F_name_function": "member1",
                                     "F_name_generic": "member1",
                                     "F_name_impl": "class1_member1",
+                                    "c_arglist": [
+                                        "self"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "Member1"
                                 }
@@ -7215,6 +7365,12 @@
                             "F_name_function": "worker1",
                             "F_name_generic": "worker1",
                             "F_name_impl": "worker1",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "Worker1"
                         }
                     }
@@ -7332,6 +7488,12 @@
                             "F_name_function": "worker1",
                             "F_name_generic": "worker1",
                             "F_name_impl": "worker1",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "Worker1"
                         }
                     }

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -88,6 +88,12 @@
                     "F_name_function": "a_function",
                     "F_name_generic": "a_function",
                     "F_name_impl": "a_function",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "AFunction"
                 }
             }

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -208,6 +208,12 @@
                     "F_name_generic": "last_function_called",
                     "F_name_impl": "last_function_called",
                     "PY_name_impl": "PY_LastFunctionCalled",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "LastFunctionCalled"
                 },
                 "zz_fmtlang": {
@@ -314,6 +320,12 @@
                     "F_name_generic": "one",
                     "F_name_impl": "one",
                     "PY_name_impl": "PY_One",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "One"
                 },
                 "zz_fmtlang": {
@@ -823,6 +835,12 @@
                             "F_name_generic": "one",
                             "F_name_impl": "one",
                             "PY_name_impl": "PY_One",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "One"
                         },
                         "zz_fmtlang": {

--- a/regression/reference/namespacedoc/namespacedoc.json
+++ b/regression/reference/namespacedoc/namespacedoc.json
@@ -102,6 +102,12 @@
                     "F_name_generic": "worker3",
                     "F_name_impl": "inner3_worker3",
                     "PY_name_impl": "PY_worker3",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "worker3"
                 },
                 "zz_fmtlang": {
@@ -207,6 +213,12 @@
                     "F_name_generic": "worker",
                     "F_name_impl": "worker",
                     "PY_name_impl": "PY_worker",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "worker"
                 },
                 "zz_fmtlang": {
@@ -318,6 +330,12 @@
                             "F_name_generic": "worker",
                             "F_name_impl": "worker",
                             "PY_name_impl": "PY_worker",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "worker"
                         },
                         "zz_fmtlang": {
@@ -459,6 +477,12 @@
                             "F_name_generic": "worker",
                             "F_name_impl": "worker",
                             "PY_name_impl": "PY_worker",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "worker"
                         },
                         "zz_fmtlang": {
@@ -600,6 +624,12 @@
                             "F_name_generic": "worker4",
                             "F_name_impl": "inner4_worker4",
                             "PY_name_impl": "PY_worker4",
+                            "c_arglist": [
+                                "c_var"
+                            ],
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "function_name": "worker4"
                         },
                         "zz_fmtlang": {

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -4354,6 +4354,7 @@ c_subroutine_assignment_weakptr:
   notes:
   - std::weak_ptr has no wrapped constructor.
   - It must be made from a std::shared_ptr with an assignment.
+  - arglist[1] is the 'from' argument.
   intent: subroutine
   c_call:
   - if (SH_this == nullptr) {{+
@@ -4361,7 +4362,7 @@ c_subroutine_assignment_weakptr:
   - self->addr = SH_this;
   - self->idtor = {idtor};
   - -}} else {{+
-  - '*{CXX_this} = *SHC_from_cxx;'
+  - '*{CXX_this} = *{c_arglist[1].c_local_cxx};'
   - -}}
   destructor_header:
   - <memory>
@@ -14177,6 +14178,7 @@ f_subroutine_assignment_weakptr:
   notes:
   - std::weak_ptr has no wrapped constructor.
   - It must be made from a std::shared_ptr with an assignment.
+  - arglist[1] is the 'from' argument.
   intent: subroutine
   f_call:
   - call {f_call_function}({F_arg_c_call})
@@ -14186,7 +14188,7 @@ f_subroutine_assignment_weakptr:
   - self->addr = SH_this;
   - self->idtor = {idtor};
   - -}} else {{+
-  - '*{CXX_this} = *SHC_from_cxx;'
+  - '*{CXX_this} = *{c_arglist[1].c_local_cxx};'
   - -}}
   destructor_header:
   - <memory>

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -114,10 +114,16 @@
                             "LUA_name": "dtor",
                             "LUA_name_api": "dtor",
                             "LUA_name_impl": "l_Class1_dtor",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "dtor"
                         },
@@ -236,6 +242,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "m_flag",
                             "function_name": "get_flag",
@@ -430,6 +439,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "ReturnIntPtrRaw",
                     "F_name_api": "return_int_ptr_raw",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "ReturnIntPtrRaw"
                 }
             },
@@ -610,6 +622,12 @@
                     "F_name_generic": "return_int_ptr_scalar",
                     "F_name_impl": "return_int_ptr_scalar",
                     "PY_name_impl": "PY_ReturnIntPtrScalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "ReturnIntPtrScalar"
                 },
                 "zz_fmtlang": {
@@ -802,6 +820,12 @@
                     "F_name_generic": "return_int_ptr_pointer",
                     "F_name_impl": "return_int_ptr_pointer",
                     "PY_name_impl": "PY_ReturnIntPtrPointer",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "ReturnIntPtrPointer"
                 },
                 "zz_fmtlang": {
@@ -969,6 +993,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "ReturnIntPtrDimRaw",
                     "F_name_api": "return_int_ptr_dim_raw",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimRaw"
                 }
             },
@@ -1350,6 +1378,14 @@
                     "F_name_generic": "return_int_ptr_dim_pointer",
                     "F_name_impl": "return_int_ptr_dim_pointer",
                     "PY_name_impl": "PY_ReturnIntPtrDimPointer",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimPointer"
                 },
                 "zz_fmtlang": {
@@ -1753,6 +1789,14 @@
                     "F_name_generic": "return_int_ptr_dim_alloc",
                     "F_name_impl": "return_int_ptr_dim_alloc",
                     "PY_name_impl": "PY_ReturnIntPtrDimAlloc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimAlloc"
                 },
                 "zz_fmtlang": {
@@ -2144,6 +2188,14 @@
                     "F_name_generic": "return_int_ptr_dim_default",
                     "F_name_impl": "return_int_ptr_dim_default",
                     "PY_name_impl": "PY_ReturnIntPtrDimDefault",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimDefault"
                 },
                 "zz_fmtlang": {
@@ -2333,6 +2385,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "ReturnIntPtrDimRawNew",
                     "F_name_api": "return_int_ptr_dim_raw_new",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimRawNew"
                 }
             },
@@ -2723,6 +2779,14 @@
                     "F_name_generic": "return_int_ptr_dim_pointer_new",
                     "F_name_impl": "return_int_ptr_dim_pointer_new",
                     "PY_name_impl": "PY_ReturnIntPtrDimPointerNew",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimPointerNew"
                 },
                 "zz_fmtlang": {
@@ -2998,6 +3062,10 @@
                     "C_name_api": "ReturnIntPtrDimAllocNew",
                     "F_name_api": "return_int_ptr_dim_alloc_new",
                     "PY_name_impl": "PY_ReturnIntPtrDimAllocNew",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimAllocNew"
                 },
                 "zz_fmtlang": {
@@ -3399,6 +3467,14 @@
                     "F_name_generic": "return_int_ptr_dim_default_new",
                     "F_name_impl": "return_int_ptr_dim_default_new",
                     "PY_name_impl": "PY_ReturnIntPtrDimDefaultNew",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "len"
+                    ],
                     "function_name": "ReturnIntPtrDimDefaultNew"
                 },
                 "zz_fmtlang": {
@@ -4439,6 +4515,14 @@
                     "F_name_generic": "create_class_static",
                     "F_name_impl": "create_class_static",
                     "PY_name_impl": "PY_createClassStatic",
+                    "c_arglist": [
+                        "c_var",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "flag"
+                    ],
                     "function_name": "createClassStatic"
                 },
                 "zz_fmtlang": {
@@ -4654,6 +4738,12 @@
                     "F_name_generic": "get_class_static",
                     "F_name_impl": "get_class_static",
                     "PY_name_impl": "PY_getClassStatic",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getClassStatic"
                 },
                 "zz_fmtlang": {
@@ -5000,6 +5090,14 @@
                     "F_name_generic": "get_class_new",
                     "F_name_impl": "get_class_new",
                     "PY_name_impl": "PY_getClassNew",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "getClassNew"
                 },
                 "zz_fmtlang": {

--- a/regression/reference/pointers-c-f/pointers.json
+++ b/regression/reference/pointers-c-f/pointers.json
@@ -135,6 +135,10 @@
                     "F_name_function": "intargs_in",
                     "F_name_generic": "intargs_in",
                     "F_name_impl": "intargs_in",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_in"
                 }
             },
@@ -262,6 +266,10 @@
                     "F_name_function": "intargs_inout",
                     "F_name_generic": "intargs_inout",
                     "F_name_impl": "intargs_inout",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_inout"
                 }
             },
@@ -389,6 +397,10 @@
                     "F_name_function": "intargs_out",
                     "F_name_generic": "intargs_out",
                     "F_name_impl": "intargs_out",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_out"
                 }
             },
@@ -639,6 +651,12 @@
                     "F_name_function": "intargs",
                     "F_name_generic": "intargs",
                     "F_name_impl": "intargs",
+                    "f_arglist": [
+                        "f_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
                     "function_name": "intargs"
                 }
             },
@@ -930,6 +948,12 @@
                     "F_name_function": "cos_doubles",
                     "F_name_generic": "cos_doubles",
                     "F_name_impl": "cos_doubles",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "cos_doubles"
                 }
             },
@@ -1221,6 +1245,12 @@
                     "F_name_function": "truncate_to_int",
                     "F_name_generic": "truncate_to_int",
                     "F_name_impl": "truncate_to_int",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "truncate_to_int"
                 }
             },
@@ -1433,6 +1463,11 @@
                     "F_name_function": "get_values",
                     "F_name_generic": "get_values",
                     "F_name_impl": "get_values",
+                    "f_arglist": [
+                        "f_var",
+                        "nvalues",
+                        "values"
+                    ],
                     "function_name": "get_values"
                 }
             },
@@ -1664,6 +1699,11 @@
                     "F_name_function": "get_values2",
                     "F_name_generic": "get_values2",
                     "F_name_impl": "get_values2",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "get_values2"
                 }
             },
@@ -1867,6 +1907,11 @@
                     "F_name_function": "iota_dimension",
                     "F_name_generic": "iota_dimension",
                     "F_name_impl": "iota_dimension",
+                    "f_arglist": [
+                        "f_var",
+                        "nvar",
+                        "values"
+                    ],
                     "function_name": "iota_dimension"
                 }
             },
@@ -2127,6 +2172,12 @@
                     "F_name_function": "sum",
                     "F_name_generic": "sum",
                     "F_name_impl": "sum",
+                    "f_arglist": [
+                        "f_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
                     "function_name": "Sum"
                 }
             },
@@ -2276,6 +2327,10 @@
                     "F_name_function": "fill_int_array",
                     "F_name_generic": "fill_int_array",
                     "F_name_impl": "fill_int_array",
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "fillIntArray"
                 }
             },
@@ -2475,6 +2530,11 @@
                     "F_name_function": "increment_int_array",
                     "F_name_generic": "increment_int_array",
                     "F_name_impl": "increment_int_array",
+                    "f_arglist": [
+                        "f_var",
+                        "array",
+                        "sizein"
+                    ],
                     "function_name": "incrementIntArray"
                 }
             },
@@ -2670,6 +2730,11 @@
                     "F_name_function": "fill_with_zeros",
                     "F_name_generic": "fill_with_zeros",
                     "F_name_impl": "fill_with_zeros",
+                    "f_arglist": [
+                        "f_var",
+                        "x",
+                        "x_length"
+                    ],
                     "function_name": "fill_with_zeros"
                 }
             },
@@ -2892,6 +2957,11 @@
                     "F_name_function": "accumulate",
                     "F_name_generic": "accumulate",
                     "F_name_impl": "accumulate",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arr",
+                        "len"
+                    ],
                     "function_name": "accumulate"
                 }
             },
@@ -3072,6 +3142,10 @@
                     "F_name_function": "accept_char_array_in",
                     "F_name_generic": "accept_char_array_in",
                     "F_name_impl": "accept_char_array_in",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "names"
+                    ],
                     "function_name": "acceptCharArrayIn"
                 }
             },
@@ -3194,6 +3268,10 @@
                     "F_name_function": "set_global_int",
                     "F_name_generic": "set_global_int",
                     "F_name_impl": "set_global_int",
+                    "f_arglist": [
+                        "f_var",
+                        "value"
+                    ],
                     "function_name": "setGlobalInt"
                 }
             },
@@ -3285,6 +3363,9 @@
                     "F_name_function": "sum_fixed_array",
                     "F_name_generic": "sum_fixed_array",
                     "F_name_impl": "sum_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "sumFixedArray"
                 }
             },
@@ -3434,6 +3515,10 @@
                     "F_name_function": "get_ptr_to_scalar",
                     "F_name_generic": "get_ptr_to_scalar",
                     "F_name_impl": "get_ptr_to_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToScalar"
                 }
             },
@@ -3607,6 +3692,10 @@
                     "F_name_function": "get_ptr_to_fixed_array",
                     "F_name_generic": "get_ptr_to_fixed_array",
                     "F_name_impl": "get_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedArray"
                 }
             },
@@ -3843,6 +3932,11 @@
                     "F_name_function": "get_ptr_to_dynamic_array",
                     "F_name_generic": "get_ptr_to_dynamic_array",
                     "F_name_impl": "get_ptr_to_dynamic_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicArray"
                 }
             },
@@ -4018,6 +4112,10 @@
                     "F_name_function": "get_ptr_to_func_array",
                     "F_name_generic": "get_ptr_to_func_array",
                     "F_name_impl": "get_ptr_to_func_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFuncArray"
                 }
             },
@@ -4168,6 +4266,10 @@
                     "F_name_function": "get_ptr_to_const_scalar",
                     "F_name_generic": "get_ptr_to_const_scalar",
                     "F_name_impl": "get_ptr_to_const_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToConstScalar"
                 }
             },
@@ -4339,6 +4441,10 @@
                     "F_name_function": "get_ptr_to_fixed_const_array",
                     "F_name_generic": "get_ptr_to_fixed_const_array",
                     "F_name_impl": "get_ptr_to_fixed_const_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedConstArray"
                 }
             },
@@ -4573,6 +4679,11 @@
                     "F_name_function": "get_ptr_to_dynamic_const_array",
                     "F_name_generic": "get_ptr_to_dynamic_const_array",
                     "F_name_impl": "get_ptr_to_dynamic_const_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicConstArray"
                 }
             },
@@ -4708,6 +4819,10 @@
                     "F_name_function": "get_raw_ptr_to_scalar",
                     "F_name_generic": "get_raw_ptr_to_scalar",
                     "F_name_impl": "get_raw_ptr_to_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalar"
                 }
             },
@@ -4846,6 +4961,10 @@
                     "F_name_function": "get_raw_ptr_to_scalar_force",
                     "F_name_generic": "get_raw_ptr_to_scalar_force",
                     "F_name_impl": "get_raw_ptr_to_scalar_force",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalarForce"
                 }
             },
@@ -4981,6 +5100,10 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array",
                     "F_name_generic": "get_raw_ptr_to_fixed_array",
                     "F_name_impl": "get_raw_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArray"
                 }
             },
@@ -5119,6 +5242,10 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array_force",
                     "F_name_generic": "get_raw_ptr_to_fixed_array_force",
                     "F_name_impl": "get_raw_ptr_to_fixed_array_force",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArrayForce"
                 }
             },
@@ -5257,6 +5384,10 @@
                     "F_name_function": "get_raw_ptr_to_int2d",
                     "F_name_generic": "get_raw_ptr_to_int2d",
                     "F_name_impl": "get_raw_ptr_to_int2d",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "getRawPtrToInt2d"
                 }
             },
@@ -5418,6 +5549,10 @@
                     "F_name_function": "check_int2d",
                     "F_name_generic": "check_int2d",
                     "F_name_impl": "check_int2d",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "checkInt2d"
                 }
             },
@@ -5576,6 +5711,10 @@
                     "F_name_function": "dimension_in",
                     "F_name_generic": "dimension_in",
                     "F_name_impl": "dimension_in",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "DimensionIn"
                 }
             },
@@ -5762,6 +5901,10 @@
                     "F_name_function": "get_alloc_to_fixed_array",
                     "F_name_generic": "get_alloc_to_fixed_array",
                     "F_name_impl": "get_alloc_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getAllocToFixedArray"
                 }
             },
@@ -5915,6 +6058,10 @@
                     "F_name_function": "return_address1",
                     "F_name_generic": "return_address1",
                     "F_name_impl": "return_address1",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress1"
                 }
             },
@@ -6070,6 +6217,10 @@
                     "F_name_function": "return_address2",
                     "F_name_generic": "return_address2",
                     "F_name_impl": "return_address2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress2"
                 }
             },
@@ -6200,6 +6351,10 @@
                     "F_name_function": "fetch_void_ptr",
                     "F_name_generic": "fetch_void_ptr",
                     "F_name_impl": "fetch_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "fetchVoidPtr"
                 }
             },
@@ -6333,6 +6488,10 @@
                     "F_name_function": "update_void_ptr",
                     "F_name_generic": "update_void_ptr",
                     "F_name_impl": "update_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "updateVoidPtr"
                 }
             },
@@ -6499,6 +6658,10 @@
                     "F_name_function": "void_ptr_array",
                     "F_name_generic": "void_ptr_array",
                     "F_name_impl": "void_ptr_array",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr"
+                    ],
                     "function_name": "VoidPtrArray"
                 }
             },
@@ -6595,6 +6758,9 @@
                     "F_name_function": "return_int_ptr_to_scalar",
                     "F_name_generic": "return_int_ptr_to_scalar",
                     "F_name_impl": "return_int_ptr_to_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToScalar"
                 }
             },
@@ -6728,6 +6894,9 @@
                     "F_name_function": "return_int_ptr_to_fixed_array",
                     "F_name_generic": "return_int_ptr_to_fixed_array",
                     "F_name_impl": "return_int_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedArray"
                 }
             },
@@ -6825,6 +6994,9 @@
                     "F_name_function": "return_int_ptr_to_const_scalar",
                     "F_name_generic": "return_int_ptr_to_const_scalar",
                     "F_name_impl": "return_int_ptr_to_const_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToConstScalar"
                 }
             },
@@ -6959,6 +7131,9 @@
                     "F_name_function": "return_int_ptr_to_fixed_const_array",
                     "F_name_generic": "return_int_ptr_to_fixed_const_array",
                     "F_name_impl": "return_int_ptr_to_fixed_const_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedConstArray"
                 }
             },
@@ -7056,6 +7231,9 @@
                     "F_name_function": "return_int_scalar",
                     "F_name_generic": "return_int_scalar",
                     "F_name_impl": "return_int_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntScalar"
                 }
             },
@@ -7158,6 +7336,9 @@
                     "F_name_function": "return_int_raw",
                     "F_name_generic": "return_int_raw",
                     "F_name_impl": "return_int_raw",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntRaw"
                 }
             },
@@ -7323,6 +7504,10 @@
                     "F_name_function": "return_int_raw_with_args",
                     "F_name_generic": "return_int_raw_with_args",
                     "F_name_impl": "return_int_raw_with_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "name"
+                    ],
                     "function_name": "returnIntRawWithArgs"
                 }
             },
@@ -7425,6 +7610,9 @@
                     "F_name_function": "return_raw_ptr_to_int2d",
                     "F_name_generic": "return_raw_ptr_to_int2d",
                     "F_name_impl": "return_raw_ptr_to_int2d",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnRawPtrToInt2d"
                 }
             },
@@ -7571,6 +7759,9 @@
                     "F_name_function": "return_int_alloc_to_fixed_array",
                     "F_name_generic": "return_int_alloc_to_fixed_array",
                     "F_name_impl": "return_int_alloc_to_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntAllocToFixedArray"
                 }
             }

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -135,6 +135,10 @@
                     "F_name_function": "intargs_in",
                     "F_name_generic": "intargs_in",
                     "F_name_impl": "intargs_in",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_in"
                 }
             },
@@ -262,6 +266,10 @@
                     "F_name_function": "intargs_inout",
                     "F_name_generic": "intargs_inout",
                     "F_name_impl": "intargs_inout",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_inout"
                 }
             },
@@ -389,6 +397,10 @@
                     "F_name_function": "intargs_out",
                     "F_name_generic": "intargs_out",
                     "F_name_impl": "intargs_out",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_out"
                 }
             },
@@ -639,6 +651,12 @@
                     "F_name_function": "intargs",
                     "F_name_generic": "intargs",
                     "F_name_impl": "intargs",
+                    "f_arglist": [
+                        "f_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
                     "function_name": "intargs"
                 }
             },
@@ -930,6 +948,12 @@
                     "F_name_function": "cos_doubles",
                     "F_name_generic": "cos_doubles",
                     "F_name_impl": "cos_doubles",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "cos_doubles"
                 }
             },
@@ -1221,6 +1245,12 @@
                     "F_name_function": "truncate_to_int",
                     "F_name_generic": "truncate_to_int",
                     "F_name_impl": "truncate_to_int",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "truncate_to_int"
                 }
             },
@@ -1433,6 +1463,11 @@
                     "F_name_function": "get_values",
                     "F_name_generic": "get_values",
                     "F_name_impl": "get_values",
+                    "f_arglist": [
+                        "f_var",
+                        "nvalues",
+                        "values"
+                    ],
                     "function_name": "get_values"
                 }
             },
@@ -1664,6 +1699,11 @@
                     "F_name_function": "get_values2",
                     "F_name_generic": "get_values2",
                     "F_name_impl": "get_values2",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "get_values2"
                 }
             },
@@ -1867,6 +1907,11 @@
                     "F_name_function": "iota_dimension",
                     "F_name_generic": "iota_dimension",
                     "F_name_impl": "iota_dimension",
+                    "f_arglist": [
+                        "f_var",
+                        "nvar",
+                        "values"
+                    ],
                     "function_name": "iota_dimension"
                 }
             },
@@ -2127,6 +2172,12 @@
                     "F_name_function": "sum",
                     "F_name_generic": "sum",
                     "F_name_impl": "sum",
+                    "f_arglist": [
+                        "f_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
                     "function_name": "Sum"
                 }
             },
@@ -2276,6 +2327,10 @@
                     "F_name_function": "fill_int_array",
                     "F_name_generic": "fill_int_array",
                     "F_name_impl": "fill_int_array",
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "fillIntArray"
                 }
             },
@@ -2475,6 +2530,11 @@
                     "F_name_function": "increment_int_array",
                     "F_name_generic": "increment_int_array",
                     "F_name_impl": "increment_int_array",
+                    "f_arglist": [
+                        "f_var",
+                        "array",
+                        "sizein"
+                    ],
                     "function_name": "incrementIntArray"
                 }
             },
@@ -2670,6 +2730,11 @@
                     "F_name_function": "fill_with_zeros",
                     "F_name_generic": "fill_with_zeros",
                     "F_name_impl": "fill_with_zeros",
+                    "f_arglist": [
+                        "f_var",
+                        "x",
+                        "x_length"
+                    ],
                     "function_name": "fill_with_zeros"
                 }
             },
@@ -2892,6 +2957,11 @@
                     "F_name_function": "accumulate",
                     "F_name_generic": "accumulate",
                     "F_name_impl": "accumulate",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arr",
+                        "len"
+                    ],
                     "function_name": "accumulate"
                 }
             },
@@ -3072,6 +3142,10 @@
                     "F_name_function": "accept_char_array_in",
                     "F_name_generic": "accept_char_array_in",
                     "F_name_impl": "accept_char_array_in",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "names"
+                    ],
                     "function_name": "acceptCharArrayIn"
                 }
             },
@@ -3194,6 +3268,10 @@
                     "F_name_function": "set_global_int",
                     "F_name_generic": "set_global_int",
                     "F_name_impl": "set_global_int",
+                    "f_arglist": [
+                        "f_var",
+                        "value"
+                    ],
                     "function_name": "setGlobalInt"
                 }
             },
@@ -3285,6 +3363,9 @@
                     "F_name_function": "sum_fixed_array",
                     "F_name_generic": "sum_fixed_array",
                     "F_name_impl": "sum_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "sumFixedArray"
                 }
             },
@@ -3434,6 +3515,10 @@
                     "F_name_function": "get_ptr_to_scalar",
                     "F_name_generic": "get_ptr_to_scalar",
                     "F_name_impl": "get_ptr_to_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToScalar"
                 }
             },
@@ -3607,6 +3692,10 @@
                     "F_name_function": "get_ptr_to_fixed_array",
                     "F_name_generic": "get_ptr_to_fixed_array",
                     "F_name_impl": "get_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedArray"
                 }
             },
@@ -3843,6 +3932,11 @@
                     "F_name_function": "get_ptr_to_dynamic_array",
                     "F_name_generic": "get_ptr_to_dynamic_array",
                     "F_name_impl": "get_ptr_to_dynamic_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicArray"
                 }
             },
@@ -4018,6 +4112,10 @@
                     "F_name_function": "get_ptr_to_func_array",
                     "F_name_generic": "get_ptr_to_func_array",
                     "F_name_impl": "get_ptr_to_func_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFuncArray"
                 }
             },
@@ -4168,6 +4266,10 @@
                     "F_name_function": "get_ptr_to_const_scalar",
                     "F_name_generic": "get_ptr_to_const_scalar",
                     "F_name_impl": "get_ptr_to_const_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToConstScalar"
                 }
             },
@@ -4339,6 +4441,10 @@
                     "F_name_function": "get_ptr_to_fixed_const_array",
                     "F_name_generic": "get_ptr_to_fixed_const_array",
                     "F_name_impl": "get_ptr_to_fixed_const_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedConstArray"
                 }
             },
@@ -4573,6 +4679,11 @@
                     "F_name_function": "get_ptr_to_dynamic_const_array",
                     "F_name_generic": "get_ptr_to_dynamic_const_array",
                     "F_name_impl": "get_ptr_to_dynamic_const_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicConstArray"
                 }
             },
@@ -4708,6 +4819,10 @@
                     "F_name_function": "get_raw_ptr_to_scalar",
                     "F_name_generic": "get_raw_ptr_to_scalar",
                     "F_name_impl": "get_raw_ptr_to_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalar"
                 }
             },
@@ -4846,6 +4961,10 @@
                     "F_name_function": "get_raw_ptr_to_scalar_force",
                     "F_name_generic": "get_raw_ptr_to_scalar_force",
                     "F_name_impl": "get_raw_ptr_to_scalar_force",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalarForce"
                 }
             },
@@ -4981,6 +5100,10 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array",
                     "F_name_generic": "get_raw_ptr_to_fixed_array",
                     "F_name_impl": "get_raw_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArray"
                 }
             },
@@ -5119,6 +5242,10 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array_force",
                     "F_name_generic": "get_raw_ptr_to_fixed_array_force",
                     "F_name_impl": "get_raw_ptr_to_fixed_array_force",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArrayForce"
                 }
             },
@@ -5257,6 +5384,10 @@
                     "F_name_function": "get_raw_ptr_to_int2d",
                     "F_name_generic": "get_raw_ptr_to_int2d",
                     "F_name_impl": "get_raw_ptr_to_int2d",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "getRawPtrToInt2d"
                 }
             },
@@ -5418,6 +5549,10 @@
                     "F_name_function": "check_int2d",
                     "F_name_generic": "check_int2d",
                     "F_name_impl": "check_int2d",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "checkInt2d"
                 }
             },
@@ -5576,6 +5711,10 @@
                     "F_name_function": "dimension_in",
                     "F_name_generic": "dimension_in",
                     "F_name_impl": "dimension_in",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "DimensionIn"
                 }
             },
@@ -5762,6 +5901,10 @@
                     "F_name_function": "get_alloc_to_fixed_array",
                     "F_name_generic": "get_alloc_to_fixed_array",
                     "F_name_impl": "get_alloc_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getAllocToFixedArray"
                 }
             },
@@ -5915,6 +6058,10 @@
                     "F_name_function": "return_address1",
                     "F_name_generic": "return_address1",
                     "F_name_impl": "return_address1",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress1"
                 }
             },
@@ -6070,6 +6217,10 @@
                     "F_name_function": "return_address2",
                     "F_name_generic": "return_address2",
                     "F_name_impl": "return_address2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress2"
                 }
             },
@@ -6200,6 +6351,10 @@
                     "F_name_function": "fetch_void_ptr",
                     "F_name_generic": "fetch_void_ptr",
                     "F_name_impl": "fetch_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "fetchVoidPtr"
                 }
             },
@@ -6333,6 +6488,10 @@
                     "F_name_function": "update_void_ptr",
                     "F_name_generic": "update_void_ptr",
                     "F_name_impl": "update_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "updateVoidPtr"
                 }
             },
@@ -6499,6 +6658,10 @@
                     "F_name_function": "void_ptr_array",
                     "F_name_generic": "void_ptr_array",
                     "F_name_impl": "void_ptr_array",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr"
+                    ],
                     "function_name": "VoidPtrArray"
                 }
             },
@@ -6595,6 +6758,9 @@
                     "F_name_function": "return_int_ptr_to_scalar",
                     "F_name_generic": "return_int_ptr_to_scalar",
                     "F_name_impl": "return_int_ptr_to_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToScalar"
                 }
             },
@@ -6728,6 +6894,9 @@
                     "F_name_function": "return_int_ptr_to_fixed_array",
                     "F_name_generic": "return_int_ptr_to_fixed_array",
                     "F_name_impl": "return_int_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedArray"
                 }
             },
@@ -6825,6 +6994,9 @@
                     "F_name_function": "return_int_ptr_to_const_scalar",
                     "F_name_generic": "return_int_ptr_to_const_scalar",
                     "F_name_impl": "return_int_ptr_to_const_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToConstScalar"
                 }
             },
@@ -6959,6 +7131,9 @@
                     "F_name_function": "return_int_ptr_to_fixed_const_array",
                     "F_name_generic": "return_int_ptr_to_fixed_const_array",
                     "F_name_impl": "return_int_ptr_to_fixed_const_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedConstArray"
                 }
             },
@@ -7056,6 +7231,9 @@
                     "F_name_function": "return_int_scalar",
                     "F_name_generic": "return_int_scalar",
                     "F_name_impl": "return_int_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntScalar"
                 }
             },
@@ -7158,6 +7336,9 @@
                     "F_name_function": "return_int_raw",
                     "F_name_generic": "return_int_raw",
                     "F_name_impl": "return_int_raw",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntRaw"
                 }
             },
@@ -7323,6 +7504,10 @@
                     "F_name_function": "return_int_raw_with_args",
                     "F_name_generic": "return_int_raw_with_args",
                     "F_name_impl": "return_int_raw_with_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "name"
+                    ],
                     "function_name": "returnIntRawWithArgs"
                 }
             },
@@ -7425,6 +7610,9 @@
                     "F_name_function": "return_raw_ptr_to_int2d",
                     "F_name_generic": "return_raw_ptr_to_int2d",
                     "F_name_impl": "return_raw_ptr_to_int2d",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnRawPtrToInt2d"
                 }
             },
@@ -7571,6 +7759,9 @@
                     "F_name_function": "return_int_alloc_to_fixed_array",
                     "F_name_generic": "return_int_alloc_to_fixed_array",
                     "F_name_impl": "return_int_alloc_to_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntAllocToFixedArray"
                 }
             }

--- a/regression/reference/pointers-cfi/pointers.json
+++ b/regression/reference/pointers-cfi/pointers.json
@@ -184,6 +184,14 @@
                     "F_name_function": "intargs_in",
                     "F_name_generic": "intargs_in",
                     "F_name_impl": "intargs_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_in"
                 }
             },
@@ -360,6 +368,14 @@
                     "F_name_function": "intargs_inout",
                     "F_name_generic": "intargs_inout",
                     "F_name_impl": "intargs_inout",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_inout"
                 }
             },
@@ -536,6 +552,14 @@
                     "F_name_function": "intargs_out",
                     "F_name_generic": "intargs_out",
                     "F_name_impl": "intargs_out",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_out"
                 }
             },
@@ -895,6 +919,18 @@
                     "F_name_function": "intargs",
                     "F_name_generic": "intargs",
                     "F_name_impl": "intargs",
+                    "c_arglist": [
+                        "c_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
                     "function_name": "intargs"
                 }
             },
@@ -1350,6 +1386,18 @@
                     "F_name_function": "cos_doubles",
                     "F_name_generic": "cos_doubles",
                     "F_name_impl": "cos_doubles",
+                    "c_arglist": [
+                        "c_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "cos_doubles"
                 }
             },
@@ -1805,6 +1853,18 @@
                     "F_name_function": "truncate_to_int",
                     "F_name_generic": "truncate_to_int",
                     "F_name_impl": "truncate_to_int",
+                    "c_arglist": [
+                        "c_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "truncate_to_int"
                 }
             },
@@ -2103,6 +2163,16 @@
                     "F_name_function": "get_values",
                     "F_name_generic": "get_values",
                     "F_name_impl": "get_values",
+                    "c_arglist": [
+                        "c_var",
+                        "nvalues",
+                        "values"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nvalues",
+                        "values"
+                    ],
                     "function_name": "get_values"
                 }
             },
@@ -2428,6 +2498,16 @@
                     "F_name_function": "get_values2",
                     "F_name_generic": "get_values2",
                     "F_name_impl": "get_values2",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "get_values2"
                 }
             },
@@ -2719,6 +2799,16 @@
                     "F_name_function": "iota_dimension",
                     "F_name_generic": "iota_dimension",
                     "F_name_impl": "iota_dimension",
+                    "c_arglist": [
+                        "c_var",
+                        "nvar",
+                        "values"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nvar",
+                        "values"
+                    ],
                     "function_name": "iota_dimension"
                 }
             },
@@ -3126,6 +3216,18 @@
                     "F_name_function": "sum",
                     "F_name_generic": "sum",
                     "F_name_impl": "sum",
+                    "c_arglist": [
+                        "c_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
                     "function_name": "Sum"
                 }
             },
@@ -3332,6 +3434,14 @@
                     "F_name_function": "fill_int_array",
                     "F_name_generic": "fill_int_array",
                     "F_name_impl": "fill_int_array",
+                    "c_arglist": [
+                        "c_var",
+                        "out"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "fillIntArray"
                 }
             },
@@ -3641,6 +3751,16 @@
                     "F_name_function": "increment_int_array",
                     "F_name_generic": "increment_int_array",
                     "F_name_impl": "increment_int_array",
+                    "c_arglist": [
+                        "c_var",
+                        "array",
+                        "sizein"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "array",
+                        "sizein"
+                    ],
                     "function_name": "incrementIntArray"
                 }
             },
@@ -3946,6 +4066,16 @@
                     "F_name_function": "fill_with_zeros",
                     "F_name_generic": "fill_with_zeros",
                     "F_name_impl": "fill_with_zeros",
+                    "c_arglist": [
+                        "c_var",
+                        "x",
+                        "x_length"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "x",
+                        "x_length"
+                    ],
                     "function_name": "fill_with_zeros"
                 }
             },
@@ -4302,6 +4432,16 @@
                     "F_name_function": "accumulate",
                     "F_name_generic": "accumulate",
                     "F_name_impl": "accumulate",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arr",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arr",
+                        "len"
+                    ],
                     "function_name": "accumulate"
                 }
             },
@@ -4571,6 +4711,14 @@
                     "F_name_function": "accept_char_array_in",
                     "F_name_generic": "accept_char_array_in",
                     "F_name_impl": "accept_char_array_in",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "names"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "names"
+                    ],
                     "function_name": "acceptCharArrayIn"
                 }
             },
@@ -4744,6 +4892,14 @@
                     "F_name_function": "set_global_int",
                     "F_name_generic": "set_global_int",
                     "F_name_impl": "set_global_int",
+                    "c_arglist": [
+                        "c_var",
+                        "value"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "value"
+                    ],
                     "function_name": "setGlobalInt"
                 }
             },
@@ -4867,6 +5023,12 @@
                     "F_name_function": "sum_fixed_array",
                     "F_name_generic": "sum_fixed_array",
                     "F_name_impl": "sum_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "sumFixedArray"
                 }
             },
@@ -5078,6 +5240,14 @@
                     "F_name_function": "get_ptr_to_scalar",
                     "F_name_generic": "get_ptr_to_scalar",
                     "F_name_impl": "get_ptr_to_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToScalar"
                 }
             },
@@ -5325,6 +5495,14 @@
                     "F_name_function": "get_ptr_to_fixed_array",
                     "F_name_generic": "get_ptr_to_fixed_array",
                     "F_name_impl": "get_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedArray"
                 }
             },
@@ -5672,6 +5850,16 @@
                     "F_name_function": "get_ptr_to_dynamic_array",
                     "F_name_generic": "get_ptr_to_dynamic_array",
                     "F_name_impl": "get_ptr_to_dynamic_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "ncount"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicArray"
                 }
             },
@@ -5922,6 +6110,14 @@
                     "F_name_function": "get_ptr_to_func_array",
                     "F_name_generic": "get_ptr_to_func_array",
                     "F_name_impl": "get_ptr_to_func_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFuncArray"
                 }
             },
@@ -6134,6 +6330,14 @@
                     "F_name_function": "get_ptr_to_const_scalar",
                     "F_name_generic": "get_ptr_to_const_scalar",
                     "F_name_impl": "get_ptr_to_const_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToConstScalar"
                 }
             },
@@ -6379,6 +6583,14 @@
                     "F_name_function": "get_ptr_to_fixed_const_array",
                     "F_name_generic": "get_ptr_to_fixed_const_array",
                     "F_name_impl": "get_ptr_to_fixed_const_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedConstArray"
                 }
             },
@@ -6724,6 +6936,16 @@
                     "F_name_function": "get_ptr_to_dynamic_const_array",
                     "F_name_generic": "get_ptr_to_dynamic_const_array",
                     "F_name_impl": "get_ptr_to_dynamic_const_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "ncount"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicConstArray"
                 }
             },
@@ -6908,6 +7130,14 @@
                     "F_name_function": "get_raw_ptr_to_scalar",
                     "F_name_generic": "get_raw_ptr_to_scalar",
                     "F_name_impl": "get_raw_ptr_to_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalar"
                 }
             },
@@ -7095,6 +7325,14 @@
                     "F_name_function": "get_raw_ptr_to_scalar_force",
                     "F_name_generic": "get_raw_ptr_to_scalar_force",
                     "F_name_impl": "get_raw_ptr_to_scalar_force",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalarForce"
                 }
             },
@@ -7279,6 +7517,14 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array",
                     "F_name_generic": "get_raw_ptr_to_fixed_array",
                     "F_name_impl": "get_raw_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArray"
                 }
             },
@@ -7466,6 +7712,14 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array_force",
                     "F_name_generic": "get_raw_ptr_to_fixed_array_force",
                     "F_name_impl": "get_raw_ptr_to_fixed_array_force",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArrayForce"
                 }
             },
@@ -7653,6 +7907,14 @@
                     "F_name_function": "get_raw_ptr_to_int2d",
                     "F_name_generic": "get_raw_ptr_to_int2d",
                     "F_name_impl": "get_raw_ptr_to_int2d",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "getRawPtrToInt2d"
                 }
             },
@@ -7876,6 +8138,14 @@
                     "F_name_function": "check_int2d",
                     "F_name_generic": "check_int2d",
                     "F_name_impl": "check_int2d",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "checkInt2d"
                 }
             },
@@ -8094,6 +8364,14 @@
                     "F_name_function": "dimension_in",
                     "F_name_generic": "dimension_in",
                     "F_name_impl": "dimension_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "DimensionIn"
                 }
             },
@@ -8336,6 +8614,14 @@
                     "F_name_function": "get_alloc_to_fixed_array",
                     "F_name_generic": "get_alloc_to_fixed_array",
                     "F_name_impl": "get_alloc_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getAllocToFixedArray"
                 }
             },
@@ -8553,6 +8839,14 @@
                     "F_name_function": "return_address1",
                     "F_name_generic": "return_address1",
                     "F_name_impl": "return_address1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress1"
                 }
             },
@@ -8772,6 +9066,14 @@
                     "F_name_function": "return_address2",
                     "F_name_generic": "return_address2",
                     "F_name_impl": "return_address2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress2"
                 }
             },
@@ -8951,6 +9253,14 @@
                     "F_name_function": "fetch_void_ptr",
                     "F_name_generic": "fetch_void_ptr",
                     "F_name_impl": "fetch_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "addr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "fetchVoidPtr"
                 }
             },
@@ -9133,6 +9443,14 @@
                     "F_name_function": "update_void_ptr",
                     "F_name_generic": "update_void_ptr",
                     "F_name_impl": "update_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "addr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "updateVoidPtr"
                 }
             },
@@ -9363,6 +9681,14 @@
                     "F_name_function": "void_ptr_array",
                     "F_name_generic": "void_ptr_array",
                     "F_name_impl": "void_ptr_array",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "addr"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr"
+                    ],
                     "function_name": "VoidPtrArray"
                 }
             },
@@ -9519,6 +9845,12 @@
                     "F_name_function": "return_int_ptr_to_scalar",
                     "F_name_generic": "return_int_ptr_to_scalar",
                     "F_name_impl": "return_int_ptr_to_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToScalar"
                 }
             },
@@ -9712,6 +10044,12 @@
                     "F_name_function": "return_int_ptr_to_fixed_array",
                     "F_name_generic": "return_int_ptr_to_fixed_array",
                     "F_name_impl": "return_int_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedArray"
                 }
             },
@@ -9869,6 +10207,12 @@
                     "F_name_function": "return_int_ptr_to_const_scalar",
                     "F_name_generic": "return_int_ptr_to_const_scalar",
                     "F_name_impl": "return_int_ptr_to_const_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToConstScalar"
                 }
             },
@@ -10063,6 +10407,12 @@
                     "F_name_function": "return_int_ptr_to_fixed_const_array",
                     "F_name_generic": "return_int_ptr_to_fixed_const_array",
                     "F_name_impl": "return_int_ptr_to_fixed_const_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedConstArray"
                 }
             },
@@ -10205,6 +10555,12 @@
                     "F_name_function": "return_int_scalar",
                     "F_name_generic": "return_int_scalar",
                     "F_name_impl": "return_int_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntScalar"
                 }
             },
@@ -10339,6 +10695,12 @@
                     "F_name_function": "return_int_raw",
                     "F_name_generic": "return_int_raw",
                     "F_name_impl": "return_int_raw",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntRaw"
                 }
             },
@@ -10599,6 +10961,14 @@
                     "F_name_function": "return_int_raw_with_args",
                     "F_name_generic": "return_int_raw_with_args",
                     "F_name_impl": "return_int_raw_with_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "name"
+                    ],
                     "function_name": "returnIntRawWithArgs"
                 }
             },
@@ -10733,6 +11103,12 @@
                     "F_name_function": "return_raw_ptr_to_int2d",
                     "F_name_generic": "return_raw_ptr_to_int2d",
                     "F_name_impl": "return_raw_ptr_to_int2d",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnRawPtrToInt2d"
                 }
             },
@@ -10921,6 +11297,12 @@
                     "F_name_function": "return_int_alloc_to_fixed_array",
                     "F_name_generic": "return_int_alloc_to_fixed_array",
                     "F_name_impl": "return_int_alloc_to_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntAllocToFixedArray"
                 }
             }

--- a/regression/reference/pointers-cxx-c/pointers.json
+++ b/regression/reference/pointers-cxx-c/pointers.json
@@ -117,6 +117,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "intargs_in",
                     "F_name_api": "intargs_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_in"
                 }
             },
@@ -226,6 +230,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "intargs_inout",
                     "F_name_api": "intargs_inout",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_inout"
                 }
             },
@@ -335,6 +343,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "intargs_out",
                     "F_name_api": "intargs_out",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_out"
                 }
             },
@@ -549,6 +561,12 @@
                 "zz_fmtdict": {
                     "C_name_api": "intargs",
                     "F_name_api": "intargs",
+                    "c_arglist": [
+                        "c_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
                     "function_name": "intargs"
                 }
             },
@@ -794,6 +812,12 @@
                 "zz_fmtdict": {
                     "C_name_api": "cos_doubles",
                     "F_name_api": "cos_doubles",
+                    "c_arglist": [
+                        "c_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "cos_doubles"
                 }
             },
@@ -1039,6 +1063,12 @@
                 "zz_fmtdict": {
                     "C_name_api": "truncate_to_int",
                     "F_name_api": "truncate_to_int",
+                    "c_arglist": [
+                        "c_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "truncate_to_int"
                 }
             },
@@ -1220,6 +1250,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "get_values",
                     "F_name_api": "get_values",
+                    "c_arglist": [
+                        "c_var",
+                        "nvalues",
+                        "values"
+                    ],
                     "function_name": "get_values"
                 }
             },
@@ -1416,6 +1451,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "get_values2",
                     "F_name_api": "get_values2",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "get_values2"
                 }
             },
@@ -1588,6 +1628,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "iota_dimension",
                     "F_name_api": "iota_dimension",
+                    "c_arglist": [
+                        "c_var",
+                        "nvar",
+                        "values"
+                    ],
                     "function_name": "iota_dimension"
                 }
             },
@@ -1806,6 +1851,12 @@
                 "zz_fmtdict": {
                     "C_name_api": "Sum",
                     "F_name_api": "sum",
+                    "c_arglist": [
+                        "c_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
                     "function_name": "Sum"
                 }
             },
@@ -1933,6 +1984,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "fillIntArray",
                     "F_name_api": "fill_int_array",
+                    "c_arglist": [
+                        "c_var",
+                        "out"
+                    ],
                     "function_name": "fillIntArray"
                 }
             },
@@ -2099,6 +2154,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "incrementIntArray",
                     "F_name_api": "increment_int_array",
+                    "c_arglist": [
+                        "c_var",
+                        "array",
+                        "sizein"
+                    ],
                     "function_name": "incrementIntArray"
                 }
             },
@@ -2261,6 +2321,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "fill_with_zeros",
                     "F_name_api": "fill_with_zeros",
+                    "c_arglist": [
+                        "c_var",
+                        "x",
+                        "x_length"
+                    ],
                     "function_name": "fill_with_zeros"
                 }
             },
@@ -2437,6 +2502,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "accumulate",
                     "F_name_api": "accumulate",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arr",
+                        "len"
+                    ],
                     "function_name": "accumulate"
                 }
             },
@@ -2567,6 +2637,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "acceptCharArrayIn",
                     "F_name_api": "accept_char_array_in",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "names"
+                    ],
                     "function_name": "acceptCharArrayIn"
                 }
             },
@@ -2671,6 +2745,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "setGlobalInt",
                     "F_name_api": "set_global_int",
+                    "c_arglist": [
+                        "c_var",
+                        "value"
+                    ],
                     "function_name": "setGlobalInt"
                 }
             },
@@ -2741,6 +2819,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "sumFixedArray",
                     "F_name_api": "sum_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "sumFixedArray"
                 }
             },
@@ -2855,6 +2936,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToScalar",
                     "F_name_api": "get_ptr_to_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToScalar"
                 }
             },
@@ -2985,6 +3070,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToFixedArray",
                     "F_name_api": "get_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedArray"
                 }
             },
@@ -3169,6 +3258,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToDynamicArray",
                     "F_name_api": "get_ptr_to_dynamic_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicArray"
                 }
             },
@@ -3301,6 +3395,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToFuncArray",
                     "F_name_api": "get_ptr_to_func_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFuncArray"
                 }
             },
@@ -3416,6 +3514,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToConstScalar",
                     "F_name_api": "get_ptr_to_const_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToConstScalar"
                 }
             },
@@ -3544,6 +3646,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToFixedConstArray",
                     "F_name_api": "get_ptr_to_fixed_const_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedConstArray"
                 }
             },
@@ -3726,6 +3832,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "getPtrToDynamicConstArray",
                     "F_name_api": "get_ptr_to_dynamic_const_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicConstArray"
                 }
             },
@@ -3842,6 +3953,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getRawPtrToScalar",
                     "F_name_api": "get_raw_ptr_to_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalar"
                 }
             },
@@ -3961,6 +4076,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getRawPtrToScalarForce",
                     "F_name_api": "get_raw_ptr_to_scalar_force",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalarForce"
                 }
             },
@@ -4077,6 +4196,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getRawPtrToFixedArray",
                     "F_name_api": "get_raw_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArray"
                 }
             },
@@ -4196,6 +4319,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getRawPtrToFixedArrayForce",
                     "F_name_api": "get_raw_ptr_to_fixed_array_force",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArrayForce"
                 }
             },
@@ -4316,6 +4443,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getRawPtrToInt2d",
                     "F_name_api": "get_raw_ptr_to_int2d",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "getRawPtrToInt2d"
                 }
             },
@@ -4446,6 +4577,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "checkInt2d",
                     "F_name_api": "check_int2d",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
                     "function_name": "checkInt2d"
                 }
             },
@@ -4582,6 +4717,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "DimensionIn",
                     "F_name_api": "dimension_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
                     "function_name": "DimensionIn"
                 }
             },
@@ -4715,6 +4854,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "getAllocToFixedArray",
                     "F_name_api": "get_alloc_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
                     "function_name": "getAllocToFixedArray"
                 }
             },
@@ -4837,6 +4980,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnAddress1",
                     "F_name_api": "return_address1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress1"
                 }
             },
@@ -4961,6 +5108,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnAddress2",
                     "F_name_api": "return_address2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress2"
                 }
             },
@@ -5073,6 +5224,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "fetchVoidPtr",
                     "F_name_api": "fetch_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "addr"
+                    ],
                     "function_name": "fetchVoidPtr"
                 }
             },
@@ -5188,6 +5343,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "updateVoidPtr",
                     "F_name_api": "update_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "addr"
+                    ],
                     "function_name": "updateVoidPtr"
                 }
             },
@@ -5318,6 +5477,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "VoidPtrArray",
                     "F_name_api": "void_ptr_array",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "addr"
+                    ],
                     "function_name": "VoidPtrArray"
                 }
             },
@@ -5390,6 +5553,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntPtrToScalar",
                     "F_name_api": "return_int_ptr_to_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntPtrToScalar"
                 }
             },
@@ -5479,6 +5645,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntPtrToFixedArray",
                     "F_name_api": "return_int_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedArray"
                 }
             },
@@ -5552,6 +5721,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntPtrToConstScalar",
                     "F_name_api": "return_int_ptr_to_const_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntPtrToConstScalar"
                 }
             },
@@ -5642,6 +5814,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntPtrToFixedConstArray",
                     "F_name_api": "return_int_ptr_to_fixed_const_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedConstArray"
                 }
             },
@@ -5717,6 +5892,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntScalar",
                     "F_name_api": "return_int_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntScalar"
                 }
             },
@@ -5797,6 +5975,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntRaw",
                     "F_name_api": "return_int_raw",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntRaw"
                 }
             },
@@ -5930,6 +6111,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntRawWithArgs",
                     "F_name_api": "return_int_raw_with_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "name"
+                    ],
                     "function_name": "returnIntRawWithArgs"
                 }
             },
@@ -6011,6 +6196,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnRawPtrToInt2d",
                     "F_name_api": "return_raw_ptr_to_int2d",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnRawPtrToInt2d"
                 }
             },
@@ -6103,6 +6291,9 @@
                 "zz_fmtdict": {
                     "C_name_api": "returnIntAllocToFixedArray",
                     "F_name_api": "return_int_alloc_to_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
                     "function_name": "returnIntAllocToFixedArray"
                 }
             }

--- a/regression/reference/pointers-cxx-f/pointers.json
+++ b/regression/reference/pointers-cxx-f/pointers.json
@@ -136,6 +136,10 @@
                     "F_name_function": "intargs_in",
                     "F_name_generic": "intargs_in",
                     "F_name_impl": "intargs_in",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_in"
                 }
             },
@@ -264,6 +268,10 @@
                     "F_name_function": "intargs_inout",
                     "F_name_generic": "intargs_inout",
                     "F_name_impl": "intargs_inout",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_inout"
                 }
             },
@@ -392,6 +400,10 @@
                     "F_name_function": "intargs_out",
                     "F_name_generic": "intargs_out",
                     "F_name_impl": "intargs_out",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_out"
                 }
             },
@@ -643,6 +655,12 @@
                     "F_name_function": "intargs",
                     "F_name_generic": "intargs",
                     "F_name_impl": "intargs",
+                    "f_arglist": [
+                        "f_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
                     "function_name": "intargs"
                 }
             },
@@ -935,6 +953,12 @@
                     "F_name_function": "cos_doubles",
                     "F_name_generic": "cos_doubles",
                     "F_name_impl": "cos_doubles",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "cos_doubles"
                 }
             },
@@ -1227,6 +1251,12 @@
                     "F_name_function": "truncate_to_int",
                     "F_name_generic": "truncate_to_int",
                     "F_name_impl": "truncate_to_int",
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "truncate_to_int"
                 }
             },
@@ -1440,6 +1470,11 @@
                     "F_name_function": "get_values",
                     "F_name_generic": "get_values",
                     "F_name_impl": "get_values",
+                    "f_arglist": [
+                        "f_var",
+                        "nvalues",
+                        "values"
+                    ],
                     "function_name": "get_values"
                 }
             },
@@ -1672,6 +1707,11 @@
                     "F_name_function": "get_values2",
                     "F_name_generic": "get_values2",
                     "F_name_impl": "get_values2",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "get_values2"
                 }
             },
@@ -1876,6 +1916,11 @@
                     "F_name_function": "iota_dimension",
                     "F_name_generic": "iota_dimension",
                     "F_name_impl": "iota_dimension",
+                    "f_arglist": [
+                        "f_var",
+                        "nvar",
+                        "values"
+                    ],
                     "function_name": "iota_dimension"
                 }
             },
@@ -2137,6 +2182,12 @@
                     "F_name_function": "sum",
                     "F_name_generic": "sum",
                     "F_name_impl": "sum",
+                    "f_arglist": [
+                        "f_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
                     "function_name": "Sum"
                 }
             },
@@ -2287,6 +2338,10 @@
                     "F_name_function": "fill_int_array",
                     "F_name_generic": "fill_int_array",
                     "F_name_impl": "fill_int_array",
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "fillIntArray"
                 }
             },
@@ -2487,6 +2542,11 @@
                     "F_name_function": "increment_int_array",
                     "F_name_generic": "increment_int_array",
                     "F_name_impl": "increment_int_array",
+                    "f_arglist": [
+                        "f_var",
+                        "array",
+                        "sizein"
+                    ],
                     "function_name": "incrementIntArray"
                 }
             },
@@ -2683,6 +2743,11 @@
                     "F_name_function": "fill_with_zeros",
                     "F_name_generic": "fill_with_zeros",
                     "F_name_impl": "fill_with_zeros",
+                    "f_arglist": [
+                        "f_var",
+                        "x",
+                        "x_length"
+                    ],
                     "function_name": "fill_with_zeros"
                 }
             },
@@ -2906,6 +2971,11 @@
                     "F_name_function": "accumulate",
                     "F_name_generic": "accumulate",
                     "F_name_impl": "accumulate",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arr",
+                        "len"
+                    ],
                     "function_name": "accumulate"
                 }
             },
@@ -3086,6 +3156,10 @@
                     "F_name_function": "accept_char_array_in",
                     "F_name_generic": "accept_char_array_in",
                     "F_name_impl": "accept_char_array_in",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "names"
+                    ],
                     "function_name": "acceptCharArrayIn"
                 }
             },
@@ -3209,6 +3283,10 @@
                     "F_name_function": "set_global_int",
                     "F_name_generic": "set_global_int",
                     "F_name_impl": "set_global_int",
+                    "f_arglist": [
+                        "f_var",
+                        "value"
+                    ],
                     "function_name": "setGlobalInt"
                 }
             },
@@ -3301,6 +3379,9 @@
                     "F_name_function": "sum_fixed_array",
                     "F_name_generic": "sum_fixed_array",
                     "F_name_impl": "sum_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "sumFixedArray"
                 }
             },
@@ -3450,6 +3531,10 @@
                     "F_name_function": "get_ptr_to_scalar",
                     "F_name_generic": "get_ptr_to_scalar",
                     "F_name_impl": "get_ptr_to_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToScalar"
                 }
             },
@@ -3623,6 +3708,10 @@
                     "F_name_function": "get_ptr_to_fixed_array",
                     "F_name_generic": "get_ptr_to_fixed_array",
                     "F_name_impl": "get_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedArray"
                 }
             },
@@ -3859,6 +3948,11 @@
                     "F_name_function": "get_ptr_to_dynamic_array",
                     "F_name_generic": "get_ptr_to_dynamic_array",
                     "F_name_impl": "get_ptr_to_dynamic_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicArray"
                 }
             },
@@ -4034,6 +4128,10 @@
                     "F_name_function": "get_ptr_to_func_array",
                     "F_name_generic": "get_ptr_to_func_array",
                     "F_name_impl": "get_ptr_to_func_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFuncArray"
                 }
             },
@@ -4184,6 +4282,10 @@
                     "F_name_function": "get_ptr_to_const_scalar",
                     "F_name_generic": "get_ptr_to_const_scalar",
                     "F_name_impl": "get_ptr_to_const_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToConstScalar"
                 }
             },
@@ -4355,6 +4457,10 @@
                     "F_name_function": "get_ptr_to_fixed_const_array",
                     "F_name_generic": "get_ptr_to_fixed_const_array",
                     "F_name_impl": "get_ptr_to_fixed_const_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedConstArray"
                 }
             },
@@ -4589,6 +4695,11 @@
                     "F_name_function": "get_ptr_to_dynamic_const_array",
                     "F_name_generic": "get_ptr_to_dynamic_const_array",
                     "F_name_impl": "get_ptr_to_dynamic_const_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicConstArray"
                 }
             },
@@ -4725,6 +4836,10 @@
                     "F_name_function": "get_raw_ptr_to_scalar",
                     "F_name_generic": "get_raw_ptr_to_scalar",
                     "F_name_impl": "get_raw_ptr_to_scalar",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalar"
                 }
             },
@@ -4864,6 +4979,10 @@
                     "F_name_function": "get_raw_ptr_to_scalar_force",
                     "F_name_generic": "get_raw_ptr_to_scalar_force",
                     "F_name_impl": "get_raw_ptr_to_scalar_force",
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalarForce"
                 }
             },
@@ -5000,6 +5119,10 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array",
                     "F_name_generic": "get_raw_ptr_to_fixed_array",
                     "F_name_impl": "get_raw_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArray"
                 }
             },
@@ -5139,6 +5262,10 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array_force",
                     "F_name_generic": "get_raw_ptr_to_fixed_array_force",
                     "F_name_impl": "get_raw_ptr_to_fixed_array_force",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArrayForce"
                 }
             },
@@ -5278,6 +5405,10 @@
                     "F_name_function": "get_raw_ptr_to_int2d",
                     "F_name_generic": "get_raw_ptr_to_int2d",
                     "F_name_impl": "get_raw_ptr_to_int2d",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "getRawPtrToInt2d"
                 }
             },
@@ -5440,6 +5571,10 @@
                     "F_name_function": "check_int2d",
                     "F_name_generic": "check_int2d",
                     "F_name_impl": "check_int2d",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "checkInt2d"
                 }
             },
@@ -5599,6 +5734,10 @@
                     "F_name_function": "dimension_in",
                     "F_name_generic": "dimension_in",
                     "F_name_impl": "dimension_in",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "DimensionIn"
                 }
             },
@@ -5785,6 +5924,10 @@
                     "F_name_function": "get_alloc_to_fixed_array",
                     "F_name_generic": "get_alloc_to_fixed_array",
                     "F_name_impl": "get_alloc_to_fixed_array",
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getAllocToFixedArray"
                 }
             },
@@ -5939,6 +6082,10 @@
                     "F_name_function": "return_address1",
                     "F_name_generic": "return_address1",
                     "F_name_impl": "return_address1",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress1"
                 }
             },
@@ -6095,6 +6242,10 @@
                     "F_name_function": "return_address2",
                     "F_name_generic": "return_address2",
                     "F_name_impl": "return_address2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress2"
                 }
             },
@@ -6226,6 +6377,10 @@
                     "F_name_function": "fetch_void_ptr",
                     "F_name_generic": "fetch_void_ptr",
                     "F_name_impl": "fetch_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "fetchVoidPtr"
                 }
             },
@@ -6360,6 +6515,10 @@
                     "F_name_function": "update_void_ptr",
                     "F_name_generic": "update_void_ptr",
                     "F_name_impl": "update_void_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "updateVoidPtr"
                 }
             },
@@ -6527,6 +6686,10 @@
                     "F_name_function": "void_ptr_array",
                     "F_name_generic": "void_ptr_array",
                     "F_name_impl": "void_ptr_array",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr"
+                    ],
                     "function_name": "VoidPtrArray"
                 }
             },
@@ -6623,6 +6786,9 @@
                     "F_name_function": "return_int_ptr_to_scalar",
                     "F_name_generic": "return_int_ptr_to_scalar",
                     "F_name_impl": "return_int_ptr_to_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToScalar"
                 }
             },
@@ -6756,6 +6922,9 @@
                     "F_name_function": "return_int_ptr_to_fixed_array",
                     "F_name_generic": "return_int_ptr_to_fixed_array",
                     "F_name_impl": "return_int_ptr_to_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedArray"
                 }
             },
@@ -6853,6 +7022,9 @@
                     "F_name_function": "return_int_ptr_to_const_scalar",
                     "F_name_generic": "return_int_ptr_to_const_scalar",
                     "F_name_impl": "return_int_ptr_to_const_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToConstScalar"
                 }
             },
@@ -6987,6 +7159,9 @@
                     "F_name_function": "return_int_ptr_to_fixed_const_array",
                     "F_name_generic": "return_int_ptr_to_fixed_const_array",
                     "F_name_impl": "return_int_ptr_to_fixed_const_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedConstArray"
                 }
             },
@@ -7084,6 +7259,9 @@
                     "F_name_function": "return_int_scalar",
                     "F_name_generic": "return_int_scalar",
                     "F_name_impl": "return_int_scalar",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntScalar"
                 }
             },
@@ -7187,6 +7365,9 @@
                     "F_name_function": "return_int_raw",
                     "F_name_generic": "return_int_raw",
                     "F_name_impl": "return_int_raw",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntRaw"
                 }
             },
@@ -7353,6 +7534,10 @@
                     "F_name_function": "return_int_raw_with_args",
                     "F_name_generic": "return_int_raw_with_args",
                     "F_name_impl": "return_int_raw_with_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "name"
+                    ],
                     "function_name": "returnIntRawWithArgs"
                 }
             },
@@ -7456,6 +7641,9 @@
                     "F_name_function": "return_raw_ptr_to_int2d",
                     "F_name_generic": "return_raw_ptr_to_int2d",
                     "F_name_impl": "return_raw_ptr_to_int2d",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnRawPtrToInt2d"
                 }
             },
@@ -7602,6 +7790,9 @@
                     "F_name_function": "return_int_alloc_to_fixed_array",
                     "F_name_generic": "return_int_alloc_to_fixed_array",
                     "F_name_impl": "return_int_alloc_to_fixed_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntAllocToFixedArray"
                 }
             }

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -184,6 +184,14 @@
                     "F_name_function": "intargs_in",
                     "F_name_generic": "intargs_in",
                     "F_name_impl": "intargs_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_in"
                 }
             },
@@ -360,6 +368,14 @@
                     "F_name_function": "intargs_inout",
                     "F_name_generic": "intargs_inout",
                     "F_name_impl": "intargs_inout",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_inout"
                 }
             },
@@ -536,6 +552,14 @@
                     "F_name_function": "intargs_out",
                     "F_name_generic": "intargs_out",
                     "F_name_impl": "intargs_out",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "intargs_out"
                 }
             },
@@ -895,6 +919,18 @@
                     "F_name_function": "intargs",
                     "F_name_generic": "intargs",
                     "F_name_impl": "intargs",
+                    "c_arglist": [
+                        "c_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "argin",
+                        "arginout",
+                        "argout"
+                    ],
                     "function_name": "intargs"
                 }
             },
@@ -1309,6 +1345,18 @@
                     "F_name_function": "cos_doubles",
                     "F_name_generic": "cos_doubles",
                     "F_name_impl": "cos_doubles",
+                    "c_arglist": [
+                        "c_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "cos_doubles"
                 }
             },
@@ -1723,6 +1771,18 @@
                     "F_name_function": "truncate_to_int",
                     "F_name_generic": "truncate_to_int",
                     "F_name_impl": "truncate_to_int",
+                    "c_arglist": [
+                        "c_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "in",
+                        "out",
+                        "sizein"
+                    ],
                     "function_name": "truncate_to_int"
                 }
             },
@@ -2021,6 +2081,16 @@
                     "F_name_function": "get_values",
                     "F_name_generic": "get_values",
                     "F_name_impl": "get_values",
+                    "c_arglist": [
+                        "c_var",
+                        "nvalues",
+                        "values"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nvalues",
+                        "values"
+                    ],
                     "function_name": "get_values"
                 }
             },
@@ -2346,6 +2416,16 @@
                     "F_name_function": "get_values2",
                     "F_name_generic": "get_values2",
                     "F_name_impl": "get_values2",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "get_values2"
                 }
             },
@@ -2637,6 +2717,16 @@
                     "F_name_function": "iota_dimension",
                     "F_name_generic": "iota_dimension",
                     "F_name_impl": "iota_dimension",
+                    "c_arglist": [
+                        "c_var",
+                        "nvar",
+                        "values"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nvar",
+                        "values"
+                    ],
                     "function_name": "iota_dimension"
                 }
             },
@@ -3007,6 +3097,18 @@
                     "F_name_function": "sum",
                     "F_name_generic": "sum",
                     "F_name_impl": "sum",
+                    "c_arglist": [
+                        "c_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "len",
+                        "values",
+                        "result"
+                    ],
                     "function_name": "Sum"
                 }
             },
@@ -3213,6 +3315,14 @@
                     "F_name_function": "fill_int_array",
                     "F_name_generic": "fill_int_array",
                     "F_name_impl": "fill_int_array",
+                    "c_arglist": [
+                        "c_var",
+                        "out"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "out"
+                    ],
                     "function_name": "fillIntArray"
                 }
             },
@@ -3493,6 +3603,16 @@
                     "F_name_function": "increment_int_array",
                     "F_name_generic": "increment_int_array",
                     "F_name_impl": "increment_int_array",
+                    "c_arglist": [
+                        "c_var",
+                        "array",
+                        "sizein"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "array",
+                        "sizein"
+                    ],
                     "function_name": "incrementIntArray"
                 }
             },
@@ -3769,6 +3889,16 @@
                     "F_name_function": "fill_with_zeros",
                     "F_name_generic": "fill_with_zeros",
                     "F_name_impl": "fill_with_zeros",
+                    "c_arglist": [
+                        "c_var",
+                        "x",
+                        "x_length"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "x",
+                        "x_length"
+                    ],
                     "function_name": "fill_with_zeros"
                 }
             },
@@ -4085,6 +4215,16 @@
                     "F_name_function": "accumulate",
                     "F_name_generic": "accumulate",
                     "F_name_impl": "accumulate",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arr",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arr",
+                        "len"
+                    ],
                     "function_name": "accumulate"
                 }
             },
@@ -4352,6 +4492,14 @@
                     "F_name_function": "accept_char_array_in",
                     "F_name_generic": "accept_char_array_in",
                     "F_name_impl": "accept_char_array_in",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "names"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "names"
+                    ],
                     "function_name": "acceptCharArrayIn"
                 }
             },
@@ -4525,6 +4673,14 @@
                     "F_name_function": "set_global_int",
                     "F_name_generic": "set_global_int",
                     "F_name_impl": "set_global_int",
+                    "c_arglist": [
+                        "c_var",
+                        "value"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "value"
+                    ],
                     "function_name": "setGlobalInt"
                 }
             },
@@ -4648,6 +4804,12 @@
                     "F_name_function": "sum_fixed_array",
                     "F_name_generic": "sum_fixed_array",
                     "F_name_impl": "sum_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "sumFixedArray"
                 }
             },
@@ -4856,6 +5018,14 @@
                     "F_name_function": "get_ptr_to_scalar",
                     "F_name_generic": "get_ptr_to_scalar",
                     "F_name_impl": "get_ptr_to_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToScalar"
                 }
             },
@@ -5100,6 +5270,14 @@
                     "F_name_function": "get_ptr_to_fixed_array",
                     "F_name_generic": "get_ptr_to_fixed_array",
                     "F_name_impl": "get_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedArray"
                 }
             },
@@ -5444,6 +5622,16 @@
                     "F_name_function": "get_ptr_to_dynamic_array",
                     "F_name_generic": "get_ptr_to_dynamic_array",
                     "F_name_impl": "get_ptr_to_dynamic_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "ncount"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicArray"
                 }
             },
@@ -5691,6 +5879,14 @@
                     "F_name_function": "get_ptr_to_func_array",
                     "F_name_generic": "get_ptr_to_func_array",
                     "F_name_impl": "get_ptr_to_func_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFuncArray"
                 }
             },
@@ -5900,6 +6096,14 @@
                     "F_name_function": "get_ptr_to_const_scalar",
                     "F_name_generic": "get_ptr_to_const_scalar",
                     "F_name_impl": "get_ptr_to_const_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getPtrToConstScalar"
                 }
             },
@@ -6142,6 +6346,14 @@
                     "F_name_function": "get_ptr_to_fixed_const_array",
                     "F_name_generic": "get_ptr_to_fixed_const_array",
                     "F_name_impl": "get_ptr_to_fixed_const_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getPtrToFixedConstArray"
                 }
             },
@@ -6484,6 +6696,16 @@
                     "F_name_function": "get_ptr_to_dynamic_const_array",
                     "F_name_generic": "get_ptr_to_dynamic_const_array",
                     "F_name_impl": "get_ptr_to_dynamic_const_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "ncount"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "ncount"
+                    ],
                     "function_name": "getPtrToDynamicConstArray"
                 }
             },
@@ -6668,6 +6890,14 @@
                     "F_name_function": "get_raw_ptr_to_scalar",
                     "F_name_generic": "get_raw_ptr_to_scalar",
                     "F_name_impl": "get_raw_ptr_to_scalar",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalar"
                 }
             },
@@ -6855,6 +7085,14 @@
                     "F_name_function": "get_raw_ptr_to_scalar_force",
                     "F_name_generic": "get_raw_ptr_to_scalar_force",
                     "F_name_impl": "get_raw_ptr_to_scalar_force",
+                    "c_arglist": [
+                        "c_var",
+                        "nitems"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "nitems"
+                    ],
                     "function_name": "getRawPtrToScalarForce"
                 }
             },
@@ -7039,6 +7277,14 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array",
                     "F_name_generic": "get_raw_ptr_to_fixed_array",
                     "F_name_impl": "get_raw_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArray"
                 }
             },
@@ -7226,6 +7472,14 @@
                     "F_name_function": "get_raw_ptr_to_fixed_array_force",
                     "F_name_generic": "get_raw_ptr_to_fixed_array_force",
                     "F_name_impl": "get_raw_ptr_to_fixed_array_force",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getRawPtrToFixedArrayForce"
                 }
             },
@@ -7413,6 +7667,14 @@
                     "F_name_function": "get_raw_ptr_to_int2d",
                     "F_name_generic": "get_raw_ptr_to_int2d",
                     "F_name_impl": "get_raw_ptr_to_int2d",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "getRawPtrToInt2d"
                 }
             },
@@ -7636,6 +7898,14 @@
                     "F_name_function": "check_int2d",
                     "F_name_generic": "check_int2d",
                     "F_name_impl": "check_int2d",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "checkInt2d"
                 }
             },
@@ -7854,6 +8124,14 @@
                     "F_name_function": "dimension_in",
                     "F_name_generic": "dimension_in",
                     "F_name_impl": "dimension_in",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "DimensionIn"
                 }
             },
@@ -8111,6 +8389,14 @@
                     "F_name_function": "get_alloc_to_fixed_array",
                     "F_name_generic": "get_alloc_to_fixed_array",
                     "F_name_impl": "get_alloc_to_fixed_array",
+                    "c_arglist": [
+                        "c_var",
+                        "count"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count"
+                    ],
                     "function_name": "getAllocToFixedArray"
                 }
             },
@@ -8328,6 +8614,14 @@
                     "F_name_function": "return_address1",
                     "F_name_generic": "return_address1",
                     "F_name_impl": "return_address1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress1"
                 }
             },
@@ -8547,6 +8841,14 @@
                     "F_name_function": "return_address2",
                     "F_name_generic": "return_address2",
                     "F_name_impl": "return_address2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnAddress2"
                 }
             },
@@ -8726,6 +9028,14 @@
                     "F_name_function": "fetch_void_ptr",
                     "F_name_generic": "fetch_void_ptr",
                     "F_name_impl": "fetch_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "addr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "fetchVoidPtr"
                 }
             },
@@ -8908,6 +9218,14 @@
                     "F_name_function": "update_void_ptr",
                     "F_name_generic": "update_void_ptr",
                     "F_name_impl": "update_void_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "addr"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "addr"
+                    ],
                     "function_name": "updateVoidPtr"
                 }
             },
@@ -9137,6 +9455,14 @@
                     "F_name_function": "void_ptr_array",
                     "F_name_generic": "void_ptr_array",
                     "F_name_impl": "void_ptr_array",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "addr"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr"
+                    ],
                     "function_name": "VoidPtrArray"
                 }
             },
@@ -9278,6 +9604,12 @@
                     "F_name_function": "return_int_ptr_to_scalar",
                     "F_name_generic": "return_int_ptr_to_scalar",
                     "F_name_impl": "return_int_ptr_to_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToScalar"
                 }
             },
@@ -9468,6 +9800,12 @@
                     "F_name_function": "return_int_ptr_to_fixed_array",
                     "F_name_generic": "return_int_ptr_to_fixed_array",
                     "F_name_impl": "return_int_ptr_to_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedArray"
                 }
             },
@@ -9610,6 +9948,12 @@
                     "F_name_function": "return_int_ptr_to_const_scalar",
                     "F_name_generic": "return_int_ptr_to_const_scalar",
                     "F_name_impl": "return_int_ptr_to_const_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToConstScalar"
                 }
             },
@@ -9801,6 +10145,12 @@
                     "F_name_function": "return_int_ptr_to_fixed_const_array",
                     "F_name_generic": "return_int_ptr_to_fixed_const_array",
                     "F_name_impl": "return_int_ptr_to_fixed_const_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntPtrToFixedConstArray"
                 }
             },
@@ -9943,6 +10293,12 @@
                     "F_name_function": "return_int_scalar",
                     "F_name_generic": "return_int_scalar",
                     "F_name_impl": "return_int_scalar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntScalar"
                 }
             },
@@ -10077,6 +10433,12 @@
                     "F_name_function": "return_int_raw",
                     "F_name_generic": "return_int_raw",
                     "F_name_impl": "return_int_raw",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntRaw"
                 }
             },
@@ -10304,6 +10666,14 @@
                     "F_name_function": "return_int_raw_with_args",
                     "F_name_generic": "return_int_raw_with_args",
                     "F_name_impl": "return_int_raw_with_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "name"
+                    ],
                     "function_name": "returnIntRawWithArgs"
                 }
             },
@@ -10438,6 +10808,12 @@
                     "F_name_function": "return_raw_ptr_to_int2d",
                     "F_name_generic": "return_raw_ptr_to_int2d",
                     "F_name_impl": "return_raw_ptr_to_int2d",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnRawPtrToInt2d"
                 }
             },
@@ -10641,6 +11017,12 @@
                     "F_name_function": "return_int_alloc_to_fixed_array",
                     "F_name_generic": "return_int_alloc_to_fixed_array",
                     "F_name_impl": "return_int_alloc_to_fixed_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnIntAllocToFixedArray"
                 }
             }

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -103,10 +103,16 @@
                             "F_name_generic": "method1",
                             "F_name_impl": "user1_method1",
                             "PY_name_impl": "PY_method1",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "method1"
                         },
@@ -215,10 +221,16 @@
                             "F_name_generic": "method2",
                             "F_name_impl": "user1_method2",
                             "PY_name_impl": "PY_method2",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "method2"
                         },
@@ -319,10 +331,16 @@
                             "F_name_function": "method3def_0",
                             "F_name_generic": "method3def",
                             "F_name_impl": "user1_method3def_0",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "method3def",
                             "function_suffix": "_0"
@@ -548,10 +566,18 @@
                             "F_name_impl": "user1_method3def_1",
                             "PY_cleanup_decref": "Py_XDECREF",
                             "PY_name_impl": "PY_method3def_1",
+                            "c_arglist": [
+                                "self",
+                                "i"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "i"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "method3def",
                             "function_suffix": "_1"
@@ -709,10 +735,16 @@
                             "F_name_generic": "exfunc",
                             "F_name_impl": "user2_exfunc_0",
                             "PY_name_impl": "PY_exfunc_0",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "exfunc",
                             "function_suffix": "_0"
@@ -939,10 +971,18 @@
                             "F_name_generic": "exfunc",
                             "F_name_impl": "user2_exfunc_1",
                             "PY_name_impl": "PY_exfunc_1",
+                            "c_arglist": [
+                                "self",
+                                "flag"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "flag"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "exfunc",
                             "function_suffix": "_1"

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -735,6 +735,10 @@
                     "F_name_function": "data_pointer_get_items",
                     "F_name_generic": "data_pointer_get_items",
                     "F_name_impl": "data_pointer_get_items",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "items",
                     "function_name": "DataPointer_get_items",
                     "struct_name": "DataPointer",
@@ -945,6 +949,11 @@
                     "F_name_function": "data_pointer_set_items",
                     "F_name_generic": "data_pointer_set_items",
                     "F_name_impl": "data_pointer_set_items",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "items",
                     "function_name": "DataPointer_set_items",
                     "struct_name": "DataPointer",
@@ -1350,6 +1359,10 @@
                             "F_name_function": "data_pointer_get_items",
                             "F_name_generic": "data_pointer_get_items",
                             "F_name_impl": "data_pointer_get_items",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "SH_this"
+                            ],
                             "field_name": "items",
                             "function_name": "DataPointer_get_items",
                             "struct_name": "DataPointer",
@@ -1560,6 +1573,11 @@
                             "F_name_function": "data_pointer_set_items",
                             "F_name_generic": "data_pointer_set_items",
                             "F_name_impl": "data_pointer_set_items",
+                            "f_arglist": [
+                                "f_var",
+                                "SH_this",
+                                "val"
+                            ],
                             "field_name": "items",
                             "function_name": "DataPointer_set_items",
                             "struct_name": "DataPointer",
@@ -1992,6 +2010,10 @@
                             "F_name_function": "data_pointer_get_items",
                             "F_name_generic": "data_pointer_get_items",
                             "F_name_impl": "data_pointer_get_items",
+                            "f_arglist": [
+                                "SHT_rv",
+                                "SH_this"
+                            ],
                             "field_name": "items",
                             "function_name": "DataPointer_get_items",
                             "struct_name": "DataPointer",
@@ -2202,6 +2224,11 @@
                             "F_name_function": "data_pointer_set_items",
                             "F_name_generic": "data_pointer_set_items",
                             "F_name_impl": "data_pointer_set_items",
+                            "f_arglist": [
+                                "f_var",
+                                "SH_this",
+                                "val"
+                            ],
                             "field_name": "items",
                             "function_name": "DataPointer_set_items",
                             "struct_name": "DataPointer",

--- a/regression/reference/sgroup/sgroup.json
+++ b/regression/reference/sgroup/sgroup.json
@@ -205,6 +205,10 @@
                     "F_name_function": "process_twostruct",
                     "F_name_generic": "process_twostruct",
                     "F_name_impl": "process_twostruct",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "process_twostruct"
                 }
             }

--- a/regression/reference/shared/shared.json
+++ b/regression/reference/shared/shared.json
@@ -155,6 +155,12 @@
                             "F_name_function": "ctor",
                             "F_name_generic": "object",
                             "F_name_impl": "object_ctor",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         }
@@ -240,10 +246,16 @@
                             "F_name_function": "dtor",
                             "F_name_generic": "dtor",
                             "F_name_impl": "object_dtor",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "dtor"
                         }
@@ -422,10 +434,16 @@
                             "F_name_function": "create_child_a",
                             "F_name_generic": "create_child_a",
                             "F_name_impl": "object_create_child_a",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "createChildA"
                         }
@@ -604,10 +622,16 @@
                             "F_name_function": "create_child_b",
                             "F_name_generic": "create_child_b",
                             "F_name_impl": "object_create_child_b",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "createChildB"
                         }
@@ -812,10 +836,18 @@
                             "F_name_function": "replace_child_b",
                             "F_name_generic": "replace_child_b",
                             "F_name_impl": "object_replace_child_b",
+                            "c_arglist": [
+                                "self",
+                                "child"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "child"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "replaceChildB"
                         }
@@ -1021,6 +1053,12 @@
                             "F_name_function": "ctor",
                             "F_name_generic": "object_shared",
                             "F_name_impl": "object_shared_ctor",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         }
@@ -1109,10 +1147,16 @@
                             "F_name_function": "dtor",
                             "F_name_generic": "dtor",
                             "F_name_impl": "object_shared_dtor",
+                            "c_arglist": [
+                                "self"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "dtor"
                         }
@@ -1292,10 +1336,16 @@
                             "F_name_function": "create_child_a",
                             "F_name_generic": "create_child_a",
                             "F_name_impl": "object_shared_create_child_a",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "createChildA"
                         }
@@ -1475,10 +1525,16 @@
                             "F_name_function": "create_child_b",
                             "F_name_generic": "create_child_b",
                             "F_name_impl": "object_shared_create_child_b",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "createChildB"
                         }
@@ -1684,10 +1740,18 @@
                             "F_name_function": "replace_child_b",
                             "F_name_generic": "replace_child_b",
                             "F_name_impl": "object_shared_replace_child_b",
+                            "c_arglist": [
+                                "self",
+                                "child"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "child"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "replaceChildB"
                         }
@@ -1815,10 +1879,16 @@
                             "F_name_function": "use_count",
                             "F_name_generic": "use_count",
                             "F_name_impl": "object_shared_use_count",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "use_count"
                         }
@@ -2086,10 +2156,18 @@
                             "F_name_function": "assign_weak",
                             "F_name_generic": "assign_weak",
                             "F_name_impl": "object_weak_assign_weak",
+                            "c_arglist": [
+                                "self",
+                                "from"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "from"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "assign_weak"
                         }
@@ -2217,10 +2295,16 @@
                             "F_name_function": "use_count",
                             "F_name_generic": "use_count",
                             "F_name_impl": "object_weak_use_count",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "use_count"
                         }

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -142,6 +142,12 @@
                     "F_name_function": "get_name_length",
                     "F_name_generic": "get_name_length",
                     "F_name_impl": "get_name_length",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "GetNameLength"
                 }
             },
@@ -305,6 +311,12 @@
                     "F_name_function": "get_name_error_pattern",
                     "F_name_generic": "get_name_error_pattern",
                     "F_name_impl": "get_name_error_pattern",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getNameErrorPattern"
                 }
             },
@@ -515,6 +527,14 @@
                     "F_name_function": "name_is_valid",
                     "F_name_generic": "name_is_valid",
                     "F_name_impl": "name_is_valid",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "name"
+                    ],
                     "function_name": "nameIsValid"
                 }
             }

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -95,6 +95,12 @@
                     "F_name_function": "init_test",
                     "F_name_generic": "init_test",
                     "F_name_impl": "init_test",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "init_test"
                 }
             },
@@ -270,6 +276,14 @@
                     "F_name_function": "pass_char",
                     "F_name_generic": "pass_char",
                     "F_name_impl": "pass_char",
+                    "c_arglist": [
+                        "c_var",
+                        "status"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "status"
+                    ],
                     "function_name": "passChar"
                 }
             },
@@ -448,6 +462,14 @@
                     "F_name_function": "pass_char_force",
                     "F_name_generic": "pass_char_force",
                     "F_name_impl": "pass_char_force",
+                    "c_arglist": [
+                        "c_var",
+                        "status"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "status"
+                    ],
                     "function_name": "passCharForce"
                 }
             },
@@ -568,6 +590,12 @@
                     "F_name_function": "return_char",
                     "F_name_generic": "return_char",
                     "F_name_impl": "return_char",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnChar"
                 }
             },
@@ -877,6 +905,16 @@
                     "F_name_function": "pass_char_ptr",
                     "F_name_generic": "pass_char_ptr",
                     "F_name_impl": "pass_char_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "dest",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "dest",
+                        "src"
+                    ],
                     "function_name": "passCharPtr"
                 }
             },
@@ -1081,6 +1119,14 @@
                     "F_name_function": "pass_char_ptr_in_out",
                     "F_name_generic": "pass_char_ptr_in_out",
                     "F_name_impl": "pass_char_ptr_in_out",
+                    "c_arglist": [
+                        "c_var",
+                        "s"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "s"
+                    ],
                     "function_name": "passCharPtrInOut"
                 }
             },
@@ -1227,6 +1273,12 @@
                     "F_name_function": "get_char_ptr1",
                     "F_name_generic": "get_char_ptr1",
                     "F_name_impl": "get_char_ptr1",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr1"
                 }
             },
@@ -1391,6 +1443,12 @@
                     "F_name_function": "get_char_ptr2",
                     "F_name_generic": "get_char_ptr2",
                     "F_name_impl": "get_char_ptr2",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr2"
                 }
             },
@@ -1548,6 +1606,12 @@
                     "F_name_generic": "get_char_ptr3",
                     "F_name_impl": "get_char_ptr3",
                     "F_string_result_as_arg": "output",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "output"
+                    ],
                     "function_name": "getCharPtr3"
                 }
             },
@@ -1682,6 +1746,12 @@
                     "F_name_function": "get_char_ptr4",
                     "F_name_generic": "get_char_ptr4",
                     "F_name_impl": "get_char_ptr4",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr4"
                 }
             },
@@ -1841,6 +1911,12 @@
                     "F_name_function": "get_char_ptr5",
                     "F_name_generic": "get_char_ptr5",
                     "F_name_impl": "get_char_ptr5",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr5"
                 }
             },
@@ -1985,6 +2061,12 @@
                     "F_name_function": "get_const_string_result",
                     "F_name_generic": "get_const_string_result",
                     "F_name_impl": "get_const_string_result",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringResult"
                 }
             },
@@ -2147,6 +2229,12 @@
                     "F_name_function": "get_const_string_len",
                     "F_name_generic": "get_const_string_len",
                     "F_name_impl": "get_const_string_len",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringLen"
                 }
             },
@@ -2302,6 +2390,12 @@
                     "F_name_generic": "get_const_string_as_arg",
                     "F_name_impl": "get_const_string_as_arg",
                     "F_string_result_as_arg": "output",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "output"
+                    ],
                     "function_name": "getConstStringAsArg"
                 }
             },
@@ -2442,6 +2536,12 @@
                     "F_name_function": "get_const_string_alloc",
                     "F_name_generic": "get_const_string_alloc",
                     "F_name_impl": "get_const_string_alloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringAlloc"
                 }
             },
@@ -2591,6 +2691,12 @@
                     "F_name_function": "get_const_string_ref_pure",
                     "F_name_generic": "get_const_string_ref_pure",
                     "F_name_impl": "get_const_string_ref_pure",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefPure"
                 }
             },
@@ -2758,6 +2864,12 @@
                     "F_name_function": "get_const_string_ref_len",
                     "F_name_generic": "get_const_string_ref_len",
                     "F_name_impl": "get_const_string_ref_len",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefLen"
                 }
             },
@@ -2918,6 +3030,12 @@
                     "F_name_generic": "get_const_string_ref_as_arg",
                     "F_name_impl": "get_const_string_ref_as_arg",
                     "F_string_result_as_arg": "output",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "output"
+                    ],
                     "function_name": "getConstStringRefAsArg"
                 }
             },
@@ -3084,6 +3202,12 @@
                     "F_name_function": "get_const_string_ref_len_empty",
                     "F_name_generic": "get_const_string_ref_len_empty",
                     "F_name_impl": "get_const_string_ref_len_empty",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefLenEmpty"
                 }
             },
@@ -3228,6 +3352,12 @@
                     "F_name_function": "get_const_string_ref_alloc",
                     "F_name_generic": "get_const_string_ref_alloc",
                     "F_name_impl": "get_const_string_ref_alloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefAlloc"
                 }
             },
@@ -3402,6 +3532,12 @@
                     "F_name_function": "get_const_string_ptr_len",
                     "F_name_generic": "get_const_string_ptr_len",
                     "F_name_impl": "get_const_string_ptr_len",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrLen"
                 }
             },
@@ -3552,6 +3688,12 @@
                     "F_name_function": "get_const_string_ptr_alloc",
                     "F_name_generic": "get_const_string_ptr_alloc",
                     "F_name_impl": "get_const_string_ptr_alloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrAlloc"
                 }
             },
@@ -3705,6 +3847,12 @@
                     "F_name_function": "get_const_string_ptr_owns_alloc",
                     "F_name_generic": "get_const_string_ptr_owns_alloc",
                     "F_name_impl": "get_const_string_ptr_owns_alloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrOwnsAlloc"
                 }
             },
@@ -3862,6 +4010,12 @@
                     "F_name_function": "get_const_string_ptr_owns_alloc_pattern",
                     "F_name_generic": "get_const_string_ptr_owns_alloc_pattern",
                     "F_name_impl": "get_const_string_ptr_owns_alloc_pattern",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrOwnsAllocPattern"
                 }
             },
@@ -4025,6 +4179,12 @@
                     "F_name_function": "get_const_string_ptr_pointer",
                     "F_name_generic": "get_const_string_ptr_pointer",
                     "F_name_impl": "get_const_string_ptr_pointer",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrPointer"
                 }
             },
@@ -4227,6 +4387,14 @@
                     "F_name_function": "accept_string_const_reference",
                     "F_name_generic": "accept_string_const_reference",
                     "F_name_impl": "accept_string_const_reference",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringConstReference"
                 }
             },
@@ -4429,6 +4597,14 @@
                     "F_name_function": "accept_string_reference_out",
                     "F_name_generic": "accept_string_reference_out",
                     "F_name_impl": "accept_string_reference_out",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringReferenceOut"
                 }
             },
@@ -4634,6 +4810,14 @@
                     "F_name_function": "accept_string_reference",
                     "F_name_generic": "accept_string_reference",
                     "F_name_impl": "accept_string_reference",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringReference"
                 }
             },
@@ -4835,6 +5019,14 @@
                     "F_name_function": "accept_string_pointer_const",
                     "F_name_generic": "accept_string_pointer_const",
                     "F_name_impl": "accept_string_pointer_const",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringPointerConst"
                 }
             },
@@ -5037,6 +5229,14 @@
                     "F_name_function": "accept_string_pointer",
                     "F_name_generic": "accept_string_pointer",
                     "F_name_impl": "accept_string_pointer",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringPointer"
                 }
             },
@@ -5239,6 +5439,14 @@
                     "F_name_function": "fetch_string_pointer",
                     "F_name_generic": "fetch_string_pointer",
                     "F_name_impl": "fetch_string_pointer",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "fetchStringPointer"
                 }
             },
@@ -5541,6 +5749,16 @@
                     "F_name_function": "accept_string_pointer_len",
                     "F_name_generic": "accept_string_pointer_len",
                     "F_name_impl": "accept_string_pointer_len",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "nlen"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "nlen"
+                    ],
                     "function_name": "acceptStringPointerLen"
                 }
             },
@@ -5842,6 +6060,16 @@
                     "F_name_function": "fetch_string_pointer_len",
                     "F_name_generic": "fetch_string_pointer_len",
                     "F_name_impl": "fetch_string_pointer_len",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "nlen"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "nlen"
+                    ],
                     "function_name": "fetchStringPointerLen"
                 }
             },
@@ -6085,6 +6313,14 @@
                     "F_name_function": "accept_string_instance",
                     "F_name_generic": "accept_string_instance",
                     "F_name_impl": "accept_string_instance",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringInstance"
                 }
             },
@@ -6502,6 +6738,16 @@
                     "F_name_function": "fetch_array_string_arg",
                     "F_name_generic": "fetch_array_string_arg",
                     "F_name_impl": "fetch_array_string_arg",
+                    "c_arglist": [
+                        "c_var",
+                        "strs",
+                        "nstrs"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "strs",
+                        "nstrs"
+                    ],
                     "function_name": "fetchArrayStringArg"
                 }
             },
@@ -6832,6 +7078,16 @@
                     "F_name_function": "fetch_array_string_alloc",
                     "F_name_generic": "fetch_array_string_alloc",
                     "F_name_impl": "fetch_array_string_alloc",
+                    "c_arglist": [
+                        "c_var",
+                        "strs",
+                        "nstrs"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "strs",
+                        "nstrs"
+                    ],
                     "function_name": "fetchArrayStringAlloc"
                 }
             },
@@ -7170,6 +7426,16 @@
                     "F_name_function": "fetch_array_string_alloc_len",
                     "F_name_generic": "fetch_array_string_alloc_len",
                     "F_name_impl": "fetch_array_string_alloc_len",
+                    "c_arglist": [
+                        "c_var",
+                        "strs",
+                        "nstrs"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "strs",
+                        "nstrs"
+                    ],
                     "function_name": "fetchArrayStringAllocLen"
                 }
             },
@@ -7439,6 +7705,14 @@
                     "F_name_function": "explicit1",
                     "F_name_generic": "explicit1",
                     "F_name_impl": "explicit1",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "explicit1"
                 }
             },
@@ -7646,6 +7920,14 @@
                     "F_name_function": "explicit2",
                     "F_name_generic": "explicit2",
                     "F_name_impl": "explicit2",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "explicit2"
                 }
             },
@@ -7823,6 +8105,14 @@
                     "F_name_function": "cpass_char",
                     "F_name_generic": "cpass_char",
                     "F_name_impl": "cpass_char",
+                    "c_arglist": [
+                        "c_var",
+                        "status"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "status"
+                    ],
                     "function_name": "CpassChar"
                 }
             },
@@ -7945,6 +8235,12 @@
                     "F_name_function": "creturn_char",
                     "F_name_generic": "creturn_char",
                     "F_name_impl": "creturn_char",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "CreturnChar"
                 }
             },
@@ -8258,6 +8554,16 @@
                     "F_name_function": "cpass_char_ptr",
                     "F_name_generic": "cpass_char_ptr",
                     "F_name_impl": "cpass_char_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "dest",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "dest",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtr"
                 }
             },
@@ -8567,6 +8873,16 @@
                     "F_name_function": "cpass_char_ptr_blank",
                     "F_name_generic": "cpass_char_ptr_blank",
                     "F_name_impl": "cpass_char_ptr_blank",
+                    "c_arglist": [
+                        "c_var",
+                        "dest",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "dest",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrBlank"
                 }
             },
@@ -8889,6 +9205,16 @@
                     "F_name_function": "post_declare",
                     "F_name_generic": "post_declare",
                     "F_name_impl": "post_declare",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "name"
+                    ],
                     "function_name": "PostDeclare"
                 }
             },
@@ -9141,6 +9467,14 @@
                     "F_name_function": "cpass_char_ptr_notrim",
                     "F_name_generic": "cpass_char_ptr_notrim",
                     "F_name_impl": "cpass_char_ptr_notrim",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrNotrim"
                 }
             },
@@ -9456,6 +9790,16 @@
                     "F_name_function": "cpass_char_ptr_capi",
                     "F_name_generic": "cpass_char_ptr_capi",
                     "F_name_impl": "cpass_char_ptr_capi",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "addr",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrCAPI"
                 }
             },
@@ -9806,6 +10150,16 @@
                     "F_name_function": "cpass_char_ptr_capi2",
                     "F_name_generic": "cpass_char_ptr_capi2",
                     "F_name_impl": "cpass_char_ptr_capi2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrCAPI2"
                 }
             }

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -109,6 +109,12 @@
                     "F_name_generic": "init_test",
                     "F_name_impl": "init_test",
                     "PY_name_impl": "PY_init_test",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "init_test"
                 },
                 "zz_fmtlang": {
@@ -334,6 +340,14 @@
                     "F_name_generic": "pass_char",
                     "F_name_impl": "pass_char",
                     "PY_name_impl": "PY_passChar",
+                    "c_arglist": [
+                        "c_var",
+                        "status"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "status"
+                    ],
                     "function_name": "passChar"
                 },
                 "zz_fmtlang": {
@@ -527,6 +541,14 @@
                     "F_name_function": "pass_char_force",
                     "F_name_generic": "pass_char_force",
                     "F_name_impl": "pass_char_force",
+                    "c_arglist": [
+                        "c_var",
+                        "status"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "status"
+                    ],
                     "function_name": "passCharForce"
                 }
             },
@@ -673,6 +695,12 @@
                     "F_name_generic": "return_char",
                     "F_name_impl": "return_char",
                     "PY_name_impl": "PY_returnChar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnChar"
                 },
                 "zz_fmtlang": {
@@ -1050,6 +1078,16 @@
                     "F_name_generic": "pass_char_ptr",
                     "F_name_impl": "pass_char_ptr",
                     "PY_name_impl": "PY_passCharPtr",
+                    "c_arglist": [
+                        "c_var",
+                        "dest",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "dest",
+                        "src"
+                    ],
                     "function_name": "passCharPtr"
                 },
                 "zz_fmtlang": {
@@ -1310,6 +1348,14 @@
                     "F_name_generic": "pass_char_ptr_in_out",
                     "F_name_impl": "pass_char_ptr_in_out",
                     "PY_name_impl": "PY_passCharPtrInOut",
+                    "c_arglist": [
+                        "c_var",
+                        "s"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "s"
+                    ],
                     "function_name": "passCharPtrInOut"
                 },
                 "zz_fmtlang": {
@@ -1516,6 +1562,12 @@
                     "F_name_generic": "get_char_ptr1",
                     "F_name_impl": "get_char_ptr1",
                     "PY_name_impl": "PY_getCharPtr1",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr1"
                 },
                 "zz_fmtlang": {
@@ -1720,6 +1772,12 @@
                     "F_name_generic": "get_char_ptr2",
                     "F_name_impl": "get_char_ptr2",
                     "PY_name_impl": "PY_getCharPtr2",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr2"
                 },
                 "zz_fmtlang": {
@@ -1916,6 +1974,12 @@
                     "F_name_impl": "get_char_ptr3",
                     "F_string_result_as_arg": "output",
                     "PY_name_impl": "PY_getCharPtr3",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "output"
+                    ],
                     "function_name": "getCharPtr3"
                 },
                 "zz_fmtlang": {
@@ -2061,6 +2125,12 @@
                     "F_name_function": "get_char_ptr4",
                     "F_name_generic": "get_char_ptr4",
                     "F_name_impl": "get_char_ptr4",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr4"
                 }
             },
@@ -2224,6 +2294,12 @@
                     "F_name_function": "get_char_ptr5",
                     "F_name_generic": "get_char_ptr5",
                     "F_name_impl": "get_char_ptr5",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getCharPtr5"
                 }
             },
@@ -2419,6 +2495,12 @@
                     "F_name_generic": "get_const_string_result",
                     "F_name_impl": "get_const_string_result",
                     "PY_name_impl": "PY_getConstStringResult",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringResult"
                 },
                 "zz_fmtlang": {
@@ -2618,6 +2700,12 @@
                     "F_name_generic": "get_const_string_len",
                     "F_name_impl": "get_const_string_len",
                     "PY_name_impl": "PY_getConstStringLen",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringLen"
                 },
                 "zz_fmtlang": {
@@ -2809,6 +2897,12 @@
                     "F_name_impl": "get_const_string_as_arg",
                     "F_string_result_as_arg": "output",
                     "PY_name_impl": "PY_getConstStringAsArg",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "output"
+                    ],
                     "function_name": "getConstStringAsArg"
                 },
                 "zz_fmtlang": {
@@ -3011,6 +3105,12 @@
                     "F_name_generic": "get_const_string_alloc",
                     "F_name_impl": "get_const_string_alloc",
                     "PY_name_impl": "PY_getConstStringAlloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringAlloc"
                 },
                 "zz_fmtlang": {
@@ -3221,6 +3321,12 @@
                     "F_name_generic": "get_const_string_ref_pure",
                     "F_name_impl": "get_const_string_ref_pure",
                     "PY_name_impl": "PY_getConstStringRefPure",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefPure"
                 },
                 "zz_fmtlang": {
@@ -3426,6 +3532,12 @@
                     "F_name_generic": "get_const_string_ref_len",
                     "F_name_impl": "get_const_string_ref_len",
                     "PY_name_impl": "PY_getConstStringRefLen",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefLen"
                 },
                 "zz_fmtlang": {
@@ -3623,6 +3735,12 @@
                     "F_name_impl": "get_const_string_ref_as_arg",
                     "F_string_result_as_arg": "output",
                     "PY_name_impl": "PY_getConstStringRefAsArg",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "output"
+                    ],
                     "function_name": "getConstStringRefAsArg"
                 },
                 "zz_fmtlang": {
@@ -3827,6 +3945,12 @@
                     "F_name_generic": "get_const_string_ref_len_empty",
                     "F_name_impl": "get_const_string_ref_len_empty",
                     "PY_name_impl": "PY_getConstStringRefLenEmpty",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefLenEmpty"
                 },
                 "zz_fmtlang": {
@@ -4032,6 +4156,12 @@
                     "F_name_generic": "get_const_string_ref_alloc",
                     "F_name_impl": "get_const_string_ref_alloc",
                     "PY_name_impl": "PY_getConstStringRefAlloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringRefAlloc"
                 },
                 "zz_fmtlang": {
@@ -4244,6 +4374,12 @@
                     "F_name_generic": "get_const_string_ptr_len",
                     "F_name_impl": "get_const_string_ptr_len",
                     "PY_name_impl": "PY_getConstStringPtrLen",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrLen"
                 },
                 "zz_fmtlang": {
@@ -4456,6 +4592,12 @@
                     "F_name_generic": "get_const_string_ptr_alloc",
                     "F_name_impl": "get_const_string_ptr_alloc",
                     "PY_name_impl": "PY_getConstStringPtrAlloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrAlloc"
                 },
                 "zz_fmtlang": {
@@ -4671,6 +4813,12 @@
                     "F_name_generic": "get_const_string_ptr_owns_alloc",
                     "F_name_impl": "get_const_string_ptr_owns_alloc",
                     "PY_name_impl": "PY_getConstStringPtrOwnsAlloc",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrOwnsAlloc"
                 },
                 "zz_fmtlang": {
@@ -4891,6 +5039,12 @@
                     "F_name_generic": "get_const_string_ptr_owns_alloc_pattern",
                     "F_name_impl": "get_const_string_ptr_owns_alloc_pattern",
                     "PY_name_impl": "PY_getConstStringPtrOwnsAllocPattern",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrOwnsAllocPattern"
                 },
                 "zz_fmtlang": {
@@ -5070,6 +5224,12 @@
                     "F_name_function": "get_const_string_ptr_pointer",
                     "F_name_generic": "get_const_string_ptr_pointer",
                     "F_name_impl": "get_const_string_ptr_pointer",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "getConstStringPtrPointer"
                 }
             },
@@ -5311,6 +5471,14 @@
                     "F_name_generic": "accept_string_const_reference",
                     "F_name_impl": "accept_string_const_reference",
                     "PY_name_impl": "PY_acceptStringConstReference",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringConstReference"
                 },
                 "zz_fmtlang": {
@@ -5569,6 +5737,14 @@
                     "F_name_generic": "accept_string_reference_out",
                     "F_name_impl": "accept_string_reference_out",
                     "PY_name_impl": "PY_acceptStringReferenceOut",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringReferenceOut"
                 },
                 "zz_fmtlang": {
@@ -5824,6 +6000,14 @@
                     "F_name_generic": "accept_string_reference",
                     "F_name_impl": "accept_string_reference",
                     "PY_name_impl": "PY_acceptStringReference",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringReference"
                 },
                 "zz_fmtlang": {
@@ -6080,6 +6264,14 @@
                     "F_name_generic": "accept_string_pointer_const",
                     "F_name_impl": "accept_string_pointer_const",
                     "PY_name_impl": "PY_acceptStringPointerConst",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringPointerConst"
                 },
                 "zz_fmtlang": {
@@ -6336,6 +6528,14 @@
                     "F_name_generic": "accept_string_pointer",
                     "F_name_impl": "accept_string_pointer",
                     "PY_name_impl": "PY_acceptStringPointer",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringPointer"
                 },
                 "zz_fmtlang": {
@@ -6595,6 +6795,14 @@
                     "F_name_generic": "fetch_string_pointer",
                     "F_name_impl": "fetch_string_pointer",
                     "PY_name_impl": "PY_fetchStringPointer",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "fetchStringPointer"
                 },
                 "zz_fmtlang": {
@@ -6972,6 +7180,16 @@
                     "F_name_generic": "accept_string_pointer_len",
                     "F_name_impl": "accept_string_pointer_len",
                     "PY_name_impl": "PY_acceptStringPointerLen",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "nlen"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "nlen"
+                    ],
                     "function_name": "acceptStringPointerLen"
                 },
                 "zz_fmtlang": {
@@ -7356,6 +7574,16 @@
                     "F_name_generic": "fetch_string_pointer_len",
                     "F_name_impl": "fetch_string_pointer_len",
                     "PY_name_impl": "PY_fetchStringPointerLen",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "nlen"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "nlen"
+                    ],
                     "function_name": "fetchStringPointerLen"
                 },
                 "zz_fmtlang": {
@@ -7663,6 +7891,14 @@
                     "F_name_generic": "accept_string_instance",
                     "F_name_impl": "accept_string_instance",
                     "PY_name_impl": "PY_acceptStringInstance",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "acceptStringInstance"
                 },
                 "zz_fmtlang": {
@@ -8189,6 +8425,16 @@
                     "F_name_function": "fetch_array_string_arg",
                     "F_name_generic": "fetch_array_string_arg",
                     "F_name_impl": "fetch_array_string_arg",
+                    "c_arglist": [
+                        "c_var",
+                        "strs",
+                        "nstrs"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "strs",
+                        "nstrs"
+                    ],
                     "function_name": "fetchArrayStringArg"
                 }
             },
@@ -8544,6 +8790,16 @@
                     "F_name_function": "fetch_array_string_alloc",
                     "F_name_generic": "fetch_array_string_alloc",
                     "F_name_impl": "fetch_array_string_alloc",
+                    "c_arglist": [
+                        "c_var",
+                        "strs",
+                        "nstrs"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "strs",
+                        "nstrs"
+                    ],
                     "function_name": "fetchArrayStringAlloc"
                 }
             },
@@ -8906,6 +9162,16 @@
                     "F_name_function": "fetch_array_string_alloc_len",
                     "F_name_generic": "fetch_array_string_alloc_len",
                     "F_name_impl": "fetch_array_string_alloc_len",
+                    "c_arglist": [
+                        "c_var",
+                        "strs",
+                        "nstrs"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "strs",
+                        "nstrs"
+                    ],
                     "function_name": "fetchArrayStringAllocLen"
                 }
             },
@@ -9192,6 +9458,14 @@
                     "F_name_generic": "explicit1",
                     "F_name_impl": "explicit1",
                     "PY_name_impl": "PY_explicit1",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "explicit1"
                 },
                 "zz_fmtlang": {
@@ -9413,6 +9687,14 @@
                     "F_name_function": "explicit2",
                     "F_name_generic": "explicit2",
                     "F_name_impl": "explicit2",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "explicit2"
                 }
             },
@@ -9630,6 +9912,14 @@
                     "F_name_generic": "cpass_char",
                     "F_name_impl": "cpass_char",
                     "PY_name_impl": "PY_CpassChar",
+                    "c_arglist": [
+                        "c_var",
+                        "status"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "status"
+                    ],
                     "function_name": "CpassChar"
                 },
                 "zz_fmtlang": {
@@ -9793,6 +10083,12 @@
                     "F_name_generic": "creturn_char",
                     "F_name_impl": "creturn_char",
                     "PY_name_impl": "PY_CreturnChar",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "CreturnChar"
                 },
                 "zz_fmtlang": {
@@ -10118,6 +10414,16 @@
                     "F_name_function": "cpass_char_ptr",
                     "F_name_generic": "cpass_char_ptr",
                     "F_name_impl": "cpass_char_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "dest",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "dest",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtr"
                 }
             },
@@ -10427,6 +10733,16 @@
                     "F_name_function": "cpass_char_ptr_blank",
                     "F_name_generic": "cpass_char_ptr_blank",
                     "F_name_impl": "cpass_char_ptr_blank",
+                    "c_arglist": [
+                        "c_var",
+                        "dest",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "dest",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrBlank"
                 }
             },
@@ -10811,6 +11127,16 @@
                     "F_name_generic": "post_declare",
                     "F_name_impl": "post_declare",
                     "PY_name_impl": "PY_PostDeclare",
+                    "c_arglist": [
+                        "c_var",
+                        "count",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "count",
+                        "name"
+                    ],
                     "function_name": "PostDeclare"
                 },
                 "zz_fmtlang": {
@@ -11081,6 +11407,14 @@
                     "F_name_function": "cpass_char_ptr_notrim",
                     "F_name_generic": "cpass_char_ptr_notrim",
                     "F_name_impl": "cpass_char_ptr_notrim",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrNotrim"
                 }
             },
@@ -11396,6 +11730,16 @@
                     "F_name_function": "cpass_char_ptr_capi",
                     "F_name_generic": "cpass_char_ptr_capi",
                     "F_name_impl": "cpass_char_ptr_capi",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "addr",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "addr",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrCAPI"
                 }
             },
@@ -11706,6 +12050,16 @@
                     "F_name_function": "cpass_char_ptr_capi2",
                     "F_name_generic": "cpass_char_ptr_capi2",
                     "F_name_impl": "cpass_char_ptr_capi2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in",
+                        "src"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in",
+                        "src"
+                    ],
                     "function_name": "CpassCharPtrCAPI2"
                 }
             }

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -858,6 +858,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "get_x1",
@@ -1003,6 +1006,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "set_x1",
@@ -1110,6 +1117,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "get_y1",
@@ -1255,6 +1265,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "set_y1",
@@ -1457,6 +1471,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "get_x1",
@@ -1602,6 +1619,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "set_x1",
@@ -1709,6 +1730,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "get_y1",
@@ -1854,6 +1878,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "set_y1",
@@ -1961,6 +1989,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "z1",
                             "function_name": "get_z1",
@@ -2106,6 +2137,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "z1",
                             "function_name": "set_z1",
@@ -2462,6 +2497,10 @@
                     "F_name_function": "pass_struct_by_value",
                     "F_name_generic": "pass_struct_by_value",
                     "F_name_impl": "pass_struct_by_value",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "passStructByValue"
                 }
             },
@@ -2616,6 +2655,10 @@
                     "F_name_function": "pass_struct1",
                     "F_name_generic": "pass_struct1",
                     "F_name_impl": "pass_struct1",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "passStruct1"
                 }
             },
@@ -2845,6 +2888,11 @@
                     "F_name_function": "pass_struct2",
                     "F_name_generic": "pass_struct2",
                     "F_name_impl": "pass_struct2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "s1",
+                        "outbuf"
+                    ],
                     "function_name": "passStruct2"
                 }
             },
@@ -2999,6 +3047,10 @@
                     "F_name_function": "accept_struct_in_ptr",
                     "F_name_generic": "accept_struct_in_ptr",
                     "F_name_impl": "accept_struct_in_ptr",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "acceptStructInPtr"
                 }
             },
@@ -3244,6 +3296,12 @@
                     "F_name_function": "accept_struct_out_ptr",
                     "F_name_generic": "accept_struct_out_ptr",
                     "F_name_impl": "accept_struct_out_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "arg",
+                        "i",
+                        "d"
+                    ],
                     "function_name": "acceptStructOutPtr"
                 }
             },
@@ -3372,6 +3430,10 @@
                     "F_name_function": "accept_struct_in_out_ptr",
                     "F_name_generic": "accept_struct_in_out_ptr",
                     "F_name_impl": "accept_struct_in_out_ptr",
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "acceptStructInOutPtr"
                 }
             },
@@ -3577,6 +3639,11 @@
                     "F_name_function": "return_struct_by_value",
                     "F_name_generic": "return_struct_by_value",
                     "F_name_impl": "return_struct_by_value",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i",
+                        "d"
+                    ],
                     "function_name": "returnStructByValue"
                 }
             },
@@ -3806,6 +3873,11 @@
                     "F_name_function": "return_struct_ptr1",
                     "F_name_generic": "return_struct_ptr1",
                     "F_name_impl": "return_struct_ptr1",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i",
+                        "d"
+                    ],
                     "function_name": "returnStructPtr1"
                 }
             },
@@ -4104,6 +4176,12 @@
                     "F_name_function": "return_struct_ptr2",
                     "F_name_generic": "return_struct_ptr2",
                     "F_name_impl": "return_struct_ptr2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i",
+                        "d",
+                        "outbuf"
+                    ],
                     "function_name": "returnStructPtr2"
                 }
             },
@@ -4241,6 +4319,9 @@
                     "F_name_function": "return_struct_ptr_array",
                     "F_name_generic": "return_struct_ptr_array",
                     "F_name_impl": "return_struct_ptr_array",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnStructPtrArray"
                 }
             },
@@ -4350,6 +4431,9 @@
                     "F_name_function": "get_global_struct_list",
                     "F_name_generic": "get_global_struct_list",
                     "F_name_impl": "get_global_struct_list",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "get_global_struct_list"
                 }
             },
@@ -4455,6 +4539,9 @@
                     "F_name_function": "create_cstruct_as_class",
                     "F_name_generic": "create_cstruct_as_class",
                     "F_name_impl": "create_cstruct_as_class",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "Create_Cstruct_as_class"
                 }
             },
@@ -4675,6 +4762,11 @@
                     "F_name_function": "create_cstruct_as_class_args",
                     "F_name_generic": "create_cstruct_as_class_args",
                     "F_name_impl": "create_cstruct_as_class_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y"
+                    ],
                     "function_name": "Create_Cstruct_as_class_args"
                 }
             },
@@ -4778,6 +4870,9 @@
                     "F_name_function": "return_cstruct_as_class",
                     "F_name_generic": "return_cstruct_as_class",
                     "F_name_impl": "return_cstruct_as_class",
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "Return_Cstruct_as_class"
                 }
             },
@@ -4997,6 +5092,11 @@
                     "F_name_function": "return_cstruct_as_class_args",
                     "F_name_generic": "return_cstruct_as_class_args",
                     "F_name_impl": "return_cstruct_as_class_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y"
+                    ],
                     "function_name": "Return_Cstruct_as_class_args"
                 }
             },
@@ -5162,6 +5262,10 @@
                     "F_name_function": "sum",
                     "F_name_generic": "cstruct_as_class_sum",
                     "F_name_impl": "cstruct_as_class_sum",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "point"
+                    ],
                     "function_name": "Cstruct_as_class_sum"
                 }
             },
@@ -5439,6 +5543,12 @@
                     "F_name_function": "create_cstruct_as_subclass_args",
                     "F_name_generic": "create_cstruct_as_subclass_args",
                     "F_name_impl": "create_cstruct_as_subclass_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y",
+                        "z"
+                    ],
                     "function_name": "Create_Cstruct_as_subclass_args"
                 }
             },
@@ -5715,6 +5825,12 @@
                     "F_name_function": "return_cstruct_as_subclass_args",
                     "F_name_generic": "return_cstruct_as_subclass_args",
                     "F_name_impl": "return_cstruct_as_subclass_args",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y",
+                        "z"
+                    ],
                     "function_name": "Return_Cstruct_as_subclass_args"
                 }
             },
@@ -5887,6 +6003,10 @@
                     "F_name_function": "cstruct_ptr_get_const_dvalue",
                     "F_name_generic": "cstruct_ptr_get_const_dvalue",
                     "F_name_impl": "cstruct_ptr_get_const_dvalue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "const_dvalue",
                     "function_name": "Cstruct_ptr_get_const_dvalue",
                     "struct_name": "Cstruct_ptr",
@@ -6090,6 +6210,11 @@
                     "F_name_function": "cstruct_ptr_set_const_dvalue",
                     "F_name_generic": "cstruct_ptr_set_const_dvalue",
                     "F_name_impl": "cstruct_ptr_set_const_dvalue",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "const_dvalue",
                     "function_name": "Cstruct_ptr_set_const_dvalue",
                     "struct_name": "Cstruct_ptr",
@@ -6313,6 +6438,10 @@
                     "F_name_function": "cstruct_list_get_ivalue",
                     "F_name_generic": "cstruct_list_get_ivalue",
                     "F_name_impl": "cstruct_list_get_ivalue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "ivalue",
                     "function_name": "Cstruct_list_get_ivalue",
                     "struct_name": "Cstruct_list",
@@ -6523,6 +6652,11 @@
                     "F_name_function": "cstruct_list_set_ivalue",
                     "F_name_generic": "cstruct_list_set_ivalue",
                     "F_name_impl": "cstruct_list_set_ivalue",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "ivalue",
                     "function_name": "Cstruct_list_set_ivalue",
                     "struct_name": "Cstruct_list",
@@ -6746,6 +6880,10 @@
                     "F_name_function": "cstruct_list_get_dvalue",
                     "F_name_generic": "cstruct_list_get_dvalue",
                     "F_name_impl": "cstruct_list_get_dvalue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "dvalue",
                     "function_name": "Cstruct_list_get_dvalue",
                     "struct_name": "Cstruct_list",
@@ -6956,6 +7094,11 @@
                     "F_name_function": "cstruct_list_set_dvalue",
                     "F_name_generic": "cstruct_list_set_dvalue",
                     "F_name_impl": "cstruct_list_set_dvalue",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "dvalue",
                     "function_name": "Cstruct_list_set_dvalue",
                     "struct_name": "Cstruct_list",

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -876,6 +876,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "get_x1",
@@ -1021,6 +1024,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "set_x1",
@@ -1128,6 +1135,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "get_y1",
@@ -1273,6 +1283,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "set_y1",
@@ -1478,6 +1492,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "get_x1",
@@ -1623,6 +1640,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "x1",
                             "function_name": "set_x1",
@@ -1730,6 +1751,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "get_y1",
@@ -1875,6 +1899,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "y1",
                             "function_name": "set_y1",
@@ -1982,6 +2010,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "z1",
                             "function_name": "get_z1",
@@ -2127,6 +2158,10 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "val"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "field_name": "z1",
                             "function_name": "set_z1",
@@ -2553,6 +2588,14 @@
                     "F_name_function": "pass_struct_by_value",
                     "F_name_generic": "pass_struct_by_value",
                     "F_name_impl": "pass_struct_by_value",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "passStructByValue"
                 }
             },
@@ -2769,6 +2812,14 @@
                     "F_name_function": "pass_struct1",
                     "F_name_generic": "pass_struct1",
                     "F_name_impl": "pass_struct1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "passStruct1"
                 }
             },
@@ -3118,6 +3169,16 @@
                     "F_name_function": "pass_struct2",
                     "F_name_generic": "pass_struct2",
                     "F_name_impl": "pass_struct2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "s1",
+                        "outbuf"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "s1",
+                        "outbuf"
+                    ],
                     "function_name": "passStruct2"
                 }
             },
@@ -3334,6 +3395,14 @@
                     "F_name_function": "accept_struct_in_ptr",
                     "F_name_generic": "accept_struct_in_ptr",
                     "F_name_impl": "accept_struct_in_ptr",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "acceptStructInPtr"
                 }
             },
@@ -3690,6 +3759,18 @@
                     "F_name_function": "accept_struct_out_ptr",
                     "F_name_generic": "accept_struct_out_ptr",
                     "F_name_impl": "accept_struct_out_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "arg",
+                        "i",
+                        "d"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg",
+                        "i",
+                        "d"
+                    ],
                     "function_name": "acceptStructOutPtr"
                 }
             },
@@ -3867,6 +3948,14 @@
                     "F_name_function": "accept_struct_in_out_ptr",
                     "F_name_generic": "accept_struct_in_out_ptr",
                     "F_name_impl": "accept_struct_in_out_ptr",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "acceptStructInOutPtr"
                 }
             },
@@ -4165,6 +4254,16 @@
                     "F_name_function": "return_struct_by_value",
                     "F_name_generic": "return_struct_by_value",
                     "F_name_impl": "return_struct_by_value",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "i",
+                        "d"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i",
+                        "d"
+                    ],
                     "function_name": "returnStructByValue"
                 }
             },
@@ -4519,6 +4618,16 @@
                     "F_name_function": "return_struct_ptr1",
                     "F_name_generic": "return_struct_ptr1",
                     "F_name_impl": "return_struct_ptr1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "i",
+                        "d"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i",
+                        "d"
+                    ],
                     "function_name": "returnStructPtr1"
                 }
             },
@@ -4978,6 +5087,18 @@
                     "F_name_function": "return_struct_ptr2",
                     "F_name_generic": "return_struct_ptr2",
                     "F_name_impl": "return_struct_ptr2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "i",
+                        "d",
+                        "outbuf"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i",
+                        "d",
+                        "outbuf"
+                    ],
                     "function_name": "returnStructPtr2"
                 }
             },
@@ -5173,6 +5294,12 @@
                     "F_name_function": "return_struct_ptr_array",
                     "F_name_generic": "return_struct_ptr_array",
                     "F_name_impl": "return_struct_ptr_array",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnStructPtrArray"
                 }
             },
@@ -5328,6 +5455,12 @@
                     "F_name_function": "get_global_struct_list",
                     "F_name_generic": "get_global_struct_list",
                     "F_name_impl": "get_global_struct_list",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "get_global_struct_list"
                 }
             },
@@ -5485,6 +5618,12 @@
                     "F_name_function": "create_cstruct_as_class",
                     "F_name_generic": "create_cstruct_as_class",
                     "F_name_impl": "create_cstruct_as_class",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "Create_Cstruct_as_class"
                 }
             },
@@ -5836,6 +5975,16 @@
                     "F_name_function": "create_cstruct_as_class_args",
                     "F_name_generic": "create_cstruct_as_class_args",
                     "F_name_impl": "create_cstruct_as_class_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "x",
+                        "y"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y"
+                    ],
                     "function_name": "Create_Cstruct_as_class_args"
                 }
             },
@@ -5973,6 +6122,12 @@
                     "F_name_function": "return_cstruct_as_class",
                     "F_name_generic": "return_cstruct_as_class",
                     "F_name_impl": "return_cstruct_as_class",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "Return_Cstruct_as_class"
                 }
             },
@@ -6289,6 +6444,16 @@
                     "F_name_function": "return_cstruct_as_class_args",
                     "F_name_generic": "return_cstruct_as_class_args",
                     "F_name_impl": "return_cstruct_as_class_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "x",
+                        "y"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y"
+                    ],
                     "function_name": "Return_Cstruct_as_class_args"
                 }
             },
@@ -6516,6 +6681,14 @@
                     "F_name_function": "sum",
                     "F_name_generic": "cstruct_as_class_sum",
                     "F_name_impl": "cstruct_as_class_sum",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "point"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "point"
+                    ],
                     "function_name": "Cstruct_as_class_sum"
                 }
             },
@@ -6963,6 +7136,18 @@
                     "F_name_function": "create_cstruct_as_subclass_args",
                     "F_name_generic": "create_cstruct_as_subclass_args",
                     "F_name_impl": "create_cstruct_as_subclass_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "x",
+                        "y",
+                        "z"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y",
+                        "z"
+                    ],
                     "function_name": "Create_Cstruct_as_subclass_args"
                 }
             },
@@ -7367,6 +7552,18 @@
                     "F_name_function": "return_cstruct_as_subclass_args",
                     "F_name_generic": "return_cstruct_as_subclass_args",
                     "F_name_impl": "return_cstruct_as_subclass_args",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "x",
+                        "y",
+                        "z"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "x",
+                        "y",
+                        "z"
+                    ],
                     "function_name": "Return_Cstruct_as_subclass_args"
                 }
             },
@@ -7539,6 +7736,10 @@
                     "F_name_function": "cstruct_ptr_get_const_dvalue",
                     "F_name_generic": "cstruct_ptr_get_const_dvalue",
                     "F_name_impl": "cstruct_ptr_get_const_dvalue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "const_dvalue",
                     "function_name": "Cstruct_ptr_get_const_dvalue",
                     "struct_name": "Cstruct_ptr",
@@ -7742,6 +7943,11 @@
                     "F_name_function": "cstruct_ptr_set_const_dvalue",
                     "F_name_generic": "cstruct_ptr_set_const_dvalue",
                     "F_name_impl": "cstruct_ptr_set_const_dvalue",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "const_dvalue",
                     "function_name": "Cstruct_ptr_set_const_dvalue",
                     "struct_name": "Cstruct_ptr",
@@ -7965,6 +8171,10 @@
                     "F_name_function": "cstruct_list_get_ivalue",
                     "F_name_generic": "cstruct_list_get_ivalue",
                     "F_name_impl": "cstruct_list_get_ivalue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "ivalue",
                     "function_name": "Cstruct_list_get_ivalue",
                     "struct_name": "Cstruct_list",
@@ -8175,6 +8385,11 @@
                     "F_name_function": "cstruct_list_set_ivalue",
                     "F_name_generic": "cstruct_list_set_ivalue",
                     "F_name_impl": "cstruct_list_set_ivalue",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "ivalue",
                     "function_name": "Cstruct_list_set_ivalue",
                     "struct_name": "Cstruct_list",
@@ -8398,6 +8613,10 @@
                     "F_name_function": "cstruct_list_get_dvalue",
                     "F_name_generic": "cstruct_list_get_dvalue",
                     "F_name_impl": "cstruct_list_get_dvalue",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "SH_this"
+                    ],
                     "field_name": "dvalue",
                     "function_name": "Cstruct_list_get_dvalue",
                     "struct_name": "Cstruct_list",
@@ -8608,6 +8827,11 @@
                     "F_name_function": "cstruct_list_set_dvalue",
                     "F_name_generic": "cstruct_list_set_dvalue",
                     "F_name_impl": "cstruct_list_set_dvalue",
+                    "f_arglist": [
+                        "f_var",
+                        "SH_this",
+                        "val"
+                    ],
                     "field_name": "dvalue",
                     "function_name": "Cstruct_list_set_dvalue",
                     "struct_name": "Cstruct_list",

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -499,10 +499,20 @@
                             "F_name_generic": "nested",
                             "F_name_impl": "user_int_nested_double",
                             "PY_name_impl": "PY_nested_double",
+                            "c_arglist": [
+                                "self",
+                                "arg1",
+                                "arg2"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "arg1",
+                                "arg2"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "nested",
                             "template_suffix": "_double"
@@ -728,6 +738,12 @@
                             "F_name_function": "ctor",
                             "F_name_generic": "struct_as_class_int",
                             "F_name_impl": "struct_as_class_int_ctor",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         }
@@ -903,10 +919,18 @@
                             "F_name_function": "set_npts",
                             "F_name_generic": "set_npts",
                             "F_name_impl": "struct_as_class_int_set_npts",
+                            "c_arglist": [
+                                "self",
+                                "n"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "n"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "set_npts"
                         }
@@ -1030,10 +1054,16 @@
                             "F_name_function": "get_npts",
                             "F_name_generic": "get_npts",
                             "F_name_impl": "struct_as_class_int_get_npts",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "get_npts"
                         }
@@ -1269,10 +1299,18 @@
                             "F_name_function": "set_value",
                             "F_name_generic": "set_value",
                             "F_name_impl": "struct_as_class_int_set_value",
+                            "c_arglist": [
+                                "self",
+                                "v"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "v"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "set_value"
                         }
@@ -1440,10 +1478,16 @@
                             "F_name_function": "get_value",
                             "F_name_generic": "get_value",
                             "F_name_impl": "struct_as_class_int_get_value",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "get_value"
                         }
@@ -1661,6 +1705,12 @@
                             "F_name_function": "ctor",
                             "F_name_generic": "struct_as_class_double",
                             "F_name_impl": "struct_as_class_double_ctor",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "ctor"
                         }
@@ -1836,10 +1886,18 @@
                             "F_name_function": "set_npts",
                             "F_name_generic": "set_npts",
                             "F_name_impl": "struct_as_class_double_set_npts",
+                            "c_arglist": [
+                                "self",
+                                "n"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "n"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "set_npts"
                         }
@@ -1963,10 +2021,16 @@
                             "F_name_function": "get_npts",
                             "F_name_generic": "get_npts",
                             "F_name_impl": "struct_as_class_double_get_npts",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "get_npts"
                         }
@@ -2202,10 +2266,18 @@
                             "F_name_function": "set_value",
                             "F_name_generic": "set_value",
                             "F_name_impl": "struct_as_class_double_set_value",
+                            "c_arglist": [
+                                "self",
+                                "v"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "f_var",
+                                "v"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "set_value"
                         }
@@ -2373,10 +2445,16 @@
                             "F_name_function": "get_value",
                             "F_name_generic": "get_value",
                             "F_name_impl": "struct_as_class_double_get_value",
+                            "c_arglist": [
+                                "SHC_rv"
+                            ],
                             "c_const": "",
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "get_value"
                         }
@@ -2629,6 +2707,12 @@
                     "F_name_function": "return_user_type",
                     "F_name_generic": "return_user_type",
                     "F_name_impl": "return_user_type",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "returnUserType"
                 }
             },
@@ -3127,6 +3211,16 @@
                     "F_name_generic": "function_tu",
                     "F_name_impl": "function_tu_0",
                     "PY_name_impl": "PY_FunctionTU_0",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "FunctionTU",
                     "template_suffix": "_0"
                 },
@@ -3527,6 +3621,16 @@
                     "F_name_generic": "function_tu",
                     "F_name_impl": "function_tu_1",
                     "PY_name_impl": "PY_FunctionTU_1",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "FunctionTU",
                     "template_suffix": "_1"
                 },
@@ -3803,6 +3907,12 @@
                     "F_name_generic": "use_impl_worker",
                     "F_name_impl": "use_impl_worker_internal_ImplWorker1",
                     "PY_name_impl": "PY_UseImplWorker_internal_ImplWorker1",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "UseImplWorker",
                     "template_suffix": "_internal_ImplWorker1"
                 },
@@ -4005,6 +4115,12 @@
                     "F_name_generic": "use_impl_worker",
                     "F_name_impl": "use_impl_worker_internal_ImplWorker2",
                     "PY_name_impl": "PY_UseImplWorker_internal_ImplWorker2",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "UseImplWorker",
                     "template_suffix": "_internal_ImplWorker2"
                 },
@@ -4211,6 +4327,12 @@
                                     "PY_name_impl": "PY_vector_int_tp_init",
                                     "PY_type_impl": "PY_vector_int_tp_init",
                                     "PY_type_method": "tp_init",
+                                    "c_arglist": [
+                                        "SHC_rv"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "ctor"
                                 },
@@ -4318,10 +4440,16 @@
                                     "F_name_function": "dtor",
                                     "F_name_generic": "dtor",
                                     "F_name_impl": "vector_int_dtor",
+                                    "c_arglist": [
+                                        "self"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "dtor"
                                 },
@@ -4615,10 +4743,18 @@
                                     "F_name_generic": "push_back",
                                     "F_name_impl": "vector_int_push_back",
                                     "PY_name_impl": "PY_push_back",
+                                    "c_arglist": [
+                                        "self",
+                                        "value"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var",
+                                        "value"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "push_back"
                                 },
@@ -4997,10 +5133,18 @@
                                     "F_name_generic": "at",
                                     "F_name_impl": "vector_int_at",
                                     "PY_name_impl": "PY_at",
+                                    "c_arglist": [
+                                        "SHC_rv",
+                                        "n"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "SHT_rv",
+                                        "n"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "at"
                                 },
@@ -5294,6 +5438,12 @@
                                     "PY_name_impl": "PY_vector_double_tp_init",
                                     "PY_type_impl": "PY_vector_double_tp_init",
                                     "PY_type_method": "tp_init",
+                                    "c_arglist": [
+                                        "SHC_rv"
+                                    ],
+                                    "f_arglist": [
+                                        "SHT_rv"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "ctor"
                                 },
@@ -5401,10 +5551,16 @@
                                     "F_name_function": "dtor",
                                     "F_name_generic": "dtor",
                                     "F_name_impl": "vector_double_dtor",
+                                    "c_arglist": [
+                                        "self"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "dtor"
                                 },
@@ -5698,10 +5854,18 @@
                                     "F_name_generic": "push_back",
                                     "F_name_impl": "vector_double_push_back",
                                     "PY_name_impl": "PY_push_back",
+                                    "c_arglist": [
+                                        "self",
+                                        "value"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "f_var",
+                                        "value"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "push_back"
                                 },
@@ -6080,10 +6244,18 @@
                                     "F_name_generic": "at",
                                     "F_name_impl": "vector_double_at",
                                     "PY_name_impl": "PY_at",
+                                    "c_arglist": [
+                                        "SHC_rv",
+                                        "n"
+                                    ],
                                     "c_const": "",
                                     "c_deref": "*",
                                     "c_member": "->",
                                     "c_var": "self",
+                                    "f_arglist": [
+                                        "SHT_rv",
+                                        "n"
+                                    ],
                                     "f_intent_attr": ", intent(INOUT)",
                                     "function_name": "at"
                                 },

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -190,6 +190,12 @@
                     "LUA_name_api": "NoReturnNoArguments",
                     "LUA_name_impl": "l_NoReturnNoArguments",
                     "PY_name_impl": "PY_NoReturnNoArguments",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "NoReturnNoArguments"
                 },
                 "zz_fmtlang": {
@@ -641,6 +647,16 @@
                     "LUA_name_api": "PassByValue",
                     "LUA_name_impl": "l_PassByValue",
                     "PY_name_impl": "PY_PassByValue",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "PassByValue"
                 },
                 "zz_fmtlang": {
@@ -1182,6 +1198,16 @@
                     "LUA_name_api": "ConcatenateStrings",
                     "LUA_name_impl": "l_ConcatenateStrings",
                     "PY_name_impl": "PY_ConcatenateStrings",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "ConcatenateStrings"
                 },
                 "zz_fmtlang": {
@@ -1338,6 +1364,12 @@
                     "F_name_function": "use_default_arguments",
                     "F_name_generic": "use_default_arguments",
                     "F_name_impl": "use_default_arguments",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "UseDefaultArguments",
                     "function_suffix": ""
                 }
@@ -1565,6 +1597,14 @@
                     "F_name_function": "use_default_arguments_arg1",
                     "F_name_generic": "use_default_arguments",
                     "F_name_impl": "use_default_arguments_arg1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "UseDefaultArguments",
                     "function_suffix": "_arg1"
                 }
@@ -2024,6 +2064,16 @@
                     "LUA_name_impl": "l_UseDefaultArguments",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_UseDefaultArguments_arg1_arg2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "arg2"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "arg2"
+                    ],
                     "function_name": "UseDefaultArguments",
                     "function_suffix": "_arg1_arg2"
                 },
@@ -2325,6 +2375,14 @@
                     "LUA_name_api": "OverloadedFunction",
                     "LUA_name_impl": "l_OverloadedFunction",
                     "PY_name_impl": "PY_OverloadedFunction_from_name",
+                    "c_arglist": [
+                        "c_var",
+                        "name"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "name"
+                    ],
                     "function_name": "OverloadedFunction",
                     "function_suffix": "_from_name"
                 },
@@ -2597,6 +2655,14 @@
                     "F_name_generic": "overloaded_function",
                     "F_name_impl": "overloaded_function_from_index",
                     "PY_name_impl": "PY_OverloadedFunction_from_index",
+                    "c_arglist": [
+                        "c_var",
+                        "indx"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "indx"
+                    ],
                     "function_name": "OverloadedFunction",
                     "function_suffix": "_from_index"
                 },
@@ -2983,6 +3049,14 @@
                     "LUA_name_api": "TemplateArgument",
                     "LUA_name_impl": "l_TemplateArgument",
                     "PY_name_impl": "PY_TemplateArgument_int",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "TemplateArgument",
                     "template_suffix": "_int"
                 },
@@ -3291,6 +3365,14 @@
                     "F_name_generic": "template_argument",
                     "F_name_impl": "template_argument_double",
                     "PY_name_impl": "PY_TemplateArgument_double",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "TemplateArgument",
                     "template_suffix": "_double"
                 },
@@ -3539,6 +3621,12 @@
                     "F_name_function": "template_return_int",
                     "F_name_generic": "template_return",
                     "F_name_impl": "template_return_int",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "TemplateReturn",
                     "template_suffix": "_int"
                 }
@@ -3704,6 +3792,12 @@
                     "F_name_function": "template_return_double",
                     "F_name_generic": "template_return",
                     "F_name_impl": "template_return_double",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "TemplateReturn",
                     "template_suffix": "_double"
                 }
@@ -3816,6 +3910,12 @@
                     "LUA_name_api": "FortranGenericOverloaded",
                     "LUA_name_impl": "l_FortranGenericOverloaded",
                     "PY_name_impl": "PY_FortranGenericOverloaded_0",
+                    "c_arglist": [
+                        "c_var"
+                    ],
+                    "f_arglist": [
+                        "f_var"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_0"
                 },
@@ -4199,6 +4299,11 @@
                     "C_name_api": "FortranGenericOverloaded",
                     "F_name_api": "fortran_generic_overloaded",
                     "PY_name_impl": "PY_FortranGenericOverloaded_1",
+                    "c_arglist": [
+                        "c_var",
+                        "name",
+                        "arg2"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_1"
                 },
@@ -4419,6 +4524,11 @@
                     "F_name_function": "fortran_generic_overloaded_1_float",
                     "F_name_generic": "fortran_generic_overloaded",
                     "F_name_impl": "fortran_generic_overloaded_1_float",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "arg2"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_1_float"
                 }
@@ -4624,6 +4734,11 @@
                     "F_name_function": "fortran_generic_overloaded_1_double",
                     "F_name_generic": "fortran_generic_overloaded",
                     "F_name_impl": "fortran_generic_overloaded_1_double",
+                    "f_arglist": [
+                        "f_var",
+                        "name",
+                        "arg2"
+                    ],
                     "function_name": "FortranGenericOverloaded",
                     "function_suffix": "_1_double"
                 }
@@ -4848,6 +4963,14 @@
                     "F_name_function": "use_default_overload_num",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_num",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "num"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "num"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_num"
                 }
@@ -5161,6 +5284,16 @@
                     "F_name_function": "use_default_overload_num_offset",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_num_offset",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "num",
+                        "offset"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "num",
+                        "offset"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_num_offset"
                 }
@@ -5750,6 +5883,18 @@
                     "LUA_name_impl": "l_UseDefaultOverload",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_UseDefaultOverload_num_offset_stride",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_num_offset_stride"
                 },
@@ -6083,6 +6228,16 @@
                     "F_name_function": "use_default_overload_3",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_3",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "type",
+                        "num"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "type",
+                        "num"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_3"
                 }
@@ -6479,6 +6634,18 @@
                     "F_name_function": "use_default_overload_4",
                     "F_name_generic": "use_default_overload",
                     "F_name_impl": "use_default_overload_4",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "type",
+                        "num",
+                        "offset"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "type",
+                        "num",
+                        "offset"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_4"
                 }
@@ -7193,6 +7360,20 @@
                     "F_name_impl": "use_default_overload_5",
                     "PY_cleanup_decref": "Py_XDECREF",
                     "PY_name_impl": "PY_UseDefaultOverload_5",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "type",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "type",
+                        "num",
+                        "offset",
+                        "stride"
+                    ],
                     "function_name": "UseDefaultOverload",
                     "function_suffix": "_5"
                 },
@@ -7514,6 +7695,14 @@
                     "LUA_name_api": "typefunc",
                     "LUA_name_impl": "l_typefunc",
                     "PY_name_impl": "PY_typefunc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "typefunc"
                 },
                 "zz_fmtlang": {
@@ -7874,6 +8063,14 @@
                     "LUA_name_api": "colorfunc",
                     "LUA_name_impl": "l_colorfunc",
                     "PY_name_impl": "PY_colorfunc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "colorfunc"
                 },
                 "zz_fmtlang": {
@@ -8254,6 +8451,16 @@
                     "F_name_generic": "get_min_max",
                     "F_name_impl": "get_min_max",
                     "PY_name_impl": "PY_getMinMax",
+                    "c_arglist": [
+                        "c_var",
+                        "min",
+                        "max"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "min",
+                        "max"
+                    ],
                     "function_name": "getMinMax"
                 },
                 "zz_fmtlang": {
@@ -8894,6 +9101,16 @@
                     "F_name_function": "callback1",
                     "F_name_generic": "callback1",
                     "F_name_impl": "callback1",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in",
+                        "incr"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in",
+                        "incr"
+                    ],
                     "function_name": "callback1"
                 }
             },
@@ -9106,6 +9323,12 @@
                     "LUA_name_api": "LastFunctionCalled",
                     "LUA_name_impl": "l_LastFunctionCalled",
                     "PY_name_impl": "PY_LastFunctionCalled",
+                    "c_arglist": [
+                        "SHC_rv"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv"
+                    ],
                     "function_name": "LastFunctionCalled"
                 },
                 "zz_fmtlang": {

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -500,6 +500,10 @@
                     "F_name_generic": "typefunc",
                     "F_name_impl": "typefunc",
                     "PY_name_impl": "PY_typefunc",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "typefunc"
                 },
                 "zz_fmtlang": {
@@ -673,6 +677,10 @@
                     "F_name_function": "typefunc_wrap",
                     "F_name_generic": "typefunc_wrap",
                     "F_name_impl": "typefunc_wrap",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "typefunc_wrap"
                 }
             },
@@ -878,6 +886,10 @@
                     "F_name_generic": "return_enum",
                     "F_name_impl": "return_enum",
                     "PY_name_impl": "PY_returnEnum",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "returnEnum"
                 },
                 "zz_fmtlang": {
@@ -1099,6 +1111,10 @@
                     "F_name_generic": "return_type_id",
                     "F_name_impl": "return_type_id",
                     "PY_name_impl": "PY_returnTypeID",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "returnTypeID"
                 },
                 "zz_fmtlang": {
@@ -1282,6 +1298,10 @@
                     "F_name_generic": "typestruct",
                     "F_name_impl": "typestruct",
                     "PY_name_impl": "PY_typestruct",
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "typestruct"
                 },
                 "zz_fmtlang": {
@@ -1448,6 +1468,10 @@
                     "F_name_function": "return_bytes_for_index_type",
                     "F_name_generic": "return_bytes_for_index_type",
                     "F_name_impl": "return_bytes_for_index_type",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "returnBytesForIndexType"
                 }
             },
@@ -1669,6 +1693,11 @@
                     "F_name_function": "return_shape_size",
                     "F_name_generic": "return_shape_size",
                     "F_name_impl": "return_shape_size",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "ndims",
+                        "shape"
+                    ],
                     "function_name": "returnShapeSize"
                 }
             },
@@ -1819,6 +1848,10 @@
                     "F_name_function": "return_bytes_for_index_type2",
                     "F_name_generic": "return_bytes_for_index_type2",
                     "F_name_impl": "return_bytes_for_index_type2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "returnBytesForIndexType2"
                 }
             },
@@ -2040,6 +2073,11 @@
                     "F_name_function": "return_shape_size2",
                     "F_name_generic": "return_shape_size2",
                     "F_name_impl": "return_shape_size2",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "ndims",
+                        "shape"
+                    ],
                     "function_name": "returnShapeSize2"
                 }
             }

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -569,6 +569,14 @@
                     "F_name_generic": "typefunc",
                     "F_name_impl": "typefunc",
                     "PY_name_impl": "PY_typefunc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "typefunc"
                 },
                 "zz_fmtlang": {
@@ -805,6 +813,14 @@
                     "F_name_function": "typefunc_wrap",
                     "F_name_generic": "typefunc_wrap",
                     "F_name_impl": "typefunc_wrap",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "typefunc_wrap"
                 }
             },
@@ -1099,6 +1115,14 @@
                     "F_name_generic": "return_enum",
                     "F_name_impl": "return_enum",
                     "PY_name_impl": "PY_returnEnum",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "returnEnum"
                 },
                 "zz_fmtlang": {
@@ -1409,6 +1433,14 @@
                     "F_name_generic": "return_type_id",
                     "F_name_impl": "return_type_id",
                     "PY_name_impl": "PY_returnTypeID",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "in"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "in"
+                    ],
                     "function_name": "returnTypeID"
                 },
                 "zz_fmtlang": {
@@ -1641,6 +1673,14 @@
                     "F_name_generic": "typestruct",
                     "F_name_impl": "typestruct",
                     "PY_name_impl": "PY_typestruct",
+                    "c_arglist": [
+                        "c_var",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg1"
+                    ],
                     "function_name": "typestruct"
                 },
                 "zz_fmtlang": {
@@ -1871,6 +1911,14 @@
                     "F_name_function": "return_bytes_for_index_type",
                     "F_name_generic": "return_bytes_for_index_type",
                     "F_name_impl": "return_bytes_for_index_type",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "returnBytesForIndexType"
                 }
             },
@@ -2186,6 +2234,16 @@
                     "F_name_function": "return_shape_size",
                     "F_name_generic": "return_shape_size",
                     "F_name_impl": "return_shape_size",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "ndims",
+                        "shape"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "ndims",
+                        "shape"
+                    ],
                     "function_name": "returnShapeSize"
                 }
             },
@@ -2400,6 +2458,14 @@
                     "F_name_function": "return_bytes_for_index_type2",
                     "F_name_generic": "return_bytes_for_index_type2",
                     "F_name_impl": "return_bytes_for_index_type2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "returnBytesForIndexType2"
                 }
             },
@@ -2715,6 +2781,16 @@
                     "F_name_function": "return_shape_size2",
                     "F_name_generic": "return_shape_size2",
                     "F_name_impl": "return_shape_size2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "ndims",
+                        "shape"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "ndims",
+                        "shape"
+                    ],
                     "function_name": "returnShapeSize2"
                 }
             }

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -278,6 +278,11 @@
                 "zz_fmtdict": {
                     "C_name_api": "passIndex",
                     "F_name_api": "pass_index",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "i1",
+                        "i2"
+                    ],
                     "function_name": "passIndex"
                 }
             },
@@ -494,6 +499,11 @@
                     "F_name_function": "pass_index_32",
                     "F_name_generic": "pass_index",
                     "F_name_impl": "pass_index_32",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i1",
+                        "i2"
+                    ],
                     "function_name": "passIndex",
                     "function_suffix": "_32"
                 }
@@ -711,6 +721,11 @@
                     "F_name_function": "pass_index_64",
                     "F_name_generic": "pass_index",
                     "F_name_impl": "pass_index_64",
+                    "f_arglist": [
+                        "SHT_rv",
+                        "i1",
+                        "i2"
+                    ],
                     "function_name": "passIndex",
                     "function_suffix": "_64"
                 }
@@ -861,6 +876,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "passIndex2",
                     "F_name_api": "pass_index2",
+                    "c_arglist": [
+                        "c_var",
+                        "i1"
+                    ],
                     "function_name": "passIndex2"
                 }
             },
@@ -987,6 +1006,10 @@
                     "F_name_function": "pass_index2_32",
                     "F_name_generic": "pass_index2",
                     "F_name_impl": "pass_index2_32",
+                    "f_arglist": [
+                        "f_var",
+                        "i1"
+                    ],
                     "function_name": "passIndex2",
                     "function_suffix": "_32"
                 }
@@ -1114,6 +1137,10 @@
                     "F_name_function": "pass_index2_64",
                     "F_name_generic": "pass_index2",
                     "F_name_impl": "pass_index2_64",
+                    "f_arglist": [
+                        "f_var",
+                        "i1"
+                    ],
                     "function_name": "passIndex2",
                     "function_suffix": "_64"
                 }
@@ -1264,6 +1291,10 @@
                 "zz_fmtdict": {
                     "C_name_api": "passFloat",
                     "F_name_api": "pass_float",
+                    "c_arglist": [
+                        "c_var",
+                        "f1"
+                    ],
                     "function_name": "passFloat"
                 }
             },
@@ -1390,6 +1421,10 @@
                     "F_name_function": "pass_float_float",
                     "F_name_generic": "pass_float",
                     "F_name_impl": "pass_float_float",
+                    "f_arglist": [
+                        "f_var",
+                        "f1"
+                    ],
                     "function_name": "passFloat",
                     "function_suffix": "_float"
                 }
@@ -1517,6 +1552,10 @@
                     "F_name_function": "pass_float_double",
                     "F_name_generic": "pass_float",
                     "F_name_impl": "pass_float_double",
+                    "f_arglist": [
+                        "f_var",
+                        "f1"
+                    ],
                     "function_name": "passFloat",
                     "function_suffix": "_double"
                 }

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -273,6 +273,14 @@
                     "F_name_generic": "short_func",
                     "F_name_impl": "short_func",
                     "PY_name_impl": "PY_short_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "short_func"
                 },
                 "zz_fmtlang": {
@@ -552,6 +560,14 @@
                     "F_name_generic": "int_func",
                     "F_name_impl": "int_func",
                     "PY_name_impl": "PY_int_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "int_func"
                 },
                 "zz_fmtlang": {
@@ -831,6 +847,14 @@
                     "F_name_generic": "long_func",
                     "F_name_impl": "long_func",
                     "PY_name_impl": "PY_long_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "long_func"
                 },
                 "zz_fmtlang": {
@@ -1114,6 +1138,14 @@
                     "F_name_generic": "long_long_func",
                     "F_name_impl": "long_long_func",
                     "PY_name_impl": "PY_long_long_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "long_long_func"
                 },
                 "zz_fmtlang": {
@@ -1395,6 +1427,14 @@
                     "F_name_generic": "short_int_func",
                     "F_name_impl": "short_int_func",
                     "PY_name_impl": "PY_short_int_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "short_int_func"
                 },
                 "zz_fmtlang": {
@@ -1676,6 +1716,14 @@
                     "F_name_generic": "long_int_func",
                     "F_name_impl": "long_int_func",
                     "PY_name_impl": "PY_long_int_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "long_int_func"
                 },
                 "zz_fmtlang": {
@@ -1961,6 +2009,14 @@
                     "F_name_generic": "long_long_int_func",
                     "F_name_impl": "long_long_int_func",
                     "PY_name_impl": "PY_long_long_int_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "long_long_int_func"
                 },
                 "zz_fmtlang": {
@@ -2240,6 +2296,14 @@
                     "F_name_generic": "unsigned_func",
                     "F_name_impl": "unsigned_func",
                     "PY_name_impl": "PY_unsigned_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "unsigned_func"
                 },
                 "zz_fmtlang": {
@@ -2521,6 +2585,14 @@
                     "F_name_generic": "ushort_func",
                     "F_name_impl": "ushort_func",
                     "PY_name_impl": "PY_ushort_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "ushort_func"
                 },
                 "zz_fmtlang": {
@@ -2802,6 +2874,14 @@
                     "F_name_generic": "uint_func",
                     "F_name_impl": "uint_func",
                     "PY_name_impl": "PY_uint_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "uint_func"
                 },
                 "zz_fmtlang": {
@@ -3083,6 +3163,14 @@
                     "F_name_generic": "ulong_func",
                     "F_name_impl": "ulong_func",
                     "PY_name_impl": "PY_ulong_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "ulong_func"
                 },
                 "zz_fmtlang": {
@@ -3368,6 +3456,14 @@
                     "F_name_generic": "ulong_long_func",
                     "F_name_impl": "ulong_long_func",
                     "PY_name_impl": "PY_ulong_long_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "ulong_long_func"
                 },
                 "zz_fmtlang": {
@@ -3651,6 +3747,14 @@
                     "F_name_generic": "ulong_int_func",
                     "F_name_impl": "ulong_int_func",
                     "PY_name_impl": "PY_ulong_int_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "ulong_int_func"
                 },
                 "zz_fmtlang": {
@@ -3930,6 +4034,14 @@
                     "F_name_generic": "int8_func",
                     "F_name_impl": "int8_func",
                     "PY_name_impl": "PY_int8_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "int8_func"
                 },
                 "zz_fmtlang": {
@@ -4209,6 +4321,14 @@
                     "F_name_generic": "int16_func",
                     "F_name_impl": "int16_func",
                     "PY_name_impl": "PY_int16_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "int16_func"
                 },
                 "zz_fmtlang": {
@@ -4488,6 +4608,14 @@
                     "F_name_generic": "int32_func",
                     "F_name_impl": "int32_func",
                     "PY_name_impl": "PY_int32_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "int32_func"
                 },
                 "zz_fmtlang": {
@@ -4767,6 +4895,14 @@
                     "F_name_generic": "int64_func",
                     "F_name_impl": "int64_func",
                     "PY_name_impl": "PY_int64_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "int64_func"
                 },
                 "zz_fmtlang": {
@@ -5046,6 +5182,14 @@
                     "F_name_generic": "uint8_func",
                     "F_name_impl": "uint8_func",
                     "PY_name_impl": "PY_uint8_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "uint8_func"
                 },
                 "zz_fmtlang": {
@@ -5325,6 +5469,14 @@
                     "F_name_generic": "uint16_func",
                     "F_name_impl": "uint16_func",
                     "PY_name_impl": "PY_uint16_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "uint16_func"
                 },
                 "zz_fmtlang": {
@@ -5604,6 +5756,14 @@
                     "F_name_generic": "uint32_func",
                     "F_name_impl": "uint32_func",
                     "PY_name_impl": "PY_uint32_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "uint32_func"
                 },
                 "zz_fmtlang": {
@@ -5883,6 +6043,14 @@
                     "F_name_generic": "uint64_func",
                     "F_name_impl": "uint64_func",
                     "PY_name_impl": "PY_uint64_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "uint64_func"
                 },
                 "zz_fmtlang": {
@@ -6162,6 +6330,14 @@
                     "F_name_generic": "size_func",
                     "F_name_impl": "size_func",
                     "PY_name_impl": "PY_size_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1"
+                    ],
                     "function_name": "size_func"
                 },
                 "zz_fmtlang": {
@@ -6441,6 +6617,14 @@
                     "F_name_generic": "bool_func",
                     "F_name_impl": "bool_func",
                     "PY_name_impl": "PY_bool_func",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "bool_func"
                 },
                 "zz_fmtlang": {
@@ -6727,6 +6911,14 @@
                     "F_name_generic": "return_bool_and_others",
                     "F_name_impl": "return_bool_and_others",
                     "PY_name_impl": "PY_returnBoolAndOthers",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "flag"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "flag"
+                    ],
                     "function_name": "returnBoolAndOthers"
                 },
                 "zz_fmtlang": {

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -261,6 +261,14 @@
                     "F_name_function": "vector_sum",
                     "F_name_generic": "vector_sum",
                     "F_name_impl": "vector_sum",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "vector_sum"
                 }
             },
@@ -506,6 +514,14 @@
                     "F_name_function": "vector_iota_out",
                     "F_name_generic": "vector_iota_out",
                     "F_name_impl": "vector_iota_out",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_iota_out"
                 }
             },
@@ -800,6 +816,14 @@
                     "F_name_function": "vector_iota_out_with_num",
                     "F_name_generic": "vector_iota_out_with_num",
                     "F_name_impl": "vector_iota_out_with_num",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "num",
+                        "arg"
+                    ],
                     "function_name": "vector_iota_out_with_num"
                 }
             },
@@ -1077,6 +1101,14 @@
                     "F_name_function": "vector_iota_out_with_num2",
                     "F_name_generic": "vector_iota_out_with_num2",
                     "F_name_impl": "vector_iota_out_with_num2",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "num",
+                        "arg"
+                    ],
                     "function_name": "vector_iota_out_with_num2"
                 }
             },
@@ -1326,6 +1358,14 @@
                     "F_name_function": "vector_iota_out_alloc",
                     "F_name_generic": "vector_iota_out_alloc",
                     "F_name_impl": "vector_iota_out_alloc",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_iota_out_alloc"
                 }
             },
@@ -1582,6 +1622,14 @@
                     "F_name_function": "vector_iota_inout_alloc",
                     "F_name_generic": "vector_iota_inout_alloc",
                     "F_name_impl": "vector_iota_inout_alloc",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_iota_inout_alloc"
                 }
             },
@@ -1825,6 +1873,14 @@
                     "F_name_function": "vector_increment",
                     "F_name_generic": "vector_increment",
                     "F_name_impl": "vector_increment",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_increment"
                 }
             },
@@ -2069,6 +2125,14 @@
                     "F_name_function": "vector_iota_out_d",
                     "F_name_generic": "vector_iota_out_d",
                     "F_name_impl": "vector_iota_out_d",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_iota_out_d"
                 }
             },
@@ -2422,6 +2486,16 @@
                     "F_name_function": "vector_of_pointers",
                     "F_name_generic": "vector_of_pointers",
                     "F_name_impl": "vector_of_pointers",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg1",
+                        "num"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg1",
+                        "num"
+                    ],
                     "function_name": "vector_of_pointers"
                 }
             },
@@ -2695,6 +2769,14 @@
                     "F_name_function": "vector_string_count",
                     "F_name_generic": "vector_string_count",
                     "F_name_impl": "vector_string_count",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg"
+                    ],
                     "function_name": "vector_string_count"
                 }
             },
@@ -2933,6 +3015,14 @@
                     "F_name_function": "vector_string_fill",
                     "F_name_generic": "vector_string_fill",
                     "F_name_impl": "vector_string_fill",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_string_fill"
                 }
             },
@@ -3183,6 +3273,14 @@
                     "F_name_function": "vector_string_fill_allocatable",
                     "F_name_generic": "vector_string_fill_allocatable",
                     "F_name_impl": "vector_string_fill_allocatable",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_string_fill_allocatable"
                 }
             },
@@ -3440,6 +3538,14 @@
                     "F_name_function": "vector_string_fill_allocatable_len",
                     "F_name_generic": "vector_string_fill_allocatable_len",
                     "F_name_impl": "vector_string_fill_allocatable_len",
+                    "c_arglist": [
+                        "c_var",
+                        "arg"
+                    ],
+                    "f_arglist": [
+                        "f_var",
+                        "arg"
+                    ],
                     "function_name": "vector_string_fill_allocatable_len"
                 }
             },
@@ -3807,6 +3913,14 @@
                     "F_name_function": "return_vector_alloc",
                     "F_name_generic": "return_vector_alloc",
                     "F_name_impl": "return_vector_alloc",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "n"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "n"
+                    ],
                     "function_name": "ReturnVectorAlloc"
                 }
             },
@@ -4123,6 +4237,16 @@
                     "F_name_function": "return_dim2",
                     "F_name_generic": "return_dim2",
                     "F_name_impl": "return_dim2",
+                    "c_arglist": [
+                        "SHC_rv",
+                        "arg",
+                        "len"
+                    ],
+                    "f_arglist": [
+                        "SHT_rv",
+                        "arg",
+                        "len"
+                    ],
                     "function_name": "returnDim2"
                 }
             }

--- a/regression/reference/wrap-c/wrap.json
+++ b/regression/reference/wrap-c/wrap.json
@@ -102,6 +102,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "FuncInClass"
                         }

--- a/regression/reference/wrap-cxx/wrap.json
+++ b/regression/reference/wrap-cxx/wrap.json
@@ -102,6 +102,9 @@
                             "c_deref": "*",
                             "c_member": "->",
                             "c_var": "self",
+                            "f_arglist": [
+                                "SHT_rv"
+                            ],
                             "f_intent_attr": ", intent(INOUT)",
                             "function_name": "FuncInClass"
                         }

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -197,7 +197,8 @@
         ],
         "notes": [
             "std::weak_ptr has no wrapped constructor.",
-            "It must be made from a std::shared_ptr with an assignment."
+            "It must be made from a std::shared_ptr with an assignment.",
+            "arglist[1] is the 'from' argument."
         ],
         "mixin": [
             "c_mixin_noargs"
@@ -211,7 +212,7 @@
             "self->addr = SH_this;",
             "self->idtor = {idtor};",
             "-}} else {{+",
-            "*{CXX_this} = *SHC_from_cxx;",
+            "*{CXX_this} = *{c_arglist[1].c_local_cxx};",
             "-}}"
         ],
         "destructor_name": "assignment-{cxx_type}",

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -143,6 +143,8 @@ class FillFormat(object):
         func_cursor = cursor.push_node(node)
 
         fmt_func = node.fmtdict
+        arglist = []
+        setattr(fmt_func, "{}_arglist".format(wlang), arglist)
 
         bind_result = statements.fetch_func_bind(node, wlang)
         fmt_result = statements.set_bind_fmtdict(bind_result, fmt_func)
@@ -156,6 +158,7 @@ class FillFormat(object):
         func_cursor.stmt = result_stmt
         set_share_function_format(node, bind_result, wlang)
         func_cursor.stmt = None
+        arglist.append(bind_result.fmtdict)
 
         # --- Loop over function parameters
         for arg in node.ast.declarator.params:
@@ -167,6 +170,7 @@ class FillFormat(object):
             fmt_arg = statements.set_bind_fmtdict(bind_arg, fmt_func)
             arg_stmt = bind_arg.stmt
             func_cursor.stmt = arg_stmt
+            arglist.append(fmt_arg)
 
             set_f_arg_format(node, arg, bind_arg, wlang)
             if wlang == "f":

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -283,6 +283,10 @@ class ToDict(visitor.Visitor):
         for key, value in node.__dict__.items():
             if key in ["gen"]:
                 continue
+            elif key == "c_arglist":
+                d[key] = [ d3.get("c_var", "c_var") for d3 in value]
+            elif key == "f_arglist":
+                d[key] = [ d3.get("f_var", "f_var") for d3 in value]
             elif key in ["baseclass"]:
                 d[key] = repr(value)
             elif key in ["targs"]:


### PR DESCRIPTION
Allows a statement group to access the format fields of another argument.  Used by `weak_ptr` instead of assuming the argument is named "from"

```diff
-            "*{CXX_this} = *SHC_from_cxx;",
+            "*{CXX_this} = *{c_arglist[1].c_local_cxx};",
```

Changes the JSON reference files.