### PR TITLE
Generate mixin_names in statements

### DIFF
--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -4,6 +4,9 @@ c_ctor_shadow_capptr:
   comments:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
   intent: ctor
   i_arg_names:
   - '{i_var}'
@@ -30,6 +33,11 @@ c_ctor_shadow_capptr_shared:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Create a std::shared_pointer on the heap to hold the pointer to the instance.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_destructor_new-shadow-shared'
+  - '  c_mixin_make-shared'
   intent: ctor
   i_arg_names:
   - '{i_var}'
@@ -66,6 +74,9 @@ c_ctor_shadow_capsule:
   name: c_ctor_shadow_capsule
   comments:
   - Pass function result as a capsule argument from Fortran to C.
+  mixin_names:
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
   intent: ctor
   i_arg_names:
   - '{i_var}'
@@ -86,6 +97,9 @@ c_dtor:
   name: c_dtor
   comments:
   - Call the C wrapper as a subroutine.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
   intent: dtor
   c_call:
   - delete {CXX_this};
@@ -104,6 +118,11 @@ c_function_bool:
   name: c_function_bool
   comments:
   - Call a function.
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   intent: function
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -115,6 +134,9 @@ c_function_char:
   name: c_function_char
   comments:
   - Call the C wrapper as a subroutine.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -133,6 +155,9 @@ c_function_char*:
   name: c_function_char*
   comments:
   - Call a function.
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -150,6 +175,14 @@ c_function_char*_arg:
   notes:
   - Change function result into an argument
   - Use F_string_result_as_arg as the argument name.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -195,6 +228,14 @@ c_function_char*_buf_arg:
   notes:
   - Change function result into an argument
   - Use F_string_result_as_arg as the argument name.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -241,6 +282,14 @@ c_function_char*_buf_copy:
   - char *getname() +len(30)
   - Copy result into caller's buffer.
   - XXX - maybe fmtdict to rename c_local_cxx as output
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -281,6 +330,11 @@ c_function_native:
   name: c_function_native
   comments:
   - Call a function.
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   intent: function
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -292,6 +346,9 @@ c_function_native&:
   name: c_function_native&
   comments:
   - Return a C pointer directly as type(C_PTR).
+  mixin_names:
+  - '  f_mixin_function_ptr'
+  - '    c_mixin_noargs'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -303,6 +360,9 @@ c_function_native*:
   name: c_function_native*
   comments:
   - Return a C pointer directly as type(C_PTR).
+  mixin_names:
+  - '  f_mixin_function_ptr'
+  - '    c_mixin_noargs'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -314,6 +374,9 @@ c_function_native**:
   name: c_function_native**
   comments:
   - Return a C pointer directly as type(C_PTR).
+  mixin_names:
+  - '  f_mixin_function_ptr'
+  - '    c_mixin_noargs'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -325,6 +388,9 @@ c_function_native*_caller:
   name: c_function_native*_caller
   comments:
   - Return a C pointer directly as type(C_PTR).
+  mixin_names:
+  - '  f_mixin_function_ptr'
+  - '    c_mixin_noargs'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -345,6 +411,12 @@ c_function_shadow&_capptr:
   name: c_function_shadow&_capptr
   comments:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -375,6 +447,12 @@ c_function_shadow&_capptr_caller:
   name: c_function_shadow&_capptr_caller
   comments:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -405,6 +483,12 @@ c_function_shadow&_capptr_library:
   name: c_function_shadow&_capptr_library
   comments:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -440,6 +524,13 @@ c_function_shadow&_capsule:
   - Assign to capsule in C wrapper.
   notes:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -468,6 +559,13 @@ c_function_shadow&_capsule_caller:
   - Assign to capsule in C wrapper.
   notes:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -496,6 +594,13 @@ c_function_shadow&_capsule_library:
   - Assign to capsule in C wrapper.
   notes:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -519,6 +624,12 @@ c_function_shadow*_capptr:
   name: c_function_shadow*_capptr
   comments:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -549,6 +660,12 @@ c_function_shadow*_capptr_caller:
   name: c_function_shadow*_capptr_caller
   comments:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -579,6 +696,12 @@ c_function_shadow*_capptr_library:
   name: c_function_shadow*_capptr_library
   comments:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -611,6 +734,12 @@ c_function_shadow*_capptr_shared:
   - Return a C_capsule_data_type.
   notes:
   - std::shared_ptr with a shadow class.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -646,6 +775,13 @@ c_function_shadow*_capsule:
   - Assign to capsule in C wrapper.
   notes:
   - Return a C_capsule_data_type.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -672,6 +808,9 @@ c_function_shadow*_this:
   notes:
   - Input set return_this.
   - Do not return anything.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
   intent: function
   c_call:
   - '{C_call_function};'
@@ -685,6 +824,12 @@ c_function_shadow<native>_capptr:
   - Create memory in c_pre_call so it will survive the return.
   - owner=caller sets idtor flag to release the memory.
   - c_local_var is passed in as argument.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -723,6 +868,12 @@ c_function_shadow_capptr:
   - Create memory in c_pre_call so it will survive the return.
   - owner=caller sets idtor flag to release the memory.
   - c_local_var is passed in as argument.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -760,6 +911,12 @@ c_function_smartptr<shadow>*_capptr:
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
   - Assign to capsule in C wrapper.
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -795,6 +952,12 @@ c_function_smartptr<shadow>_capptr:
   - Assign to capsule in C wrapper.
   notes:
   - Used with std::shared_ptr<Object>* createChildA(void)
+  mixin_names:
+  - '  c_mixin_function_shadow_capptr'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -830,6 +993,11 @@ c_function_string:
   comments:
   - Cannot return a char array by value.
   - Return a const pointer to std::string data.
+  mixin_names:
+  - '  c_mixin_pass_capsule'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_c-str'
+  - '  c_mixin_native_capsule_fill'
   intent: function
   i_arg_names:
   - '{i_var_capsule}'
@@ -882,6 +1050,15 @@ c_function_string&_buf_arg:
   comments:
   - Change function result into an argument.
   - Use F_string_result_as_arg as the argument name.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -929,6 +1106,15 @@ c_function_string&_buf_copy:
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -1001,6 +1187,15 @@ c_function_string*_buf_copy:
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -1086,6 +1281,15 @@ c_function_string_buf_arg:
   comments:
   - Change function result into an argument.
   - Use F_string_result_as_arg as the argument name.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -1133,6 +1337,15 @@ c_function_string_buf_copy:
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -1169,6 +1382,11 @@ c_function_struct:
   name: c_function_struct
   comments:
   - Call the C wrapper as a subroutine.
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-result'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -1187,6 +1405,9 @@ c_function_struct*:
   name: c_function_struct*
   comments:
   - C++ pointer -> void pointer -> C pointer.
+  mixin_names:
+  - '  f_mixin_function_c-ptr'
+  - '    c_mixin_noargs'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -1208,6 +1429,8 @@ c_function_vector<native>_malloc:
   - Create empty local vector then copy result to
   - malloc allocated array.
   - Add an argument with the length of the array.
+  mixin_names:
+  - '  c_mixin_function_vector_malloc'
   intent: function
   i_arg_names:
   - '{i_var_size}'
@@ -1244,6 +1467,8 @@ c_function_void*:
   name: c_function_void*
   notes:
   - XXX - f entries are the same as the i entries, share?
+  mixin_names:
+  - '  f_mixin_declare-fortran-result'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -1253,6 +1478,10 @@ c_function_void*:
   owner: library
 c_getter_native:
   name: c_getter_native
+  mixin_names:
+  - '  c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   intent: getter
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -1266,6 +1495,10 @@ c_getter_native:
   owner: library
 c_getter_native*:
   name: c_getter_native*
+  mixin_names:
+  - '  c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   intent: getter
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -1281,6 +1514,13 @@ c_in_bool:
   name: c_in_bool
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-in'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1298,6 +1538,8 @@ c_in_char:
   name: c_in_char
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1315,6 +1557,11 @@ c_in_char*:
   name: c_in_char*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1334,6 +1581,8 @@ c_in_char**:
   - Pass cxx variable to library.
   notes:
   - Treat as an assumed length array in Fortran interface.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1352,6 +1601,9 @@ c_in_char**_buf:
   comments:
   - Pass argument, size and len to C.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1391,6 +1643,11 @@ c_in_char*_buf:
   comments:
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1426,6 +1683,9 @@ c_in_enum:
   notes:
   - Use gen.cidecl to get the C interface type.
   - enums use option.F_enum_type to control the C type.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1449,6 +1709,11 @@ c_in_native:
   - Pass cxx variable to library.
   notes:
   - An intent of 'none' is used with function pointers
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1466,6 +1731,11 @@ c_in_native&:
   name: c_in_native&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1483,6 +1753,11 @@ c_in_native*:
   name: c_in_native*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1503,6 +1778,11 @@ c_in_native**:
   notes:
   - Any array of pointers.  Assumed to be non-contiguous memory.
   - All Fortran can do is treat as a type(C_PTR).
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr-value'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1521,6 +1801,9 @@ c_in_native*_cdesc:
   comments:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var_cdesc}'
@@ -1549,6 +1832,9 @@ c_in_procedure:
   name: c_in_procedure
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1567,6 +1853,9 @@ c_in_procedure_external:
   - Pass cxx variable to library.
   notes:
   - EXTERNAL is not allowed in BIND(C), so force wrapper.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1586,6 +1875,11 @@ c_in_procedure_funptr:
   - Pass type(C_FUNPTR) argument.
   notes:
   - Accept a function pointer in an argument.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_procedure-as-funptr'
+  - '  f_mixin_procedure-as-funptr-byvalue'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1604,6 +1898,10 @@ c_in_shadow:
   comments:
   - Pass a shadow type to C wrapper.
   - Pass dereference of local cxx variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_shadow'
+  - '  c_mixin_arg-call-cxx-deref'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1626,6 +1924,10 @@ c_in_shadow&:
   comments:
   - Pass a shadow type to C wrapper.
   - Pass dereference of local cxx variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_shadow'
+  - '  c_mixin_arg-call-cxx-deref'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1649,6 +1951,11 @@ c_in_shadow*:
   - Pass a shadow type to C wrapper.
   - Cast C argument to local C++ variable.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1672,6 +1979,11 @@ c_in_smartptr<shadow>*:
   - Pass a shadow type to C wrapper.
   - Cast C argument to local C++ variable.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1696,6 +2008,9 @@ c_in_string:
   notes:
   - Pass directly as argument which will construct the std::string.
   - This would work for Fortran if it explicited added C_NULL_CHAR.
+  mixin_names:
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1716,6 +2031,11 @@ c_in_string&:
   - Pass cxx local variable to library.
   notes:
   - Similar to f_in_string*, but c_arg_call is pass by value
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx'
+  - '  f_mixin_declare-interface-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1739,6 +2059,12 @@ c_in_string&_buf:
   - Pass CHARACTER and LEN to C wrapper.
   - Create local std::string from the argument with trim.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1771,6 +2097,11 @@ c_in_string*:
   comments:
   - Create local std::string from the argument.
   - Pass address of local cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx-address'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1794,6 +2125,12 @@ c_in_string*_buf:
   - Pass CHARACTER and LEN to C wrapper.
   - Create local std::string from the argument with trim.
   - Pass address of local cxx variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx-address'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1827,6 +2164,12 @@ c_in_string_buf:
   - Pass CHARACTER and LEN to C wrapper.
   - Create local std::string from the argument with trim.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1861,6 +2204,11 @@ c_in_struct:
   notes:
   - Used with in, out, inout.
   - C pointer -> void pointer -> C++ pointer
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1878,6 +2226,11 @@ c_in_struct&:
   name: c_in_struct&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1898,6 +2251,11 @@ c_in_struct*:
   notes:
   - Used with in, out, inout.
   - C pointer -> void pointer -> C++ pointer
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1917,6 +2275,11 @@ c_in_unknown:
   - Pass cxx variable to library.
   notes:
   - Used with MPI types
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1943,6 +2306,9 @@ c_in_vector<native*>&_buf:
   - Create a vector for pointers.
   notes:
   - Specialize for std::vector<native *>
+  mixin_names:
+  - '  f_mixin_in_2d_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -1987,6 +2353,9 @@ c_in_vector<native>&_buf:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_in_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2017,6 +2386,9 @@ c_in_vector<native>*_buf:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_in_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2047,6 +2419,9 @@ c_in_vector<native>_buf:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_in_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2084,6 +2459,9 @@ c_in_vector<string>&_buf:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2135,6 +2513,9 @@ c_in_vector<string>*_buf:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2186,6 +2567,9 @@ c_in_vector<string>_buf:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2234,6 +2618,11 @@ c_in_void:
   name: c_in_void
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2251,6 +2640,11 @@ c_in_void*:
   name: c_in_void*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-fortran-arg'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2270,6 +2664,8 @@ c_in_void**:
   - Pass cxx variable to library.
   notes:
   - Treat as an assumed length array in Fortran interface.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var}'
@@ -2288,6 +2684,9 @@ c_in_void*_cdesc:
   comments:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
   - '{i_var_cdesc}'
@@ -2316,6 +2715,14 @@ c_inout_bool_*:
   name: c_inout_bool_*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-in'
+  - '  f_mixin_logical-out'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2333,6 +2740,11 @@ c_inout_char*:
   name: c_inout_char*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2351,6 +2763,11 @@ c_inout_char*_buf:
   comments:
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2385,6 +2802,10 @@ c_inout_enum*:
   name: c_inout_enum*
   comments:
   - Pass address of local cxx variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_arg-call-cxx-address'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2408,6 +2829,11 @@ c_inout_native&:
   name: c_inout_native&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2425,6 +2851,8 @@ c_inout_native&_hidden:
   name: c_inout_native&_hidden
   comments:
   - Declare a local variable and pass to C.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: inout
   c_pre_call:
   - '{cxx_type} {cxx_var};'
@@ -2435,6 +2863,11 @@ c_inout_native*:
   name: c_inout_native*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2453,6 +2886,9 @@ c_inout_native*_cdesc:
   comments:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: inout
   i_arg_names:
   - '{i_var_cdesc}'
@@ -2481,6 +2917,8 @@ c_inout_native*_hidden:
   name: c_inout_native*_hidden
   comments:
   - Declare a local variable and pass to C.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar-address'
   intent: inout
   c_pre_call:
   - '{cxx_type} {cxx_var};'
@@ -2493,6 +2931,11 @@ c_inout_shadow&:
   - Pass a shadow type to C wrapper.
   - Cast C argument to local C++ variable.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2516,6 +2959,11 @@ c_inout_shadow*:
   - Pass a shadow type to C wrapper.
   - Cast C argument to local C++ variable.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2539,6 +2987,11 @@ c_inout_smartptr<shadow>*:
   - Pass a shadow type to C wrapper.
   - Cast C argument to local C++ variable.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2563,6 +3016,12 @@ c_inout_string&:
   - Create local std::string from the argument.
   - Pass cxx local variable to library.
   - Strcpy std::string into argument.
+  mixin_names:
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_character'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-strcpy-out'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2591,6 +3050,13 @@ c_inout_string&_buf:
   - Create local std::string from the argument with trim.
   - Pass cxx local variable to library.
   - Copy std::string into argument.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-copy-out'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2631,6 +3097,12 @@ c_inout_string*:
   notes:
   - XXX - the fortran wrapper is incorrect since it is passing buf
   - '  but only accepting one argument. Confused with f_inout_string*_buf'
+  mixin_names:
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_character'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-strcpy-out'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2659,6 +3131,13 @@ c_inout_string*_buf:
   - Create local std::string from the argument with trim.
   - Pass address of local cxx variable to library.
   - Copy std::string into argument.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-copy-out'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2693,6 +3172,11 @@ c_inout_struct&:
   name: c_inout_struct&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2713,6 +3197,11 @@ c_inout_struct*:
   notes:
   - Used with in, out, inout.
   - C pointer -> void pointer -> C++ pointer
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2731,6 +3220,9 @@ c_inout_vector<native>&_buf_copy:
   comments:
   - Pass argument and size by reference to C.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_out_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2762,6 +3254,9 @@ c_inout_vector<native>&_buf_malloc:
   comments:
   - Create local vector from arguments then copy result to
   - malloc allocated array.
+  mixin_names:
+  - '  c_mixin_out_vector_buf_malloc'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2799,6 +3294,9 @@ c_inout_vector<native>*_buf_copy:
   comments:
   - Pass argument and size by reference to C.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_out_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2830,6 +3328,9 @@ c_inout_vector<native>*_buf_malloc:
   comments:
   - Create local vector from arguments then copy result to
   - malloc allocated array.
+  mixin_names:
+  - '  c_mixin_out_vector_buf_malloc'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2867,6 +3368,9 @@ c_inout_vector<native>_buf_copy:
   comments:
   - Pass argument and size by reference to C.
   - Pass cxx local variable to library.
+  mixin_names:
+  - '  f_mixin_out_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2898,6 +3402,9 @@ c_inout_vector<native>_buf_malloc:
   comments:
   - Create local vector from arguments then copy result to
   - malloc allocated array.
+  mixin_names:
+  - '  c_mixin_out_vector_buf_malloc'
+  - '  c_mixin_arg-call-cxx'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2943,6 +3450,8 @@ c_inout_void**:
   - Pass cxx variable to library.
   notes:
   - Treat as an assumed length array in Fortran interface.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -2961,6 +3470,9 @@ c_inout_void*_cdesc:
   comments:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: inout
   i_arg_names:
   - '{i_var_cdesc}'
@@ -3050,6 +3562,8 @@ c_mixin_arg_character_cfi:
   comments:
   - Make the C wrapper argument a CFI_desc_t.
   - Local character argument passed as CFI_desc_t.
+  mixin_names:
+  - '  c_mixin_arg_cfi'
   intent: mixin
   i_arg_names:
   - '{i_var}'
@@ -3071,6 +3585,8 @@ c_mixin_arg_native_cfi:
   comments:
   - Make the C wrapper argument a CFI_desc_t.
   - Native argument which use CFI_desc_t.
+  mixin_names:
+  - '  c_mixin_arg_cfi'
   intent: mixin
   i_arg_names:
   - '{i_var}'
@@ -3332,6 +3848,11 @@ c_mixin_inout_vector<native>_cdesc:
   - Pass array_type to C which will fill it in.
   - Fill cdesc with vector information.
   - Return address and size of vector data.
+  mixin_names:
+  - '  f_mixin_inout_array_cdesc'
+  - '  c_mixin_inout_vector_cdesc'
+  - '  c_mixin_destructor_new-vector'
+  - '  c_mixin_vector_cdesc_fill-cdesc'
   intent: mixin
   i_arg_names:
   - '{i_var}'
@@ -3545,6 +4066,9 @@ c_mixin_out_vector<native>_cdesc:
   - Fill cdesc with vector information.
   - Return address and size of vector data.
   - Create a local std::vector.
+  mixin_names:
+  - '  c_mixin_destructor_new-vector'
+  - '  c_mixin_vector_cdesc_fill-cdesc'
   intent: mixin
   c_pre_call:
   - "{c_const}std::vector<{cxx_T}>\t *{c_local_cxx} = new std::vector<{cxx_T}>;"
@@ -3666,6 +4190,13 @@ c_out_bool_*:
   name: c_out_bool_*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-out'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3683,6 +4214,11 @@ c_out_char*:
   name: c_out_char*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3701,6 +4237,11 @@ c_out_char_*_buf:
   comments:
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3728,6 +4269,10 @@ c_out_enum*:
   name: c_out_enum*
   comments:
   - Pass address of local cxx variable to library.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_arg-call-cxx-address'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3751,6 +4296,11 @@ c_out_native&:
   name: c_out_native&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3768,6 +4318,8 @@ c_out_native&_hidden:
   name: c_out_native&_hidden
   comments:
   - Declare a local variable and pass to C.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: out
   c_pre_call:
   - '{cxx_type} {cxx_var};'
@@ -3778,6 +4330,11 @@ c_out_native*:
   name: c_out_native*
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3795,6 +4352,11 @@ c_out_native*&:
   name: c_out_native*&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3814,6 +4376,11 @@ c_out_native**:
   - Pass cxx variable to library.
   notes:
   - Make argument type(C_PTR) from 'int ** +intent(out)+deref(raw)'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-as-cptr'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3831,6 +4398,11 @@ c_out_native***:
   name: c_out_native***
   comments:
   - Pass cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-as-cptr'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3850,6 +4422,11 @@ c_out_native**_raw:
   - Pass cxx variable to library.
   notes:
   - Make argument type(C_PTR) from 'int ** +intent(out)+deref(raw)'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-as-cptr'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3868,6 +4445,9 @@ c_out_native*_cdesc:
   comments:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -3896,6 +4476,8 @@ c_out_native*_hidden:
   name: c_out_native*_hidden
   comments:
   - Declare a local variable and pass to C.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar-address'
   intent: out
   c_pre_call:
   - '{cxx_type} {cxx_var};'
@@ -3909,6 +4491,11 @@ c_out_procedure*_funptr:
   - Pass type(C_FUNPTR) argument.
   notes:
   - Return a function pointer in an argument.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_procedure-as-funptr'
+  - '  f_mixin_procedure-as-funptr-byreference'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3930,6 +4517,12 @@ c_out_string&:
   - Strcpy std::string into argument.
   notes:
   - Similar to f_out_string*
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_local-string'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-strcpy-out'
+  - '  f_mixin_declare-interface-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3958,6 +4551,13 @@ c_out_string&_buf:
   - Create local std::string.
   - Pass cxx local variable to library.
   - Copy std::string into argument.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-copy-out'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -3991,6 +4591,12 @@ c_out_string*:
   - Create local std::string.
   - Pass address of local cxx variable to library.
   - Strcpy std::string into argument.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_local-string'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-strcpy-out'
+  - '  f_mixin_declare-interface-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4020,6 +4626,10 @@ c_out_string**:
   - std::string **arg+intent(out)+dimension(size)
   - Returning a pointer to a string*. However, this needs additional
   - mapping for the C interface.  Fortran calls the +api(cdesc) variant.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr-value'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4044,6 +4654,10 @@ c_out_string**_cdesc_copy:
   - Pass a cdesc down to describe the memory and a capsule to hold the
   - C++ array. Copy into Fortran argument.
   - '[see also f_out_vector_&_cdesc_allocatable_targ_string_scalar]'
+  mixin_names:
+  - '  f_mixin_str_array'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar-address'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -4071,6 +4685,13 @@ c_out_string*_buf:
   - Create local std::string.
   - Pass address of local cxx variable to library.
   - Copy std::string into argument.
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-copy-out'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4102,6 +4723,11 @@ c_out_struct&:
   name: c_out_struct&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4122,6 +4748,11 @@ c_out_struct*:
   notes:
   - Used with in, out, inout.
   - C pointer -> void pointer -> C++ pointer
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4149,6 +4780,9 @@ c_out_vector<native>&_buf_copy:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_out_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4187,6 +4821,9 @@ c_out_vector<native>&_buf_malloc:
   - malloc allocated array.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  c_mixin_out_vector_buf_malloc'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4230,6 +4867,13 @@ c_out_vector<native>&_cdesc:
   - Pass dereference of local cxx variable to library.
   notes:
   - Not supported for C wrappers.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_out_vector<native>_copy'
+  - '  c_mixin_out_vector<native>_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx-deref'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -4271,6 +4915,9 @@ c_out_vector<native>*_buf_copy:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_out_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4309,6 +4956,9 @@ c_out_vector<native>*_buf_malloc:
   - malloc allocated array.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  c_mixin_out_vector_buf_malloc'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4352,6 +5002,13 @@ c_out_vector<native>*_cdesc:
   - Pass cxx local variable to library.
   notes:
   - Not supported for C wrappers.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_out_vector<native>_copy'
+  - '  c_mixin_out_vector<native>_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -4393,6 +5050,9 @@ c_out_vector<native>_buf_copy:
   - Pass cxx local variable to library.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  f_mixin_out_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4431,6 +5091,9 @@ c_out_vector<native>_buf_malloc:
   - malloc allocated array.
   notes:
   - XXX - need to test scalar and pointer versions
+  mixin_names:
+  - '  c_mixin_out_vector_buf_malloc'
+  - '  c_mixin_arg-call-cxx'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4474,6 +5137,9 @@ c_out_vector<string>&_buf_copy:
   name: c_out_vector<string>&_buf_copy
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4497,6 +5163,10 @@ c_out_vector<string>&_cdesc:
   notes:
   - f_arg_decl replaces values from f_mixin_str_array.
   - This one needs to use targs.
+  mixin_names:
+  - '  f_mixin_str_array'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -4528,6 +5198,14 @@ c_out_vector<string>&_cdesc_allocatable:
   - Copy into Fortran allocated memory.
   - Release memory from capsule.
   - Pass dereference of local cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  f_mixin_out_array_cdesc_allocatable'
+  - '  f_mixin_helper_vector_string_allocatable'
+  - '  f_mixin_capsule_dtor'
+  - '  c_mixin_arg-call-cxx-deref'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -4569,6 +5247,9 @@ c_out_vector<string>*_buf_copy:
   name: c_out_vector<string>*_buf_copy
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4587,6 +5268,9 @@ c_out_vector<string>_buf_copy:
   name: c_out_vector<string>_buf_copy
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4605,6 +5289,11 @@ c_out_void*&:
   name: c_out_void*&
   comments:
   - Pass dereference of cxx variable to library.
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-fortran-arg'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4624,6 +5313,8 @@ c_out_void**:
   - Pass cxx variable to library.
   notes:
   - Treat as an assumed length array in Fortran interface.
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
   - '{i_var}'
@@ -4642,6 +5333,9 @@ c_out_void*_cdesc:
   comments:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
   - '{i_var_cdesc}'
@@ -4668,12 +5362,18 @@ c_out_void*_cdesc:
     - "{cxx_type} * {c_var} = static_cast<{cxx_type} *>\t(const_cast<void *>({c_var_cdesc}->base_addr));"
 c_setter:
   name: c_setter
+  mixin_names:
+  - '  c_mixin_noargs'
   intent: setter
   c_call:
   - // skip call c_setter
   owner: library
 c_setter_native:
   name: c_setter_native
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: setter
   i_arg_names:
   - '{i_var}'
@@ -4689,6 +5389,10 @@ c_setter_native:
   owner: library
 c_setter_native*:
   name: c_setter_native*
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   intent: setter
   i_arg_names:
   - '{i_var}'
@@ -4707,6 +5411,9 @@ c_setter_string_scalar_buf:
   comments:
   - Extract meta data and pass to C.
   - Create std::string from Fortran meta data.
+  mixin_names:
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
   intent: setter
   i_arg_names:
   - '{i_var}'
@@ -4728,6 +5435,8 @@ c_setter_string_scalar_buf:
   owner: library
 c_subroutine:
   name: c_subroutine
+  mixin_names:
+  - '  c_mixin_noargs'
   intent: subroutine
   owner: library
 c_subroutine_assignment_weakptr:
@@ -4736,6 +5445,8 @@ c_subroutine_assignment_weakptr:
   - std::weak_ptr has no wrapped constructor.
   - It must be made from a std::shared_ptr with an assignment.
   - arglist[1] is the 'from' argument.
+  mixin_names:
+  - '  c_mixin_noargs'
   intent: subroutine
   c_call:
   - if (SH_this == nullptr) {{+
@@ -4762,6 +5473,9 @@ f_ctor_shadow_capsule:
   f_arg_call:
   - '{f_var}%{F_derived_member}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -4791,6 +5505,13 @@ f_ctor_shadow_capsule_shared:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_destructor_new-shadow-shared'
+  - '  c_mixin_make-shared'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -4825,6 +5546,9 @@ f_dtor:
   intent: dtor
   f_call:
   - call {f_call_function}({F_arg_c_call})
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
   c_call:
   - delete {CXX_this};
   - '{C_this}->addr = {nullptr};'
@@ -4845,6 +5569,11 @@ f_function_bool:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -4862,6 +5591,9 @@ f_function_char:
   - '{f_var}'
   f_call:
   - call {f_call_function}({F_arg_c_call})
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -4884,6 +5616,9 @@ f_function_char*:
   - 'type(C_PTR) :: {f_var}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -4899,6 +5634,9 @@ f_function_char*_allocatable:
   - 'type(C_PTR) :: {f_var}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -4938,6 +5676,14 @@ f_function_char*_arg:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -5005,6 +5751,14 @@ f_function_char*_buf_arg:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -5070,6 +5824,14 @@ f_function_char*_buf_copy:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -5123,6 +5885,12 @@ f_function_char*_cdesc_allocatable:
   - array_context
   - copy_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  c_mixin_function_char*_cdesc'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -5172,6 +5940,12 @@ f_function_char*_cdesc_pointer:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_char*_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -5208,6 +5982,10 @@ f_function_char*_cfi_allocatable:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5247,6 +6025,13 @@ f_function_char*_cfi_arg:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5289,6 +6074,13 @@ f_function_char*_cfi_copy:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5325,6 +6117,10 @@ f_function_char*_cfi_pointer:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5368,6 +6164,9 @@ f_function_char*_copy:
   - 'type(C_PTR) :: {f_var}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -5383,6 +6182,9 @@ f_function_char*_pointer:
   - 'type(C_PTR) :: {f_var}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -5398,6 +6200,9 @@ f_function_char*_raw:
   - 'type(C_PTR) :: {f_var}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -5430,6 +6235,12 @@ f_function_char_cdesc_allocatable:
   - array_context
   - copy_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  c_mixin_function_char*_cdesc'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -5479,6 +6290,12 @@ f_function_char_cdesc_pointer:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_char*_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -5515,6 +6332,10 @@ f_function_char_cfi_allocatable:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5548,6 +6369,10 @@ f_function_char_cfi_pointer:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5594,6 +6419,11 @@ f_function_enum:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -5614,6 +6444,11 @@ f_function_native:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -5644,6 +6479,9 @@ f_function_native&:
     - c_f_pointer
   f_local:
   - ptr
+  mixin_names:
+  - '  f_mixin_function_c-ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -5675,6 +6513,9 @@ f_function_native&_pointer:
     - c_f_pointer
   f_local:
   - ptr
+  mixin_names:
+  - '  f_mixin_function_c-ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -5692,6 +6533,9 @@ f_function_native**:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  f_mixin_function_ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -5741,6 +6585,17 @@ f_function_native*_cdesc_allocatable:
   - array_context
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_native_cdesc_allocate'
+  - '  f_mixin_use_capsule'
+  - '    f_mixin_pass_capsule'
+  - '      c_mixin_pass_capsule'
+  - '    c_mixin_native_capsule_fill'
+  - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -5797,6 +6652,12 @@ f_function_native*_cdesc_pointer:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_native_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -5859,6 +6720,15 @@ f_function_native*_cdesc_pointer_caller:
   - array_context
   - capsule_helper
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_arg_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_native_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -5904,6 +6774,13 @@ f_function_native*_cfi_allocatable:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_native_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_native_cfi_allocatable'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5953,6 +6830,13 @@ f_function_native*_cfi_pointer:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_native_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_native_cfi_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6015,6 +6899,9 @@ f_function_native*_pointer:
     - c_f_pointer
   f_local:
   - ptr
+  mixin_names:
+  - '  f_mixin_function_c-ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -6046,6 +6933,9 @@ f_function_native*_pointer_caller:
     - c_f_pointer
   f_local:
   - ptr
+  mixin_names:
+  - '  f_mixin_function_c-ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -6063,6 +6953,9 @@ f_function_native*_raw:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  f_mixin_function_ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -6081,6 +6974,11 @@ f_function_native*_scalar:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_function'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -6108,6 +7006,13 @@ f_function_shadow&_capsule:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6143,6 +7048,13 @@ f_function_shadow&_capsule_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6178,6 +7090,13 @@ f_function_shadow&_capsule_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6213,6 +7132,13 @@ f_function_shadow*_capsule:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6248,6 +7174,13 @@ f_function_shadow*_capsule_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6283,6 +7216,13 @@ f_function_shadow*_capsule_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6312,6 +7252,9 @@ f_function_shadow*_this:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_result_var: as-subroutine
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
   c_call:
   - '{C_call_function};'
   c_return_type: void
@@ -6332,6 +7275,13 @@ f_function_shadow<native>_capsule:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6370,6 +7320,13 @@ f_function_shadow_capsule:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6407,6 +7364,13 @@ f_function_smartptr<shadow>*_capsule:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6442,6 +7406,13 @@ f_function_smartptr<shadow>_capsule:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_shadow_capsule'
+  - '  c_mixin_shadow'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_cvar-capsule-fill'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6492,6 +7463,15 @@ f_function_string&_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -6551,6 +7531,15 @@ f_function_string&_buf_arg:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -6617,6 +7606,15 @@ f_function_string&_buf_caller:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_char-copy-to-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_delete-cxx-variable'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -6673,6 +7671,15 @@ f_function_string&_buf_copy:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -6732,6 +7739,15 @@ f_function_string&_buf_copy_caller:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_char-copy-to-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_delete-cxx-variable'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -6797,6 +7813,16 @@ f_function_string&_cdesc_allocatable:
   - copy_string
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_function_string_cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -6859,6 +7885,16 @@ f_function_string&_cdesc_allocatable_caller:
   - copy_string
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_function_string_cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -6921,6 +7957,16 @@ f_function_string&_cdesc_allocatable_library:
   - copy_string
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_function_string_cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -6974,6 +8020,12 @@ f_function_string&_cdesc_pointer:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7019,6 +8071,12 @@ f_function_string&_cdesc_pointer_caller:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7064,6 +8122,12 @@ f_function_string&_cdesc_pointer_library:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7094,6 +8158,11 @@ f_function_string&_cfi_allocatable:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7127,6 +8196,11 @@ f_function_string&_cfi_allocatable_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7160,6 +8234,11 @@ f_function_string&_cfi_allocatable_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7199,6 +8278,16 @@ f_function_string&_cfi_arg:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_cfi'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg-cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7253,6 +8342,16 @@ f_function_string&_cfi_copy:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_cfi'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg-cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7298,6 +8397,10 @@ f_function_string&_cfi_pointer:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7348,6 +8451,10 @@ f_function_string&_cfi_pointer_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7398,6 +8505,10 @@ f_function_string&_cfi_pointer_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7460,6 +8571,15 @@ f_function_string*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -7519,6 +8639,15 @@ f_function_string*_buf_caller:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_char-copy-to-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_delete-cxx-variable'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -7575,6 +8704,15 @@ f_function_string*_buf_copy:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -7634,6 +8772,15 @@ f_function_string*_buf_copy_caller:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_char-copy-to-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_delete-cxx-variable'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -7699,6 +8846,16 @@ f_function_string*_cdesc_allocatable:
   - copy_string
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_function_string_cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -7761,6 +8918,16 @@ f_function_string*_cdesc_allocatable_caller:
   - copy_string
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_function_string_cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -7823,6 +8990,16 @@ f_function_string*_cdesc_allocatable_library:
   - copy_string
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_function_string_cdesc'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -7876,6 +9053,12 @@ f_function_string*_cdesc_pointer:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7921,6 +9104,12 @@ f_function_string*_cdesc_pointer_caller:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7966,6 +9155,12 @@ f_function_string*_cdesc_pointer_library:
   - array_context
   - pointer_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7996,6 +9191,11 @@ f_function_string*_cfi_allocatable:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8029,6 +9229,11 @@ f_function_string*_cfi_allocatable_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8062,6 +9267,11 @@ f_function_string*_cfi_allocatable_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8103,6 +9313,16 @@ f_function_string*_cfi_copy:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_cfi'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg-cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8148,6 +9368,10 @@ f_function_string*_cfi_pointer:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8198,6 +9422,10 @@ f_function_string*_cfi_pointer_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8248,6 +9476,10 @@ f_function_string*_cfi_pointer_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8310,6 +9542,15 @@ f_function_string_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -8369,6 +9610,15 @@ f_function_string_buf_arg:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -8435,6 +9685,15 @@ f_function_string_buf_caller:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_char-copy-to-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_delete-cxx-variable'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -8491,6 +9750,15 @@ f_function_string_buf_copy:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -8550,6 +9818,15 @@ f_function_string_buf_copy_caller:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_char-copy-to-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_delete-cxx-variable'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -8616,6 +9893,19 @@ f_function_string_cdesc_allocatable:
   - array_context
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_destructor_new-string'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_use_capsule'
+  - '    f_mixin_pass_capsule'
+  - '      c_mixin_pass_capsule'
+  - '    c_mixin_native_capsule_fill'
+  - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -8691,6 +9981,19 @@ f_function_string_cdesc_allocatable_caller:
   - array_context
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_destructor_new-string'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_use_capsule'
+  - '    f_mixin_pass_capsule'
+  - '      c_mixin_pass_capsule'
+  - '    c_mixin_native_capsule_fill'
+  - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -8766,6 +10069,19 @@ f_function_string_cdesc_allocatable_library:
   - array_context
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_function-assign-to-new'
+  - '  c_mixin_destructor_new-string'
+  - '  c_mixin_function_string_cdesc'
+  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_use_capsule'
+  - '    f_mixin_pass_capsule'
+  - '      c_mixin_pass_capsule'
+  - '    c_mixin_native_capsule_fill'
+  - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -8818,6 +10134,11 @@ f_function_string_cfi_allocatable:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8849,6 +10170,11 @@ f_function_string_cfi_allocatable_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8882,6 +10208,11 @@ f_function_string_cfi_allocatable_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_function_string_cfi_allocatable'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8921,6 +10252,16 @@ f_function_string_cfi_arg:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_cfi'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg-cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8975,6 +10316,16 @@ f_function_string_cfi_copy:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_pass_character_cfi'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_function-assign-to-local'
+  - '  c_mixin_char-copy-to-arg-cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9020,6 +10371,10 @@ f_function_string_cfi_pointer:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9070,6 +10425,10 @@ f_function_string_cfi_pointer_caller:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9120,6 +10479,10 @@ f_function_string_cfi_pointer_library:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9168,6 +10531,11 @@ f_function_struct:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-result'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9209,6 +10577,12 @@ f_function_struct*_cdesc_pointer:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_native_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9250,6 +10624,9 @@ f_function_struct*_pointer:
     - c_f_pointer
   f_local:
   - ptr
+  mixin_names:
+  - '  f_mixin_function_c-ptr'
+  - '    c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -9290,6 +10667,12 @@ f_function_vector<native>_cdesc_allocatable:
   f_helper:
   - copy_array
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_destructor_new-vector'
+  - '  c_mixin_vector_cdesc_fill-cdesc'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9348,6 +10731,8 @@ f_function_void*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-result'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -9362,6 +10747,10 @@ f_getter_bool:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -9380,6 +10769,10 @@ f_getter_native:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -9421,6 +10814,12 @@ f_getter_native*_cdesc_pointer:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_native_cdesc_pointer'
+  - '  f_mixin_getter_cdesc'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9451,6 +10850,10 @@ f_getter_native*_pointer:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_noargs'
+  - '  f_mixin_declare-fortran-result'
+  - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
   i_module:
@@ -9483,6 +10886,11 @@ f_getter_string_cdesc_allocatable:
   - array_context
   - copy_string
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_char_cdesc_allocate'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9531,6 +10939,12 @@ f_getter_struct**_cdesc_raw:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_native_cdesc_raw'
+  - '  f_mixin_getter_cdesc'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9584,6 +10998,12 @@ f_getter_struct*_cdesc_pointer:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_function-to-subroutine'
+  - '    c_mixin_noargs'
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_native_cdesc_pointer'
+  - '  f_mixin_getter_cdesc'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9644,6 +11064,13 @@ f_in_bool:
     - C_BOOL
   f_temps:
   - cxx
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-in'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9665,6 +11092,8 @@ f_in_char:
   - '{f_var}'
   f_arg_decl:
   - 'character, value{f_intent_attr} :: {f_var}'
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9689,6 +11118,11 @@ f_in_char*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9708,6 +11142,8 @@ f_in_char**:
   notes:
   - Treat as an assumed length array in Fortran interface.
   intent: in
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9739,6 +11175,9 @@ f_in_char**_buf:
     - C_SIZE_T
     - C_INT
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -9783,6 +11222,10 @@ f_in_char**_cfi:
   - '{f_var}'
   f_arg_decl:
   - 'character(len=*){f_intent_attr} :: {f_var}(:)'
+  mixin_names:
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9836,6 +11279,11 @@ f_in_char*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -9875,6 +11323,11 @@ f_in_char*_capi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9901,6 +11354,11 @@ f_in_char*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9940,6 +11398,9 @@ f_in_enum:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9970,6 +11431,11 @@ f_in_native:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9994,6 +11460,11 @@ f_in_native&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10018,6 +11489,11 @@ f_in_native*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10045,6 +11521,11 @@ f_in_native**:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr-value'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10088,6 +11569,9 @@ f_in_native*_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -10119,6 +11603,11 @@ f_in_native*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_native_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10150,6 +11639,9 @@ f_in_procedure:
   - 'procedure({f_abstract_interface}) :: {f_var}'
   f_arg_call:
   - '{f_var}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10175,6 +11667,9 @@ f_in_procedure_external:
   f_arg_call:
   - '{f_var}'
   f_need_wrapper: true
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10203,6 +11698,11 @@ f_in_procedure_funptr:
   f_module:
     iso_c_binding:
     - C_FUNPTR
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_procedure-as-funptr'
+  - '  f_mixin_procedure-as-funptr-byvalue'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10231,6 +11731,10 @@ f_in_shadow:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_shadow'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10263,6 +11767,10 @@ f_in_shadow&:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_shadow'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10296,6 +11804,11 @@ f_in_shadow*:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10329,6 +11842,11 @@ f_in_smartptr<shadow>*:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10353,6 +11871,11 @@ f_in_string&:
   notes:
   - Similar to f_in_string*, but c_arg_call is pass by value
   intent: in
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx'
+  - '  f_mixin_declare-interface-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10395,6 +11918,12 @@ f_in_string&_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -10432,6 +11961,10 @@ f_in_string&_cfi:
   - '{f_var}'
   f_arg_decl:
   - 'character(len=*){f_intent_attr} :: {f_var}'
+  mixin_names:
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10460,6 +11993,11 @@ f_in_string*:
   - Create local std::string from the argument.
   - Pass address of local cxx variable to library.
   intent: in
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10502,6 +12040,12 @@ f_in_string*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -10539,6 +12083,10 @@ f_in_string*_cfi:
   - '{f_var}'
   f_arg_decl:
   - 'character(len=*){f_intent_attr} :: {f_var}'
+  mixin_names:
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10587,6 +12135,12 @@ f_in_string_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -10624,6 +12178,10 @@ f_in_string_cfi:
   - '{f_var}'
   f_arg_decl:
   - 'character(len=*){f_intent_attr} :: {f_var}'
+  mixin_names:
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10661,6 +12219,11 @@ f_in_struct:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10685,6 +12248,11 @@ f_in_struct&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10712,6 +12280,11 @@ f_in_struct*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10738,6 +12311,11 @@ f_in_unknown:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10770,6 +12348,9 @@ f_in_vector<native*>&_buf:
     - '{targs[0].f_kind}'
     - C_SIZE_T
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_2d_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -10819,6 +12400,9 @@ f_in_vector<native>&_buf:
     - '{targs[0].f_kind}'
     - C_SIZE_T
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -10861,6 +12445,9 @@ f_in_vector<native>*_buf:
     - '{targs[0].f_kind}'
     - C_SIZE_T
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -10903,6 +12490,9 @@ f_in_vector<native>_buf:
     - '{targs[0].f_kind}'
     - C_SIZE_T
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_vector_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -10946,6 +12536,9 @@ f_in_vector<string>&_buf:
     - C_SIZE_T
     - C_INT
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -11010,6 +12603,9 @@ f_in_vector<string>*_buf:
     - C_SIZE_T
     - C_INT
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -11074,6 +12670,9 @@ f_in_vector<string>_buf:
     - C_SIZE_T
     - C_INT
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -11133,6 +12732,11 @@ f_in_void:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11157,6 +12761,11 @@ f_in_void*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11183,6 +12792,8 @@ f_in_void**:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11209,6 +12820,8 @@ f_in_void**_cfi:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11252,6 +12865,9 @@ f_in_void*_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -11293,6 +12909,14 @@ f_inout_bool*:
     - C_BOOL
   f_temps:
   - cxx
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-in'
+  - '  f_mixin_logical-out'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11317,6 +12941,11 @@ f_inout_char*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11354,6 +12983,11 @@ f_inout_char*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -11395,6 +13029,11 @@ f_inout_char*_capi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11421,6 +13060,11 @@ f_inout_char*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11459,6 +13103,10 @@ f_inout_enum*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11489,6 +13137,11 @@ f_inout_native&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11506,6 +13159,8 @@ f_inout_native&_hidden:
   comments:
   - Declare a local variable and pass to C.
   intent: inout
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   c_pre_call:
   - '{cxx_type} {cxx_var};'
   c_arg_call:
@@ -11523,6 +13178,11 @@ f_inout_native*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11566,6 +13226,9 @@ f_inout_native*_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -11597,6 +13260,11 @@ f_inout_native*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_native_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11622,6 +13290,8 @@ f_inout_native*_hidden:
   comments:
   - Declare a local variable and pass to C.
   intent: inout
+  mixin_names:
+  - '  c_mixin_arg-call-cvar-address'
   c_pre_call:
   - '{cxx_type} {cxx_var};'
   c_arg_call:
@@ -11644,6 +13314,11 @@ f_inout_shadow&:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11677,6 +13352,11 @@ f_inout_shadow*:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11710,6 +13390,11 @@ f_inout_smartptr<shadow>*:
     '{f_module_name}':
     - '{f_kind}'
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_shadow-arg'
+  - '  c_mixin_cast-argument'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_shadow'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11747,6 +13432,12 @@ f_inout_string&:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_character'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-strcpy-out'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11794,6 +13485,13 @@ f_inout_string&_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-copy-out'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -11837,6 +13535,11 @@ f_inout_string&_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11887,6 +13590,12 @@ f_inout_string*:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_character'
+  - '  c_mixin_local-string-init'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-strcpy-out'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11934,6 +13643,13 @@ f_inout_string*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string-init-trim'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-copy-out'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -11977,6 +13693,11 @@ f_inout_string*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -12015,6 +13736,11 @@ f_inout_struct&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -12042,6 +13768,11 @@ f_inout_struct*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -12087,6 +13818,13 @@ f_inout_vector<native>&_cdesc:
   f_helper:
   - array_context
   - copy_array
+  mixin_names:
+  - '  c_mixin_inout_vector<native>_cdesc'
+  - '    f_mixin_inout_array_cdesc'
+  - '    c_mixin_inout_vector_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -12166,6 +13904,13 @@ f_inout_vector<native>&_cdesc_allocatable:
   f_helper:
   - array_context
   - copy_array
+  mixin_names:
+  - '  c_mixin_inout_vector<native>_cdesc'
+  - '    f_mixin_inout_array_cdesc'
+  - '    c_mixin_inout_vector_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -12229,6 +13974,9 @@ f_inout_vector_buf_targ_string_scalar:
     - C_SIZE_T
     - C_INT
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -12299,6 +14047,8 @@ f_inout_void**:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -12342,6 +14092,9 @@ f_inout_void*_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -12378,6 +14131,8 @@ f_mixin_arg_capsule:
   - array_context
   - capsule_helper
   f_need_wrapper: true
+  mixin_names:
+  - '  c_mixin_pass_capsule'
   i_arg_names:
   - '{i_var_capsule}'
   i_arg_decl:
@@ -12481,6 +14236,8 @@ f_mixin_function:
   intent: mixin
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
+  mixin_names:
+  - '  c_mixin_noargs'
   owner: library
 f_mixin_function-to-subroutine:
   name: f_mixin_function-to-subroutine
@@ -12489,6 +14246,8 @@ f_mixin_function-to-subroutine:
   intent: mixin
   f_call:
   - call {f_call_function}({F_arg_c_call})
+  mixin_names:
+  - '  c_mixin_noargs'
   c_return_type: void
   owner: library
 f_mixin_function_c-ptr:
@@ -12512,6 +14271,8 @@ f_mixin_function_c-ptr:
     - c_f_pointer
   f_local:
   - ptr
+  mixin_names:
+  - '  c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -12529,6 +14290,8 @@ f_mixin_function_ptr:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_noargs'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -12970,6 +14733,8 @@ f_mixin_pass_capsule:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  c_mixin_pass_capsule'
   i_arg_names:
   - '{i_var_capsule}'
   i_arg_decl:
@@ -13146,6 +14911,11 @@ f_mixin_use_capsule:
   - array_context
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_capsule}'
   i_arg_decl:
@@ -13182,6 +14952,13 @@ f_none_bool:
     - C_BOOL
   f_temps:
   - cxx
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-in'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13216,6 +14993,13 @@ f_none_bool*:
     - C_BOOL
   f_temps:
   - cxx
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-out'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13237,6 +15021,8 @@ f_none_char:
   - '{f_var}'
   f_arg_decl:
   - 'character, value{f_intent_attr} :: {f_var}'
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13261,6 +15047,11 @@ f_none_char*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13287,6 +15078,11 @@ f_none_native:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13311,6 +15107,11 @@ f_none_native*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13335,6 +15136,11 @@ f_none_void*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13369,6 +15175,13 @@ f_out_bool*:
     - C_BOOL
   f_temps:
   - cxx
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-out'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13393,6 +15206,11 @@ f_out_char*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13430,6 +15248,11 @@ f_out_char*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -13464,6 +15287,11 @@ f_out_char*_capi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13490,6 +15318,11 @@ f_out_char*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13523,6 +15356,10 @@ f_out_enum*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13553,6 +15390,11 @@ f_out_native&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13570,6 +15412,8 @@ f_out_native&_hidden:
   comments:
   - Declare a local variable and pass to C.
   intent: out
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   c_pre_call:
   - '{cxx_type} {cxx_var};'
   c_arg_call:
@@ -13587,6 +15431,11 @@ f_out_native*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13628,6 +15477,12 @@ f_out_native*&_cdesc:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_out_native**'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_out_native_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -13680,6 +15535,12 @@ f_out_native*&_cdesc_pointer:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_out_native**'
+  - '  c_mixin_arg-call-cvar'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_out_native_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -13715,6 +15576,11 @@ f_out_native***:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-as-cptr'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13773,6 +15639,18 @@ f_out_native**_cdesc_allocatable:
   - array_context
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  c_mixin_out_native**'
+  - '  c_mixin_arg-call-cvar-address'
+  - '  f_mixin_out_native_cdesc_allocate'
+  - '  f_mixin_use_capsule'
+  - '    f_mixin_pass_capsule'
+  - '      c_mixin_pass_capsule'
+  - '    c_mixin_native_capsule_fill'
+  - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -13839,6 +15717,12 @@ f_out_native**_cdesc_pointer:
   f_helper:
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_out_native**'
+  - '  c_mixin_arg-call-cvar-address'
+  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_out_native_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -13874,6 +15758,12 @@ f_out_native**_cfi_allocatable:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_native_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_native_cfi_allocatable'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13916,6 +15806,12 @@ f_out_native**_cfi_pointer:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_native_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_native_cfi_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -13967,6 +15863,11 @@ f_out_native**_raw:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-as-cptr'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14010,6 +15911,9 @@ f_out_native*_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14036,6 +15940,8 @@ f_out_native*_hidden:
   comments:
   - Declare a local variable and pass to C.
   intent: out
+  mixin_names:
+  - '  c_mixin_arg-call-cvar-address'
   c_pre_call:
   - '{cxx_type} {cxx_var};'
   c_arg_call:
@@ -14058,6 +15964,11 @@ f_out_procedure*_funptr:
   f_module:
     iso_c_binding:
     - C_FUNPTR
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_procedure-as-funptr'
+  - '  f_mixin_procedure-as-funptr-byreference'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14097,6 +16008,13 @@ f_out_string&_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string'
+  - '  c_mixin_arg-call-cxx'
+  - '  c_mixin_string-copy-out'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -14137,6 +16055,11 @@ f_out_string&_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14201,6 +16124,15 @@ f_out_string**_cdesc_allocatable:
   - array_string_allocatable
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  f_mixin_out_array_cdesc_allocatable'
+  - '  f_mixin_helper_array_string_allocatable'
+  - '  c_mixin_arg-call-cvar-address'
+  - '  c_mixin_native_capsule_fill'
+  - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -14269,6 +16201,10 @@ f_out_string**_cdesc_copy:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_str_array'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar-address'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14305,6 +16241,11 @@ f_out_string**_cfi_allocatable:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_cfi'
+  - '  c_mixin_out_string**'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14338,6 +16279,11 @@ f_out_string**_cfi_copy:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_cfi'
+  - '  c_mixin_out_string**'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14366,6 +16312,10 @@ f_out_string**_copy:
   - Returning a pointer to a string*. However, this needs additional
   - mapping for the C interface.  Fortran calls the +api(cdesc) variant.
   intent: out
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_interface-as-cptr-value'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14406,6 +16356,13 @@ f_out_string*_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
+  - '  c_mixin_local-string'
+  - '  c_mixin_arg-call-cxx-address'
+  - '  c_mixin_string-copy-out'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -14446,6 +16403,11 @@ f_out_string*_cfi:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  f_mixin_declare-fortran-arg'
+  - '  c_mixin_arg_character_cfi'
+  - '    c_mixin_arg_cfi'
+  - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14481,6 +16443,11 @@ f_out_struct&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14508,6 +16475,11 @@ f_out_struct*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -14553,6 +16525,13 @@ f_out_vector<native>&_cdesc:
   - array_context
   - copy_array
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_out_vector<native>_copy'
+  - '  c_mixin_out_vector<native>_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14618,6 +16597,12 @@ f_out_vector<native>&_cdesc_allocatable:
   f_helper:
   - copy_array
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_out_vector<native>_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14681,6 +16666,13 @@ f_out_vector<native>*_cdesc:
   - array_context
   - copy_array
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_out_vector<native>_copy'
+  - '  c_mixin_out_vector<native>_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14746,6 +16738,12 @@ f_out_vector<native>*_cdesc_allocatable:
   f_helper:
   - copy_array
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_out_vector<native>_cdesc'
+  - '    c_mixin_destructor_new-vector'
+  - '    c_mixin_vector_cdesc_fill-cdesc'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14809,6 +16807,10 @@ f_out_vector<string>&_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_str_array'
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -14867,6 +16869,14 @@ f_out_vector<string>&_cdesc_allocatable:
   - vector_string_allocatable
   - capsule_dtor
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_pass_capsule'
+  - '    c_mixin_pass_capsule'
+  - '  f_mixin_out_array_cdesc_allocatable'
+  - '  f_mixin_helper_vector_string_allocatable'
+  - '  f_mixin_capsule_dtor'
+  - '  c_mixin_arg-call-cxx-deref'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -14922,6 +16932,9 @@ f_out_vector_buf_targ_string_scalar:
     - C_SIZE_T
     - C_INT
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_in_string_array_buf'
+  - '  c_mixin_arg-call-cxx'
   i_arg_names:
   - '{i_var}'
   - '{i_var_size}'
@@ -14979,6 +16992,11 @@ f_out_void*&:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  c_mixin_arg-call-cvar-deref'
+  - '  f_mixin_interface-as-cptr'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15005,6 +17023,8 @@ f_out_void**:
   f_module:
     iso_c_binding:
     - C_PTR
+  mixin_names:
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15048,6 +17068,9 @@ f_out_void*_cdesc:
   - type_defines
   - array_context
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_cdesc'
+  - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -15070,6 +17093,8 @@ f_setter:
   intent: setter
   f_call:
   - call {f_call_function}({F_arg_c_call})
+  mixin_names:
+  - '  c_mixin_noargs'
   c_call:
   - // skip call c_setter
   owner: library
@@ -15093,6 +17118,12 @@ f_setter_bool:
     - C_BOOL
   f_temps:
   - cxx
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-fortran-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_logical-local-var'
+  - '  f_mixin_logical-in'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15117,6 +17148,10 @@ f_setter_native:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15141,6 +17176,10 @@ f_setter_native*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15176,6 +17215,9 @@ f_setter_string_buf:
   f_temps:
   - len
   f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_pass_character_buf'
+  - '  c_mixin_in_character_buf'
   i_arg_names:
   - '{i_var}'
   - '{i_var_len}'
@@ -15204,6 +17246,10 @@ f_setter_struct*:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15226,6 +17272,9 @@ f_setter_struct**:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15248,6 +17297,10 @@ f_setter_struct*_pointer:
   f_module:
     '{f_module_name}':
     - '{f_kind}'
+  mixin_names:
+  - '  c_mixin_declare-arg'
+  - '  f_mixin_declare-interface-arg'
+  - '  f_mixin_declare-fortran-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15265,6 +17318,8 @@ f_subroutine:
   intent: subroutine
   f_call:
   - call {f_call_function}({F_arg_c_call})
+  mixin_names:
+  - '  c_mixin_noargs'
   owner: library
 f_subroutine_assignment_weakptr:
   name: f_subroutine_assignment_weakptr
@@ -15275,6 +17330,8 @@ f_subroutine_assignment_weakptr:
   intent: subroutine
   f_call:
   - call {f_call_function}({F_arg_c_call})
+  mixin_names:
+  - '  c_mixin_noargs'
   c_call:
   - if (SH_this == nullptr) {{+
   - SH_this = new {cxx_type}(*SHC_from_cxx);

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -405,6 +405,9 @@ def append_mixin(stmt, mixin):
             if key == "notes":
                 # notes do not accumulate like other fields.
                 continue
+            elif key == "mixin_names":
+                # Indent nested mixins
+                value = ["  " + val for val in value]
             if key not in stmt:
                 stmt[key] = []
             if False:#True:
@@ -512,11 +515,13 @@ def process_mixin(stmts, defaults, stmtdict):
         if "mixin" in stmt:
             if "base" in stmt:
                 print("XXXX - Groups with mixin cannot have a 'base' field ", name)
+            tmp_node["mixin_names"] = []
             for mixin in stmt["mixin"]:
                 ### compute mixin permutations
                 if mixin[0] == "#":
                     continue
                 mparts = mixin.split("_", 2)
+                tmp_node["mixin_names"].append("  " + mixin)
                 if mparts[1] != "mixin":
                     cursor.warning("Mixin '{}' must have intent 'mixin'.".format(mixin))
                 elif mixin not in mixins:
@@ -805,6 +810,7 @@ CStmts = util.Scope(
     name="c_default",
     comments=[],
     notes=[],      # implementation notes
+    mixin_names=[],
     index="X",
     intent=None,
 


### PR DESCRIPTION
Can be used to help understand how a group was composed of mixins. Nested mixins are indented an additional layer.  Top level names are indented to ensure single quotes are in the --write-statements file and makes the names line up when there are nested mixins.