### PR TITLE
define sh_type for Typemap char

### DIFF
--- a/regression/reference/char-cxx-cfi/char.json
+++ b/regression/reference/char-cxx-cfi/char.json
@@ -180,7 +180,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -246,7 +246,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -370,7 +370,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -436,7 +436,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -527,7 +527,7 @@
                                 "i_intent_attr": ", intent(OUT)",
                                 "i_name_function": "c_return_char",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char",
                                 "typemap_name": "char"
                             },
@@ -574,7 +574,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char",
                                 "typemap_name": "char"
                             },
@@ -729,7 +729,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "dest",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -767,7 +767,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -839,7 +839,7 @@
                                 "i_var_cfi": "SHT_dest_cfi",
                                 "i_var_len": "SHT_dest_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -887,7 +887,7 @@
                                 "i_var_cfi": "SHT_src_cfi",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -1040,7 +1040,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "s",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_inout_char*",
                                 "typemap_name": "char"
                             },
@@ -1114,7 +1114,7 @@
                                 "i_var_cfi": "SHT_s_cfi",
                                 "i_var_len": "SHT_s_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_inout_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -1221,7 +1221,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1272,7 +1272,7 @@
                                 "i_var": "SHT_rv",
                                 "i_var_cfi": "SHT_rv_cfi",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_cfi_allocatable",
                                 "typemap_name": "char"
                             },
@@ -1382,7 +1382,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1440,7 +1440,7 @@
                                 "i_var_cfi": "SHT_rv_cfi",
                                 "i_var_len": "SHT_rv_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_cfi_copy",
                                 "typemap_name": "char"
                             },
@@ -1550,7 +1550,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1604,7 +1604,7 @@
                                 "i_var_cfi": "SHT_rv_cfi",
                                 "i_var_len": "SHT_rv_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_cfi_arg",
                                 "typemap_name": "char"
                             },
@@ -1698,7 +1698,7 @@
                                 "cxx_var": "SHC_rv",
                                 "i_name_function": "c_get_char_ptr4",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1744,7 +1744,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_raw",
                                 "typemap_name": "char"
                             },
@@ -1846,7 +1846,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1907,7 +1907,7 @@
                                 "i_var": "SHT_rv",
                                 "i_var_cfi": "SHT_rv_cfi",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_cfi_pointer",
                                 "typemap_name": "char"
                             },
@@ -2109,7 +2109,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2182,7 +2182,7 @@
                                 "i_var_cfi": "SHT_name_cfi",
                                 "i_var_len": "SHT_name_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -2327,7 +2327,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -2402,7 +2402,7 @@
                                 "i_var_cfi": "SHT_name_cfi",
                                 "i_var_len": "SHT_name_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -2524,7 +2524,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -2590,7 +2590,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -2681,7 +2681,7 @@
                                 "i_intent_attr": ", intent(OUT)",
                                 "i_name_function": "c_creturn_char",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char",
                                 "typemap_name": "char"
                             },
@@ -2728,7 +2728,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char",
                                 "typemap_name": "char"
                             },
@@ -2886,7 +2886,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "dest",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -2924,7 +2924,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2996,7 +2996,7 @@
                                 "i_var_cfi": "SHT_dest_cfi",
                                 "i_var_len": "SHT_dest_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -3045,7 +3045,7 @@
                                 "i_var_cfi": "SHT_src_cfi",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -3217,7 +3217,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "dest",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -3255,7 +3255,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -3327,7 +3327,7 @@
                                 "i_var_cfi": "SHT_dest_cfi",
                                 "i_var_len": "SHT_dest_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -3376,7 +3376,7 @@
                                 "i_var_cfi": "SHT_src_cfi",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -3550,7 +3550,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -3647,7 +3647,7 @@
                                 "i_var_cfi": "SHT_src_cfi",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -3839,7 +3839,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -3969,7 +3969,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -4161,7 +4161,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "in",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4199,7 +4199,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4296,7 +4296,7 @@
                                 "i_var_cfi": "SHT_in_cfi",
                                 "i_var_len": "SHT_in_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },
@@ -4336,7 +4336,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -4514,7 +4514,7 @@
                                 "i_var": "names",
                                 "idtor": "0",
                                 "rank": "1",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "size": "size(names)",
                                 "stmt_name": "c_in_char**",
                                 "typemap_name": "char"
@@ -4618,7 +4618,7 @@
                                 "i_var_size": "SHT_names_size",
                                 "idtor": "0",
                                 "rank": "1",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "size": "size(names)",
                                 "stmt_name": "f_in_char**_cfi",
                                 "typemap_name": "char"

--- a/regression/reference/char-cxx/char.json
+++ b/regression/reference/char-cxx/char.json
@@ -205,7 +205,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -271,7 +271,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -449,7 +449,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -515,7 +515,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -607,7 +607,7 @@
                                 "i_intent_attr": ", intent(OUT)",
                                 "i_name_function": "c_return_char",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char",
                                 "typemap_name": "char"
                             },
@@ -654,7 +654,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char",
                                 "typemap_name": "char"
                             },
@@ -845,7 +845,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "dest",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -883,7 +883,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -952,7 +952,7 @@
                                 "i_var": "dest",
                                 "i_var_len": "SHT_dest_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -992,7 +992,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1226,7 +1226,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "s",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_inout_char*",
                                 "typemap_name": "char"
                             },
@@ -1299,7 +1299,7 @@
                                 "i_var": "s",
                                 "i_var_len": "SHT_s_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_inout_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -1472,7 +1472,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1529,7 +1529,7 @@
                                 "i_var": "SHT_rv",
                                 "i_var_cdesc": "SHT_rv_cdesc",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_cdesc_allocatable",
                                 "typemap_name": "char"
                             },
@@ -1677,7 +1677,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1734,7 +1734,7 @@
                                 "i_var": "SHT_rv",
                                 "i_var_len": "SHT_rv_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_buf_copy",
                                 "typemap_name": "char"
                             },
@@ -1883,7 +1883,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -1936,7 +1936,7 @@
                                 "i_var": "output",
                                 "i_var_len": "noutput",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_buf_arg",
                                 "typemap_name": "char"
                             },
@@ -2067,7 +2067,7 @@
                                 "cxx_var": "SHC_rv",
                                 "i_name_function": "c_get_char_ptr4",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -2113,7 +2113,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_raw",
                                 "typemap_name": "char"
                             },
@@ -2225,7 +2225,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char*",
                                 "typemap_name": "char"
                             },
@@ -2280,7 +2280,7 @@
                                 "i_var": "SHT_rv",
                                 "i_var_cdesc": "SHT_rv_cdesc",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_cdesc_pointer",
                                 "typemap_name": "char"
                             },
@@ -2468,7 +2468,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2532,7 +2532,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2730,7 +2730,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -2802,7 +2802,7 @@
                                 "i_var": "name",
                                 "i_var_len": "SHT_name_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -2925,7 +2925,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -2991,7 +2991,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -3137,7 +3137,7 @@
                                 "i_intent_attr": ", intent(OUT)",
                                 "i_name_function": "c_creturn_char",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char",
                                 "typemap_name": "char"
                             },
@@ -3184,7 +3184,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char",
                                 "typemap_name": "char"
                             },
@@ -3379,7 +3379,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "dest",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -3417,7 +3417,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -3486,7 +3486,7 @@
                                 "i_var": "dest",
                                 "i_var_len": "SHT_dest_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -3534,7 +3534,7 @@
                                 "i_var": "src",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -3706,7 +3706,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "dest",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -3744,7 +3744,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -3813,7 +3813,7 @@
                                 "i_var": "dest",
                                 "i_var_len": "SHT_dest_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -3861,7 +3861,7 @@
                                 "i_var": "src",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -4035,7 +4035,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4131,7 +4131,7 @@
                                 "i_var": "src",
                                 "i_var_len": "SHT_src_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -4324,7 +4324,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4454,7 +4454,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -4622,7 +4622,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4653,7 +4653,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4741,7 +4741,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "in",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4781,7 +4781,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "src",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -4960,7 +4960,7 @@
                                 "i_var": "names",
                                 "idtor": "0",
                                 "rank": "1",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "size": "size(names)",
                                 "stmt_name": "c_in_char**",
                                 "typemap_name": "char"
@@ -5062,7 +5062,7 @@
                                 "i_var_size": "SHT_names_size",
                                 "idtor": "0",
                                 "rank": "1",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "size": "size(names)",
                                 "stmt_name": "f_in_char**_buf",
                                 "typemap_name": "char"

--- a/regression/reference/char-cxx/wrapchar.cpp
+++ b/regression/reference/char-cxx/wrapchar.cpp
@@ -314,7 +314,7 @@ void CHA_getCharPtr1_bufferify(CHA_SHROUD_array *SHT_rv_cdesc)
     // splicer begin function.getCharPtr1_bufferify
     const char *SHC_rv = getCharPtr1();
     SHT_rv_cdesc->base_addr = const_cast<char *>(SHC_rv);
-    SHT_rv_cdesc->type = SH_TYPE_OTHER;
+    SHT_rv_cdesc->type = SH_TYPE_CHAR;
     SHT_rv_cdesc->elem_len = SHC_rv == nullptr ? 0 : std::strlen(SHC_rv);
     SHT_rv_cdesc->size = 1;
     SHT_rv_cdesc->rank = 0;
@@ -440,7 +440,7 @@ void CHA_getCharPtr5_bufferify(CHA_SHROUD_array *SHT_rv_cdesc)
     // splicer begin function.getCharPtr5_bufferify
     const char *SHC_rv = getCharPtr5();
     SHT_rv_cdesc->base_addr = const_cast<char *>(SHC_rv);
-    SHT_rv_cdesc->type = SH_TYPE_OTHER;
+    SHT_rv_cdesc->type = SH_TYPE_CHAR;
     SHT_rv_cdesc->elem_len = SHC_rv == nullptr ? 0 : std::strlen(SHC_rv);
     SHT_rv_cdesc->size = 1;
     SHT_rv_cdesc->rank = 0;

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -1475,7 +1475,7 @@
                                 "i_var": "SHT_rv",
                                 "i_var_len": "SHT_rv_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char*_buf_copy",
                                 "typemap_name": "char"
                             },
@@ -1517,7 +1517,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "arg1",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1557,7 +1557,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "arg2",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1792,7 +1792,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1999,7 +1999,7 @@
                                 "i_var": "s",
                                 "i_var_len": "SHT_s_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_inout_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -2222,7 +2222,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "in",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_inout_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -2304,7 +2304,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "out",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -2470,7 +2470,7 @@
                                 "i_var": "name1",
                                 "i_var_len": "SHT_name1_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -2689,7 +2689,7 @@
                                 "i_var": "name1",
                                 "i_var_len": "SHT_name1_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -2733,7 +2733,7 @@
                                 "i_var": "name2",
                                 "i_var_len": "SHT_name2_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -3025,7 +3025,7 @@
                                 "i_var": "text",
                                 "i_var_len": "SHT_text_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -3385,7 +3385,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "text",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -3796,7 +3796,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "text",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_capi",
                                 "typemap_name": "char"
                             },
@@ -4607,7 +4607,7 @@
                                 "i_var": "outbuf",
                                 "i_var_len": "SHT_outbuf_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -5365,7 +5365,7 @@
                                 "i_var": "outbuf",
                                 "i_var_len": "SHT_outbuf_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/funptr-c/funptr.json
+++ b/regression/reference/funptr-c/funptr.json
@@ -1181,7 +1181,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1440,7 +1440,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1700,7 +1700,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4708,7 +4708,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg2",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char",
                                                     "typemap_name": "char"
                                                 },
@@ -4729,7 +4729,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg3",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char*",
                                                     "typemap_name": "char"
                                                 },
@@ -5016,7 +5016,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg2",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char",
                                                     "typemap_name": "char"
                                                 },
@@ -5037,7 +5037,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg3",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char*",
                                                     "typemap_name": "char"
                                                 },

--- a/regression/reference/funptr-cxx/funptr.json
+++ b/regression/reference/funptr-cxx/funptr.json
@@ -1585,7 +1585,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1734,7 +1734,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -1967,7 +1967,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2117,7 +2117,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2351,7 +2351,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -2501,7 +2501,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -6695,7 +6695,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg2",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char",
                                                     "typemap_name": "char"
                                                 },
@@ -6716,7 +6716,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg3",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char*",
                                                     "typemap_name": "char"
                                                 },
@@ -7056,7 +7056,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg2",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char",
                                                     "typemap_name": "char"
                                                 },
@@ -7077,7 +7077,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg3",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char*",
                                                     "typemap_name": "char"
                                                 },
@@ -7365,7 +7365,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg2",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char",
                                                     "typemap_name": "char"
                                                 },
@@ -7386,7 +7386,7 @@
                                                     "i_module_name": "iso_c_binding",
                                                     "i_type": "character(kind=C_CHAR)",
                                                     "i_var": "arg3",
-                                                    "sh_type": "SH_TYPE_OTHER",
+                                                    "sh_type": "SH_TYPE_CHAR",
                                                     "stmt_name": "f_none_char*",
                                                     "typemap_name": "char"
                                                 },

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -496,7 +496,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_inout_char*",
                                 "typemap_name": "char"
                             },
@@ -572,7 +572,7 @@
                                 "i_var": "name",
                                 "i_var_len": "SHT_name_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_inout_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -4549,7 +4549,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4580,7 +4580,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -4611,7 +4611,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -5196,7 +5196,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -5236,7 +5236,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "pkg",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },
@@ -5276,7 +5276,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "rdbase",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/none/def_types.yaml
+++ b/regression/reference/none/def_types.yaml
@@ -101,7 +101,7 @@ typemap:
       LUA_pop: lua_tostring({LUA_state_var}, {LUA_index})
       LUA_push: lua_pushstring({LUA_state_var}, {push_arg})
       sgroup: char
-      sh_type: SH_TYPE_OTHER
+      sh_type: SH_TYPE_CHAR
       cfi_type: CFI_type_other
   - type: double
     fields:

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -355,7 +355,8 @@
             },
             "i_module_name": "iso_c_binding",
             "i_type": "character(kind=C_CHAR)",
-            "sgroup": "char"
+            "sgroup": "char",
+            "sh_type": "SH_TYPE_CHAR"
         },
         "double": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -3827,6 +3827,20 @@ c_mixin_cast-argument:
   c_local:
   - cxx
   owner: library
+c_mixin_cdesc-char-fill-cvar:
+  name: c_mixin_cdesc-char-fill-cvar
+  comments:
+  - Fill cdesc from char * in the C wrapper.
+  intent: mixin
+  c_post_call:
+  - "{c_var_cdesc}->base_addr =\t const_cast<char *>(\t{cxx_var});"
+  - '{c_var_cdesc}->type = {sh_type};'
+  - '{c_var_cdesc}->elem_len = {cxx_var} == {nullptr} ? 0 : {stdlib}strlen({cxx_var});'
+  - '{c_var_cdesc}->size = 1;'
+  - '{c_var_cdesc}->rank = 0;'
+  c_helper:
+  - type_defines
+  owner: library
 c_mixin_cfi-unpack-base-addr:
   name: c_mixin_cfi-unpack-base-addr
   intent: mixin
@@ -4090,20 +4104,6 @@ c_mixin_function-return-cvar:
   c_return:
   - return {c_var};
   c_return_type: '{c_type} *'
-  owner: library
-c_mixin_function_char*_cdesc:
-  name: c_mixin_function_char*_cdesc
-  comments:
-  - Fill cdesc from char * in the C wrapper.
-  intent: mixin
-  c_post_call:
-  - "{c_var_cdesc}->base_addr =\t const_cast<char *>(\t{cxx_var});"
-  - '{c_var_cdesc}->type = {sh_type};'
-  - '{c_var_cdesc}->elem_len = {cxx_var} == {nullptr} ? 0 : {stdlib}strlen({cxx_var});'
-  - '{c_var_cdesc}->size = 1;'
-  - '{c_var_cdesc}->rank = 0;'
-  c_helper:
-  - type_defines
   owner: library
 c_mixin_function_shadow_capptr:
   name: c_mixin_function_shadow_capptr
@@ -6317,7 +6317,7 @@ f_function_char*_cdesc_allocatable:
   - '    c_mixin_as-intent-out'
   - '  f_mixin_pass_cdesc'
   - '  f_mixin_char_cdesc_allocate'
-  - '  c_mixin_function_char*_cdesc'
+  - '  c_mixin_cdesc-char-fill-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -6374,7 +6374,7 @@ f_function_char*_cdesc_pointer:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_char*_cdesc'
+  - '  c_mixin_cdesc-char-fill-cvar'
   - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -6735,7 +6735,7 @@ f_function_char_cdesc_allocatable:
   - '    c_mixin_as-intent-out'
   - '  f_mixin_pass_cdesc'
   - '  f_mixin_char_cdesc_allocate'
-  - '  c_mixin_function_char*_cdesc'
+  - '  c_mixin_cdesc-char-fill-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -6792,7 +6792,7 @@ f_function_char_cdesc_pointer:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_char*_cdesc'
+  - '  c_mixin_cdesc-char-fill-cvar'
   - '  f_mixin_char_cdesc_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -19306,6 +19306,7 @@ root
       as-intent-out -- c_mixin_as-intent-out
       c-str -- c_mixin_c-str
       cast-argument -- c_mixin_cast-argument
+      cdesc-char-fill-cvar -- c_mixin_cdesc-char-fill-cvar
       cfi-unpack-base-addr -- c_mixin_cfi-unpack-base-addr
       cfi-unpack-base-addr-cxx -- c_mixin_cfi-unpack-base-addr-cxx
       cfi-unpack-len -- c_mixin_cfi-unpack-len
@@ -19328,8 +19329,6 @@ root
         new-string -- c_mixin_destructor_new-string
         new-vector -- c_mixin_destructor_new-vector
       function
-        char*
-          cdesc -- c_mixin_function_char*_cdesc
         shadow
           capptr -- c_mixin_function_shadow_capptr
         string

--- a/regression/reference/pointers-c-f/pointers.json
+++ b/regression/reference/pointers-c-f/pointers.json
@@ -7373,7 +7373,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -7373,7 +7373,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/pointers-cfi/pointers.json
+++ b/regression/reference/pointers-cfi/pointers.json
@@ -10735,7 +10735,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -10833,7 +10833,7 @@
                                 "i_var_cfi": "SHT_name_cfi",
                                 "i_var_len": "SHT_name_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*_cfi",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/pointers-cxx-c/pointers.json
+++ b/regression/reference/pointers-cxx-c/pointers.json
@@ -6052,7 +6052,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/pointers-cxx-f/pointers.json
+++ b/regression/reference/pointers-cxx-f/pointers.json
@@ -7403,7 +7403,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -10449,7 +10449,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char*",
                                 "typemap_name": "char"
                             },
@@ -10538,7 +10538,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "name",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char*",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -5628,7 +5628,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -5694,7 +5694,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -5787,7 +5787,7 @@
                                 "i_intent_attr": ", intent(OUT)",
                                 "i_name_function": "c_creturn_char",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char",
                                 "typemap_name": "char"
                             },
@@ -5834,7 +5834,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -7010,7 +7010,7 @@
                                 "i_intent": "IN",
                                 "i_intent_attr": ", intent(IN)",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_in_char",
                                 "typemap_name": "char"
                             },
@@ -7076,7 +7076,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "status",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_in_char",
                                 "typemap_name": "char"
                             },
@@ -7224,7 +7224,7 @@
                                 "i_intent_attr": ", intent(OUT)",
                                 "i_name_function": "c_creturn_char",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_function_char",
                                 "typemap_name": "char"
                             },
@@ -7271,7 +7271,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "SHT_rv",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_function_char",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -2794,7 +2794,7 @@
                                 "i_var": "outbuf",
                                 "i_var_len": "SHT_outbuf_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -4139,7 +4139,7 @@
                                 "i_var": "outbuf",
                                 "i_var_len": "SHT_outbuf_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -2948,7 +2948,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "outbuf",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -3081,7 +3081,7 @@
                                 "i_var": "outbuf",
                                 "i_var_len": "SHT_outbuf_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },
@@ -4892,7 +4892,7 @@
                                 "i_type": "character(kind=C_CHAR)",
                                 "i_var": "outbuf",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "c_out_char*",
                                 "typemap_name": "char"
                             },
@@ -5078,7 +5078,7 @@
                                 "i_var": "outbuf",
                                 "i_var_len": "SHT_outbuf_len",
                                 "idtor": "0",
-                                "sh_type": "SH_TYPE_OTHER",
+                                "sh_type": "SH_TYPE_CHAR",
                                 "stmt_name": "f_out_char*_buf",
                                 "typemap_name": "char"
                             },

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -805,7 +805,7 @@
         ]
     },
     {
-        "name": "c_mixin_function_char*_cdesc",
+        "name": "c_mixin_cdesc-char-fill-cvar",
         "comments": [
             "Fill cdesc from char * in the C wrapper."
         ],
@@ -2435,7 +2435,7 @@
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
             "f_mixin_char_cdesc_allocate",
-            "c_mixin_function_char*_cdesc"
+            "c_mixin_cdesc-char-fill-cvar"
         ]
     },
     {
@@ -2446,7 +2446,7 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
-            "c_mixin_function_char*_cdesc",
+            "c_mixin_cdesc-char-fill-cvar",
             "f_mixin_char_cdesc_pointer"
         ]
     },

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -874,6 +874,7 @@ def default_typemap():
             LUA_push="lua_pushstring({LUA_state_var}, {push_arg})",
             base="string",
             sgroup="char",
+            sh_type="SH_TYPE_CHAR",
         ),
         # C++ std::string
         string=Typemap(


### PR DESCRIPTION
Set to `SH_TYPE_CHAR`. It was defaulting to `SH_TYPE_OTHER`.