### PR TITLE
Rename groups

### DIFF
--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -329,7 +329,7 @@ pointers and references.
 
 .. mixin naming conventions
    Must start with c_mixin_ or f_mixin_
-   Group together by adding cdesc_  or capsule_.
+   Group together by adding cdesc_  or capsule_ or _cfi.
    This makes the mixin block standout better which groups are working together
    rather than adding the intent or type before cdesc or capsule.
    

--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -324,3 +324,13 @@ pointers and references.
     "c_post_call": [
         "{c_abstract_decl} {c_var} = {cxx_var}{cxx_member}c_str();"
     ]
+
+
+
+.. mixin naming conventions
+   Must start with c_mixin_ or f_mixin_
+   Group together by adding cdesc_  or capsule_.
+   This makes the mixin block standout better which groups are working together
+   rather than adding the intent or type before cdesc or capsule.
+   
+   The non-mixin groups add capsule/cdesc later since it is from api(cdesc).

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -129,9 +129,10 @@ c_function_bool:
   name: c_function_bool
   comments:
   - Call a function.
+  - Declare a Fortran variable.
   mixin_names:
   - '  f_mixin_function'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   intent: function
   i_result_decl:
@@ -306,6 +307,7 @@ c_function_char*_buf_copy:
   name: c_function_char*_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
@@ -317,7 +319,7 @@ c_function_char*_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -366,9 +368,10 @@ c_function_native:
   name: c_function_native
   comments:
   - Call a function.
+  - Declare a Fortran variable.
   mixin_names:
   - '  f_mixin_function'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   intent: function
   i_result_decl:
@@ -1244,6 +1247,7 @@ c_function_string&_buf_copy:
   name: c_function_string&_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
@@ -1251,7 +1255,7 @@ c_function_string&_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -1328,6 +1332,7 @@ c_function_string*_buf_copy:
   name: c_function_string*_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
@@ -1335,7 +1340,7 @@ c_function_string*_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -1491,6 +1496,7 @@ c_function_string_buf_copy:
   name: c_function_string_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
@@ -1498,7 +1504,7 @@ c_function_string_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -1543,11 +1549,12 @@ c_function_struct:
   name: c_function_struct
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-interface-arg'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -1633,10 +1640,12 @@ c_function_vector<native>_malloc:
   owner: library
 c_function_void*:
   name: c_function_void*
+  comments:
+  - Declare a Fortran variable.
   notes:
   - XXX - f entries are the same as the i entries, share?
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   intent: function
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
@@ -1646,8 +1655,10 @@ c_function_void*:
   owner: library
 c_getter_native:
   name: c_getter_native
+  comments:
+  - Declare a Fortran variable.
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   intent: getter
   i_result_decl:
@@ -1662,8 +1673,10 @@ c_getter_native:
   owner: library
 c_getter_native*:
   name: c_getter_native*
+  comments:
+  - Declare a Fortran variable.
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   intent: getter
   i_result_decl:
@@ -6025,9 +6038,10 @@ f_function_bool:
   name: f_function_bool
   comments:
   - Call a function.
+  - Declare a Fortran variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
   f_module:
@@ -6036,7 +6050,7 @@ f_function_bool:
   f_need_wrapper: true
   mixin_names:
   - '  f_mixin_function'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -6288,6 +6302,7 @@ f_function_char*_buf_copy:
   name: f_function_char*_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
@@ -6298,7 +6313,7 @@ f_function_char*_buf_copy:
   - XXX - maybe fmtdict to rename c_local_cxx as output
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -6319,7 +6334,7 @@ f_function_char*_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -6588,6 +6603,7 @@ f_function_char*_cfi_copy:
   name: f_function_char*_cfi_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass argument to C wrapper
   - Make the C wrapper argument a CFI_desc_t.
   - Character argument passed as CFI_desc_t.
@@ -6598,7 +6614,7 @@ f_function_char*_cfi_copy:
   - Copy result into caller's buffer.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -6610,7 +6626,7 @@ f_function_char*_cfi_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_cfi_pass_character'
   - '  c_mixin_cfi_arg_character'
   - '    c_mixin_cfi_arg'
@@ -7007,11 +7023,12 @@ f_function_enum:
   name: f_function_enum
   comments:
   - Call a function.
+  - Declare a Fortran variable.
   notes:
   - Return as the Fortran bind(C) type.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
   f_module:
@@ -7019,7 +7036,7 @@ f_function_enum:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_function'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -7033,9 +7050,10 @@ f_function_native:
   name: f_function_native
   comments:
   - Call a function.
+  - Declare a Fortran variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
   f_module:
@@ -7043,7 +7061,7 @@ f_function_native:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_function'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -7594,11 +7612,12 @@ f_function_native*_scalar:
   name: f_function_native*_scalar
   comments:
   - Call a function.
+  - Declare a Fortran variable.
   notes:
   - Return a scalar to avoid doing the deref in Fortran.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{f_result_var} = {f_call_function}({F_arg_c_call})'
   f_module:
@@ -7606,7 +7625,7 @@ f_function_native*_scalar:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_function'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -8106,13 +8125,14 @@ f_function_string&_buf:
   name: f_function_string&_buf
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -8133,7 +8153,7 @@ f_function_string&_buf:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -8260,13 +8280,14 @@ f_function_string&_buf_caller:
   name: f_function_string&_buf_caller
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Copy cxx variable into c variable.
   - Pass cxx variable to library.
   - Delete the cxx variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -8287,7 +8308,7 @@ f_function_string&_buf_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_string-char-copy-to-arg'
@@ -8328,13 +8349,14 @@ f_function_string&_buf_copy:
   name: f_function_string&_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -8355,7 +8377,7 @@ f_function_string&_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -8399,13 +8421,14 @@ f_function_string&_buf_copy_caller:
   name: f_function_string&_buf_copy_caller
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Copy cxx variable into c variable.
   - Pass cxx variable to library.
   - Delete the cxx variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -8426,7 +8449,7 @@ f_function_string&_buf_copy_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_string-char-copy-to-arg'
@@ -9058,6 +9081,7 @@ f_function_string&_cfi_copy:
   name: f_function_string&_cfi_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass argument to C wrapper
   - Make the C wrapper argument a CFI_desc_t.
   - Character argument passed as CFI_desc_t.
@@ -9066,7 +9090,7 @@ f_function_string&_cfi_copy:
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -9078,7 +9102,7 @@ f_function_string&_cfi_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_cfi_pass_character'
   - '  c_mixin_cfi_arg_character'
   - '    c_mixin_cfi_arg'
@@ -9303,13 +9327,14 @@ f_function_string*_buf:
   name: f_function_string*_buf
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -9330,7 +9355,7 @@ f_function_string*_buf:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -9374,13 +9399,14 @@ f_function_string*_buf_caller:
   name: f_function_string*_buf_caller
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Copy cxx variable into c variable.
   - Pass cxx variable to library.
   - Delete the cxx variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -9401,7 +9427,7 @@ f_function_string*_buf_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_string-char-copy-to-arg'
@@ -9442,13 +9468,14 @@ f_function_string*_buf_copy:
   name: f_function_string*_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -9469,7 +9496,7 @@ f_function_string*_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -9513,13 +9540,14 @@ f_function_string*_buf_copy_caller:
   name: f_function_string*_buf_copy_caller
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Copy cxx variable into c variable.
   - Pass cxx variable to library.
   - Delete the cxx variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -9540,7 +9568,7 @@ f_function_string*_buf_copy_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_string-char-copy-to-arg'
@@ -10103,6 +10131,7 @@ f_function_string*_cfi_copy:
   name: f_function_string*_cfi_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass argument to C wrapper
   - Make the C wrapper argument a CFI_desc_t.
   - Character argument passed as CFI_desc_t.
@@ -10111,7 +10140,7 @@ f_function_string*_cfi_copy:
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -10123,7 +10152,7 @@ f_function_string*_cfi_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_cfi_pass_character'
   - '  c_mixin_cfi_arg_character'
   - '    c_mixin_cfi_arg'
@@ -10348,13 +10377,14 @@ f_function_string_buf:
   name: f_function_string_buf
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -10375,7 +10405,7 @@ f_function_string_buf:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -10502,13 +10532,14 @@ f_function_string_buf_caller:
   name: f_function_string_buf_caller
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Copy cxx variable into c variable.
   - Pass cxx variable to library.
   - Delete the cxx variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -10529,7 +10560,7 @@ f_function_string_buf_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_string-char-copy-to-arg'
@@ -10570,13 +10601,14 @@ f_function_string_buf_copy:
   name: f_function_string_buf_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Pass cxx variable to library.
   - Call function and assign to a local C++ variable.
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -10597,7 +10629,7 @@ f_function_string_buf_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_arg-call-cvar'
@@ -10641,13 +10673,14 @@ f_function_string_buf_copy_caller:
   name: f_function_string_buf_copy_caller
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass CHARACTER and LEN to C wrapper.
   - Copy cxx variable into c variable.
   - Pass cxx variable to library.
   - Delete the cxx variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -10668,7 +10701,7 @@ f_function_string_buf_copy_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_pass_character_buf'
   - '  c_mixin_in_character_buf'
   - '  c_mixin_string-char-copy-to-arg'
@@ -11182,6 +11215,7 @@ f_function_string_cfi_copy:
   name: f_function_string_cfi_copy
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   - Pass argument to C wrapper
   - Make the C wrapper argument a CFI_desc_t.
   - Character argument passed as CFI_desc_t.
@@ -11190,7 +11224,7 @@ f_function_string_cfi_copy:
   - Copy cxx variable into c variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -11202,7 +11236,7 @@ f_function_string_cfi_copy:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  f_mixin_cfi_pass_character'
   - '  c_mixin_cfi_arg_character'
   - '    c_mixin_cfi_arg'
@@ -11427,9 +11461,10 @@ f_function_struct:
   name: f_function_struct
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -11441,7 +11476,7 @@ f_function_struct:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-interface-arg'
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11639,16 +11674,18 @@ f_function_vector_scalar_cdesc:
   owner: library
 f_function_void*:
   name: f_function_void*
+  comments:
+  - Declare a Fortran variable.
   notes:
   - XXX - f entries are the same as the i entries, share?
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   i_result_decl:
   - 'type(C_PTR) :: {i_var}'
   i_module:
@@ -11657,14 +11694,16 @@ f_function_void*:
   owner: library
 f_getter_bool:
   name: f_getter_bool
+  comments:
+  - Declare a Fortran variable.
   intent: getter
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -11678,14 +11717,16 @@ f_getter_bool:
   owner: library
 f_getter_native:
   name: f_getter_native
+  comments:
+  - Declare a Fortran variable.
   intent: getter
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -11761,14 +11802,16 @@ f_getter_native*_cdesc_pointer:
   owner: library
 f_getter_native*_pointer:
   name: f_getter_native*_pointer
+  comments:
+  - Declare a Fortran variable.
   intent: getter
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
   mixin_names:
-  - '  f_mixin_declare-fortran-result'
+  - '  f_mixin_declare-local-variable'
   - '  c_mixin_declare-fortran-result'
   i_result_decl:
   - '{i_type} :: {i_var}'
@@ -15549,15 +15592,6 @@ f_mixin_declare-fortran-arg:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
-  f_module:
-    '{f_module_name}':
-    - '{f_kind}'
-  owner: library
-f_mixin_declare-fortran-result:
-  name: f_mixin_declare-fortran-result
-  intent: mixin
-  f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -20068,7 +20102,6 @@ root
       declare-arg-char -- f_mixin_declare-arg-char
       declare-as-cptr -- f_mixin_declare-as-cptr
       declare-fortran-arg -- f_mixin_declare-fortran-arg
-      declare-fortran-result -- f_mixin_declare-fortran-result
       declare-interface-arg -- f_mixin_declare-interface-arg
       declare-local-variable -- f_mixin_declare-local-variable
       dummy

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -3948,7 +3948,7 @@ c_mixin_cfi_arg_native:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}'
+  - '{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'
@@ -7363,6 +7363,8 @@ f_function_native*_cfi_allocatable:
   name: f_function_native*_cfi_allocatable
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
+  - Pass Fortran variable to C wrapper.
   - Make the C wrapper argument a CFI_desc_t.
   - Native argument which use CFI_desc_t.
   - Pass cxx local variable to library.
@@ -7374,7 +7376,7 @@ f_function_native*_cfi_allocatable:
   - Return an allocated copy of data.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -7385,6 +7387,8 @@ f_function_native*_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
+  - '  f_mixin_declare-local-variable'
+  - '  f_mixin_arg-call-fvar'
   - '  c_mixin_cfi_arg_native'
   - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
@@ -7428,6 +7432,8 @@ f_function_native*_cfi_pointer:
   name: f_function_native*_cfi_pointer
   comments:
   - Call the C wrapper as a subroutine.
+  - Declare a Fortran variable.
+  - Pass Fortran variable to C wrapper.
   - Make the C wrapper argument a CFI_desc_t.
   - Native argument which use CFI_desc_t.
   - Pass cxx local variable to library.
@@ -7439,7 +7445,7 @@ f_function_native*_cfi_pointer:
   - Return Fortran pointer to data.
   intent: function
   f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_pre_call:
   - nullify({f_var})
   f_arg_call:
@@ -7452,6 +7458,8 @@ f_function_native*_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
+  - '  f_mixin_declare-local-variable'
+  - '  f_mixin_arg-call-fvar'
   - '  c_mixin_cfi_arg_native'
   - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
@@ -12557,7 +12565,7 @@ f_in_native*_cfi:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}'
+  - '{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'
@@ -14258,7 +14266,7 @@ f_inout_native*_cfi:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}'
+  - '{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'
@@ -15116,6 +15124,14 @@ f_inout_void*_cdesc:
   c_helper:
   - array_context
   owner: library
+f_mixin_arg-call-fvar:
+  name: f_mixin_arg-call-fvar
+  comments:
+  - Pass Fortran variable to C wrapper.
+  intent: mixin
+  f_arg_call:
+  - '{f_var}'
+  owner: library
 f_mixin_as-intent-out:
   name: f_mixin_as-intent-out
   intent: mixin
@@ -15556,6 +15572,17 @@ f_mixin_declare-interface-arg:
   i_module:
     '{i_module_name}':
     - '{i_kind}'
+  owner: library
+f_mixin_declare-local-variable:
+  name: f_mixin_declare-local-variable
+  comments:
+  - Declare a Fortran variable.
+  intent: mixin
+  f_arg_decl:
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{f_module_name}':
+    - '{f_kind}'
   owner: library
 f_mixin_dummy_arg:
   name: f_mixin_dummy_arg
@@ -20004,6 +20031,7 @@ root
         cdesc -- f_inout_void*_cdesc
       void** -- f_inout_void**
     mixin
+      arg-call-fvar -- f_mixin_arg-call-fvar
       as-intent-out -- f_mixin_as-intent-out
       capsule
         arg -- f_mixin_capsule_arg
@@ -20042,6 +20070,7 @@ root
       declare-fortran-arg -- f_mixin_declare-fortran-arg
       declare-fortran-result -- f_mixin_declare-fortran-result
       declare-interface-arg -- f_mixin_declare-interface-arg
+      declare-local-variable -- f_mixin_declare-local-variable
       dummy
         arg -- f_mixin_dummy_arg
       function -- f_mixin_function

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -3744,59 +3744,6 @@ c_mixin_arg-call-cxx-deref:
   c_arg_call:
   - '*{c_local_cxx}'
   owner: library
-c_mixin_arg_cfi:
-  name: c_mixin_arg_cfi
-  comments:
-  - Make the C wrapper argument a CFI_desc_t.
-  intent: mixin
-  c_arg_decl:
-  - CFI_cdesc_t *{c_var_cfi}
-  c_temps:
-  - cfi
-  iface_header:
-  - ISO_Fortran_binding.h
-  owner: library
-c_mixin_arg_character_cfi:
-  name: c_mixin_arg_character_cfi
-  comments:
-  - Make the C wrapper argument a CFI_desc_t.
-  - Character argument passed as CFI_desc_t.
-  mixin_names:
-  - '  c_mixin_arg_cfi'
-  intent: mixin
-  i_arg_names:
-  - '{i_var}'
-  i_arg_decl:
-  - 'character(len=*){i_intent_attr} :: {i_var}'
-  c_arg_decl:
-  - CFI_cdesc_t *{c_var_cfi}
-  c_temps:
-  - cfi
-  iface_header:
-  - ISO_Fortran_binding.h
-  owner: library
-c_mixin_arg_native_cfi:
-  name: c_mixin_arg_native_cfi
-  comments:
-  - Make the C wrapper argument a CFI_desc_t.
-  - Native argument which use CFI_desc_t.
-  mixin_names:
-  - '  c_mixin_arg_cfi'
-  intent: mixin
-  i_arg_names:
-  - '{i_var}'
-  i_arg_decl:
-  - '{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}'
-  i_module:
-    iso_c_binding:
-    - '{f_kind}'
-  c_arg_decl:
-  - CFI_cdesc_t *{c_var_cfi}
-  c_temps:
-  - cfi
-  iface_header:
-  - ISO_Fortran_binding.h
-  owner: library
 c_mixin_as-intent-out:
   name: c_mixin_as-intent-out
   intent: mixin
@@ -3959,6 +3906,145 @@ c_mixin_cfi-unpack-len-size:
   - len
   - size
   owner: library
+c_mixin_cfi_arg:
+  name: c_mixin_cfi_arg
+  comments:
+  - Make the C wrapper argument a CFI_desc_t.
+  intent: mixin
+  c_arg_decl:
+  - CFI_cdesc_t *{c_var_cfi}
+  c_temps:
+  - cfi
+  iface_header:
+  - ISO_Fortran_binding.h
+  owner: library
+c_mixin_cfi_arg_character:
+  name: c_mixin_cfi_arg_character
+  comments:
+  - Make the C wrapper argument a CFI_desc_t.
+  - Character argument passed as CFI_desc_t.
+  mixin_names:
+  - '  c_mixin_cfi_arg'
+  intent: mixin
+  i_arg_names:
+  - '{i_var}'
+  i_arg_decl:
+  - 'character(len=*){i_intent_attr} :: {i_var}'
+  c_arg_decl:
+  - CFI_cdesc_t *{c_var_cfi}
+  c_temps:
+  - cfi
+  iface_header:
+  - ISO_Fortran_binding.h
+  owner: library
+c_mixin_cfi_arg_native:
+  name: c_mixin_cfi_arg_native
+  comments:
+  - Make the C wrapper argument a CFI_desc_t.
+  - Native argument which use CFI_desc_t.
+  mixin_names:
+  - '  c_mixin_cfi_arg'
+  intent: mixin
+  i_arg_names:
+  - '{i_var}'
+  i_arg_decl:
+  - '{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}'
+  i_module:
+    iso_c_binding:
+    - '{f_kind}'
+  c_arg_decl:
+  - CFI_cdesc_t *{c_var_cfi}
+  c_temps:
+  - cfi
+  iface_header:
+  - ISO_Fortran_binding.h
+  owner: library
+c_mixin_cfi_character_pointer:
+  name: c_mixin_cfi_character_pointer
+  comments:
+  - Convert C pointer to deferred-length CHARACTER Fortran scalar pointer.
+  intent: mixin
+  c_post_call:
+  - int {c_local_err};
+  - if ({cxx_var} == {nullptr}) {{+
+  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {nullptr},\t {nullptr});"
+  - -}} else {{+
+  - CFI_CDESC_T(0) {c_local_fptr};
+  - CFI_cdesc_t *{c_local_cdesc} = {cast_reinterpret}CFI_cdesc_t *{cast1}&{c_local_fptr}{cast2};
+  - void *{c_local_cptr} = {cxx_nonconst_ptr};
+  - size_t {c_local_len} = {stdlib}strlen({cxx_var});
+  - "{c_local_err} = CFI_establish({c_local_cdesc},\t {c_local_cptr},\t CFI_attribute_pointer,\t\
+    \ CFI_type_char,\t {c_local_len},\t 0,\t {nullptr});"
+  - if ({c_local_err} == CFI_SUCCESS) {{+
+  - '{c_var_cfi}->elem_len = {c_local_cdesc}->elem_len;'
+  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {c_local_cdesc},\t {nullptr});"
+  - -}}
+  - -}}
+  c_local:
+  - cptr
+  - fptr
+  - cdesc
+  - len
+  - err
+  owner: library
+c_mixin_cfi_copy-to-arg:
+  name: c_mixin_cfi_copy-to-arg
+  comments:
+  - Copy cxx variable into c variable.
+  intent: mixin
+  c_post_call:
+  - char *{c_var} = {cast_static}char *{cast1}{c_var_cfi}->base_addr{cast2};
+  - if ({c_local_cxx}{cxx_member}empty()) {{+
+  - "{c_helper_char_copy}({c_var}, {c_var_cfi}->elem_len,\t {nullptr},\t 0);"
+  - -}} else {{+
+  - "{c_helper_char_copy}({c_var}, {c_var_cfi}->elem_len,\t {c_local_cxx}{cxx_member}data(),\t\
+    \ {c_local_cxx}{cxx_member}size());"
+  - -}}
+  c_helper:
+  - char_copy
+  owner: library
+c_mixin_cfi_native_allocatable:
+  name: c_mixin_cfi_native_allocatable
+  comments:
+  - Allocate copy of C pointer (requires +dimension).
+  intent: mixin
+  c_post_call:
+  - if ({c_local_cxx} != {nullptr}) {{+
+  - "{c_temp_lower_decl}{c_temp_extents_decl}int SH_ret = CFI_allocate({c_var_cfi},\
+    \ \t{c_temp_lower_use}, \t{c_temp_extents_use}, \t0);"
+  - if (SH_ret == CFI_SUCCESS) {{+
+  - "{stdlib}memcpy({c_var_cfi}->base_addr, \t{c_local_cxx}, \t{c_var_cfi}->elem_len);"
+  - -}}
+  - -}}
+  c_temps:
+  - extents
+  - lower
+  owner: library
+c_mixin_cfi_native_pointer:
+  name: c_mixin_cfi_native_pointer
+  comments:
+  - Convert C pointer to Fortran pointer.
+  intent: mixin
+  c_post_call:
+  - '{{+'
+  - CFI_CDESC_T({rank}) {c_local_fptr};
+  - CFI_cdesc_t *{c_local_cdesc} = {cast_reinterpret}CFI_cdesc_t *{cast1}&{c_local_fptr}{cast2};
+  - void *{c_local_cptr} = const_cast<{c_type} *>({c_local_cxx});
+  - "{c_temp_extents_decl}{c_temp_lower_decl}int {c_local_err} = CFI_establish({c_local_cdesc},\t\
+    \ {c_local_cptr},\t CFI_attribute_pointer,\t {cfi_type},\t 0,\t {rank},\t {c_temp_extents_use});"
+  - if ({c_local_err} == CFI_SUCCESS) {{+
+  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {c_local_cdesc},\t {c_temp_lower_use});"
+  - -}}
+  - -}}
+  c_temps:
+  - extents
+  - lower
+  c_local:
+  - cptr
+  - fptr
+  - cdesc
+  - err
+  owner: library
 c_mixin_char-alloc:
   name: c_mixin_char-alloc
   comments:
@@ -4008,22 +4094,6 @@ c_mixin_char-copy:
   intent: mixin
   c_post_call:
   - "{c_helper_char_copy}({c_var}, {c_var_len},\t {c_local_cxx},\t -1);"
-  c_helper:
-  - char_copy
-  owner: library
-c_mixin_char-copy-to-arg-cfi:
-  name: c_mixin_char-copy-to-arg-cfi
-  comments:
-  - Copy cxx variable into c variable.
-  intent: mixin
-  c_post_call:
-  - char *{c_var} = {cast_static}char *{cast1}{c_var_cfi}->base_addr{cast2};
-  - if ({c_local_cxx}{cxx_member}empty()) {{+
-  - "{c_helper_char_copy}({c_var}, {c_var_cfi}->elem_len,\t {nullptr},\t 0);"
-  - -}} else {{+
-  - "{c_helper_char_copy}({c_var}, {c_var_cfi}->elem_len,\t {c_local_cxx}{cxx_member}data(),\t\
-    \ {c_local_cxx}{cxx_member}size());"
-  - -}}
   c_helper:
   - char_copy
   owner: library
@@ -4091,34 +4161,6 @@ c_mixin_character-deferred-length:
   intent: mixin
   i_arg_decl:
   - 'character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}'
-  owner: library
-c_mixin_character_cfi_pointer:
-  name: c_mixin_character_cfi_pointer
-  comments:
-  - Convert C pointer to deferred-length CHARACTER Fortran scalar pointer.
-  intent: mixin
-  c_post_call:
-  - int {c_local_err};
-  - if ({cxx_var} == {nullptr}) {{+
-  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {nullptr},\t {nullptr});"
-  - -}} else {{+
-  - CFI_CDESC_T(0) {c_local_fptr};
-  - CFI_cdesc_t *{c_local_cdesc} = {cast_reinterpret}CFI_cdesc_t *{cast1}&{c_local_fptr}{cast2};
-  - void *{c_local_cptr} = {cxx_nonconst_ptr};
-  - size_t {c_local_len} = {stdlib}strlen({cxx_var});
-  - "{c_local_err} = CFI_establish({c_local_cdesc},\t {c_local_cptr},\t CFI_attribute_pointer,\t\
-    \ CFI_type_char,\t {c_local_len},\t 0,\t {nullptr});"
-  - if ({c_local_err} == CFI_SUCCESS) {{+
-  - '{c_var_cfi}->elem_len = {c_local_cdesc}->elem_len;'
-  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {c_local_cdesc},\t {nullptr});"
-  - -}}
-  - -}}
-  c_local:
-  - cptr
-  - fptr
-  - cdesc
-  - len
-  - err
   owner: library
 c_mixin_declare-arg:
   name: c_mixin_declare-arg
@@ -4434,48 +4476,6 @@ c_mixin_make-shared:
   impl_header:
   - <memory>
   owner: shared
-c_mixin_native_cfi_allocatable:
-  name: c_mixin_native_cfi_allocatable
-  comments:
-  - Allocate copy of C pointer (requires +dimension).
-  intent: mixin
-  c_post_call:
-  - if ({c_local_cxx} != {nullptr}) {{+
-  - "{c_temp_lower_decl}{c_temp_extents_decl}int SH_ret = CFI_allocate({c_var_cfi},\
-    \ \t{c_temp_lower_use}, \t{c_temp_extents_use}, \t0);"
-  - if (SH_ret == CFI_SUCCESS) {{+
-  - "{stdlib}memcpy({c_var_cfi}->base_addr, \t{c_local_cxx}, \t{c_var_cfi}->elem_len);"
-  - -}}
-  - -}}
-  c_temps:
-  - extents
-  - lower
-  owner: library
-c_mixin_native_cfi_pointer:
-  name: c_mixin_native_cfi_pointer
-  comments:
-  - Convert C pointer to Fortran pointer.
-  intent: mixin
-  c_post_call:
-  - '{{+'
-  - CFI_CDESC_T({rank}) {c_local_fptr};
-  - CFI_cdesc_t *{c_local_cdesc} = {cast_reinterpret}CFI_cdesc_t *{cast1}&{c_local_fptr}{cast2};
-  - void *{c_local_cptr} = const_cast<{c_type} *>({c_local_cxx});
-  - "{c_temp_extents_decl}{c_temp_lower_decl}int {c_local_err} = CFI_establish({c_local_cdesc},\t\
-    \ {c_local_cptr},\t CFI_attribute_pointer,\t {cfi_type},\t 0,\t {rank},\t {c_temp_extents_use});"
-  - if ({c_local_err} == CFI_SUCCESS) {{+
-  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {c_local_cdesc},\t {c_temp_lower_use});"
-  - -}}
-  - -}}
-  c_temps:
-  - extents
-  - lower
-  c_local:
-  - cptr
-  - fptr
-  - cdesc
-  - err
-  owner: library
 c_mixin_out_native**:
   name: c_mixin_out_native**
   comments:
@@ -6491,7 +6491,7 @@ f_function_char*_cfi_allocatable:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6544,9 +6544,9 @@ f_function_char*_cfi_arg:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_function-as-character-arg'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_arg-call-cxx'
@@ -6611,9 +6611,9 @@ f_function_char*_cfi_copy:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-fortran-result'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_arg-call-cxx'
@@ -6669,8 +6669,8 @@ f_function_char*_cfi_pointer:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
-  - '  c_mixin_character_cfi_pointer'
+  - '    c_mixin_cfi_arg'
+  - '  c_mixin_cfi_character_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6919,7 +6919,7 @@ f_function_char_cfi_allocatable:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6964,8 +6964,8 @@ f_function_char_cfi_pointer:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
-  - '  c_mixin_character_cfi_pointer'
+  - '    c_mixin_cfi_arg'
+  - '  c_mixin_cfi_character_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7385,11 +7385,11 @@ f_function_native*_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_native_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_native'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_native_cfi_allocatable'
+  - '  c_mixin_cfi_native_allocatable'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7452,11 +7452,11 @@ f_function_native*_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_native_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_native'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_native_cfi_pointer'
+  - '  c_mixin_cfi_native_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8862,7 +8862,7 @@ f_function_string&_cfi_allocatable:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -8907,7 +8907,7 @@ f_function_string&_cfi_allocatable_caller:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -8952,7 +8952,7 @@ f_function_string&_cfi_allocatable_library:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -9006,12 +9006,12 @@ f_function_string&_cfi_arg:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_function-as-character-arg'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_char-copy-to-arg-cfi'
+  - '  c_mixin_cfi_copy-to-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9071,12 +9071,12 @@ f_function_string&_cfi_copy:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-fortran-result'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_char-copy-to-arg-cfi'
+  - '  c_mixin_cfi_copy-to-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9131,7 +9131,7 @@ f_function_string&_cfi_pointer:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9192,7 +9192,7 @@ f_function_string&_cfi_pointer_caller:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9253,7 +9253,7 @@ f_function_string&_cfi_pointer_library:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9976,7 +9976,7 @@ f_function_string*_cfi_allocatable:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -10021,7 +10021,7 @@ f_function_string*_cfi_allocatable_caller:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -10066,7 +10066,7 @@ f_function_string*_cfi_allocatable_library:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -10116,12 +10116,12 @@ f_function_string*_cfi_copy:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-fortran-result'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_char-copy-to-arg-cfi'
+  - '  c_mixin_cfi_copy-to-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10176,7 +10176,7 @@ f_function_string*_cfi_pointer:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10237,7 +10237,7 @@ f_function_string*_cfi_pointer_caller:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10298,7 +10298,7 @@ f_function_string*_cfi_pointer_library:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10989,7 +10989,7 @@ f_function_string_cfi_allocatable:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11031,7 +11031,7 @@ f_function_string_cfi_allocatable_caller:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -11076,7 +11076,7 @@ f_function_string_cfi_allocatable_library:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_header_string'
   i_arg_names:
   - '{i_var}'
@@ -11130,12 +11130,12 @@ f_function_string_cfi_arg:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_function-as-character-arg'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_char-copy-to-arg-cfi'
+  - '  c_mixin_cfi_copy-to-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11195,12 +11195,12 @@ f_function_string_cfi_copy:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-fortran-result'
-  - '  f_mixin_pass_character_cfi'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_pass_character'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_arg-call-cxx'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_char-copy-to-arg-cfi'
+  - '  c_mixin_cfi_copy-to-arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11255,7 +11255,7 @@ f_function_string_cfi_pointer:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11316,7 +11316,7 @@ f_function_string_cfi_pointer_caller:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11377,7 +11377,7 @@ f_function_string_cfi_pointer_library:
   - '    f_mixin_character-deferred-length'
   - '    c_mixin_dummy_arg'
   - '    c_mixin_character-deferred-length'
-  - '    c_mixin_arg_cfi'
+  - '    c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -12158,8 +12158,8 @@ f_in_char**_cfi:
   f_arg_decl:
   - 'character(len=*){f_intent_attr} :: {f_var}(:)'
   mixin_names:
-  - '  f_mixin_arg-character-array-cfi'
-  - '    c_mixin_arg_cfi'
+  - '  f_mixin_cfi_arg-character-array'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len-size'
   - '  c_mixin_char-array-alloc'
@@ -12297,8 +12297,8 @@ f_in_char*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_char-alloc'
@@ -12550,8 +12550,8 @@ f_in_native*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_native_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_native'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr-cxx'
   - '  c_mixin_arg-call-cxx'
   i_arg_names:
@@ -12913,8 +12913,8 @@ f_in_string&_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_local-string-init-trim'
@@ -13047,8 +13047,8 @@ f_in_string*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_local-string-init-trim'
@@ -13152,8 +13152,8 @@ f_in_string_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_local-string-init-trim'
@@ -14044,8 +14044,8 @@ f_inout_char*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_char-blank-fill'
@@ -14251,8 +14251,8 @@ f_inout_native*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_native_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_native'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr-cxx'
   - '  c_mixin_arg-call-cxx'
   i_arg_names:
@@ -14533,8 +14533,8 @@ f_inout_string&_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_local-string-init-trim'
@@ -14698,8 +14698,8 @@ f_inout_string*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_local-string-init-trim'
@@ -15116,29 +15116,6 @@ f_inout_void*_cdesc:
   c_helper:
   - array_context
   owner: library
-f_mixin_arg-character-array-cfi:
-  name: f_mixin_arg-character-array-cfi
-  comments:
-  - Make the C wrapper argument a CFI_desc_t.
-  - Character array argument passed as CFI_desc_t.
-  intent: mixin
-  f_arg_name:
-  - '{f_var}'
-  f_arg_decl:
-  - 'character(len=*){f_intent_attr} :: {f_var}(:)'
-  mixin_names:
-  - '  c_mixin_arg_cfi'
-  i_arg_names:
-  - '{i_var}'
-  i_arg_decl:
-  - 'character(len=*){i_intent_attr} :: {i_var}(:)'
-  c_arg_decl:
-  - CFI_cdesc_t *{c_var_cfi}
-  c_temps:
-  - cfi
-  iface_header:
-  - ISO_Fortran_binding.h
-  owner: library
 f_mixin_as-intent-out:
   name: f_mixin_as-intent-out
   intent: mixin
@@ -15465,6 +15442,29 @@ f_mixin_cdesc_pass:
   c_helper:
   - array_context
   owner: library
+f_mixin_cfi_arg-character-array:
+  name: f_mixin_cfi_arg-character-array
+  comments:
+  - Make the C wrapper argument a CFI_desc_t.
+  - Character array argument passed as CFI_desc_t.
+  intent: mixin
+  f_arg_name:
+  - '{f_var}'
+  f_arg_decl:
+  - 'character(len=*){f_intent_attr} :: {f_var}(:)'
+  mixin_names:
+  - '  c_mixin_cfi_arg'
+  i_arg_names:
+  - '{i_var}'
+  i_arg_decl:
+  - 'character(len=*){i_intent_attr} :: {i_var}(:)'
+  c_arg_decl:
+  - CFI_cdesc_t *{c_var_cfi}
+  c_temps:
+  - cfi
+  iface_header:
+  - ISO_Fortran_binding.h
+  owner: library
 f_mixin_cfi_character-deferred-length:
   name: f_mixin_cfi_character-deferred-length
   comments:
@@ -15478,7 +15478,7 @@ f_mixin_cfi_character-deferred-length:
   - '  f_mixin_character-deferred-length'
   - '  c_mixin_dummy_arg'
   - '  c_mixin_character-deferred-length'
-  - '  c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15489,6 +15489,15 @@ f_mixin_cfi_character-deferred-length:
   - cfi
   iface_header:
   - ISO_Fortran_binding.h
+  owner: library
+f_mixin_cfi_pass_character:
+  name: f_mixin_cfi_pass_character
+  comments:
+  - Pass argument to C wrapper
+  intent: mixin
+  f_arg_call:
+  - '{f_var}'
+  f_need_wrapper: true
   owner: library
 f_mixin_character-deferred-length:
   name: f_mixin_character-deferred-length
@@ -15971,15 +15980,6 @@ f_mixin_pass_character_buf:
   - len
   f_need_wrapper: true
   owner: library
-f_mixin_pass_character_cfi:
-  name: f_mixin_pass_character_cfi
-  comments:
-  - Pass argument to C wrapper
-  intent: mixin
-  f_arg_call:
-  - '{f_var}'
-  f_need_wrapper: true
-  owner: library
 f_mixin_procedure-as-funptr:
   name: f_mixin_procedure-as-funptr
   comments:
@@ -16449,10 +16449,10 @@ f_out_char**_cfi_pointer:
   - '  f_mixin_character-deferred-length'
   - '  c_mixin_dummy_arg'
   - '  c_mixin_character-deferred-length'
-  - '  c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg'
   - '  c_mixin_local-cvar-ptr'
   - '  c_mixin_arg-call-cvar-address'
-  - '  c_mixin_character_cfi_pointer'
+  - '  c_mixin_cfi_character_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -16596,8 +16596,8 @@ f_out_char*_cfi:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_char-malloc'
@@ -17056,11 +17056,11 @@ f_out_native**_cfi_allocatable:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_native_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_native'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_local-cxx-ptr'
   - '  c_mixin_arg-call-cxx-address'
-  - '  c_mixin_native_cfi_allocatable'
+  - '  c_mixin_cfi_native_allocatable'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -17111,11 +17111,11 @@ f_out_native**_cfi_pointer:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_native_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_native'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_local-cxx-ptr'
   - '  c_mixin_arg-call-cxx-address'
-  - '  c_mixin_native_cfi_pointer'
+  - '  c_mixin_cfi_native_pointer'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -17368,8 +17368,8 @@ f_out_string&_cfi:
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
   - '  c_mixin_local-string'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_arg-call-cxx'
@@ -17557,7 +17557,7 @@ f_out_string**_cfi_allocatable:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg'
   - '  c_mixin_out_string**'
   - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
@@ -17595,7 +17595,7 @@ f_out_string**_cfi_copy:
     - '{f_kind}'
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg'
   - '  c_mixin_out_string**'
   - '  c_mixin_arg-call-cxx-address'
   i_arg_names:
@@ -17722,8 +17722,8 @@ f_out_string*_cfi:
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
   - '  c_mixin_local-string'
-  - '  c_mixin_arg_character_cfi'
-  - '    c_mixin_arg_cfi'
+  - '  c_mixin_cfi_arg_character'
+  - '    c_mixin_cfi_arg'
   - '  c_mixin_cfi-unpack-base-addr'
   - '  c_mixin_cfi-unpack-len'
   - '  c_mixin_arg-call-cxx-address'
@@ -19592,12 +19592,6 @@ root
         cdesc -- c_inout_void*_cdesc
       void** -- c_inout_void**
     mixin
-      arg
-        cfi -- c_mixin_arg_cfi
-        character
-          cfi -- c_mixin_arg_character_cfi
-        native
-          cfi -- c_mixin_arg_native_cfi
       arg-call-cvar -- c_mixin_arg-call-cvar
       arg-call-cvar-address -- c_mixin_arg-call-cvar-address
       arg-call-cvar-deref -- c_mixin_arg-call-cvar-deref
@@ -19622,6 +19616,16 @@ root
           vector -- c_mixin_cdesc_inout_vector
         native
           fill -- c_mixin_cdesc_native_fill
+      cfi
+        arg -- c_mixin_cfi_arg
+          character -- c_mixin_cfi_arg_character
+          native -- c_mixin_cfi_arg_native
+        character
+          pointer -- c_mixin_cfi_character_pointer
+        copy-to-arg -- c_mixin_cfi_copy-to-arg
+        native
+          allocatable -- c_mixin_cfi_native_allocatable
+          pointer -- c_mixin_cfi_native_pointer
       cfi-unpack-base-addr -- c_mixin_cfi-unpack-base-addr
       cfi-unpack-base-addr-cxx -- c_mixin_cfi-unpack-base-addr-cxx
       cfi-unpack-len -- c_mixin_cfi-unpack-len
@@ -19630,12 +19634,9 @@ root
       char-array-alloc -- c_mixin_char-array-alloc
       char-blank-fill -- c_mixin_char-blank-fill
       char-copy -- c_mixin_char-copy
-      char-copy-to-arg-cfi -- c_mixin_char-copy-to-arg-cfi
       char-free -- c_mixin_char-free
       char-malloc -- c_mixin_char-malloc
       character -- c_mixin_character
-        cfi
-          pointer -- c_mixin_character_cfi_pointer
       character-deferred-length -- c_mixin_character-deferred-length
       declare-arg -- c_mixin_declare-arg
       declare-arg-char -- c_mixin_declare-arg-char
@@ -19671,10 +19672,6 @@ root
       local-string-init -- c_mixin_local-string-init
       local-string-init-trim -- c_mixin_local-string-init-trim
       make-shared -- c_mixin_make-shared
-      native
-        cfi
-          allocatable -- c_mixin_native_cfi_allocatable
-          pointer -- c_mixin_native_cfi_pointer
       out
         native** -- c_mixin_out_native**
         string** -- c_mixin_out_string**
@@ -20007,7 +20004,6 @@ root
         cdesc -- f_inout_void*_cdesc
       void** -- f_inout_void**
     mixin
-      arg-character-array-cfi -- f_mixin_arg-character-array-cfi
       as-intent-out -- f_mixin_as-intent-out
       capsule
         arg -- f_mixin_capsule_arg
@@ -20036,7 +20032,10 @@ root
             pointer -- f_mixin_cdesc_out_native_pointer
         pass -- f_mixin_cdesc_pass
       cfi
+        arg-character-array -- f_mixin_cfi_arg-character-array
         character-deferred-length -- f_mixin_cfi_character-deferred-length
+        pass
+          character -- f_mixin_cfi_pass_character
       character-deferred-length -- f_mixin_character-deferred-length
       declare-arg-char -- f_mixin_declare-arg-char
       declare-as-cptr -- f_mixin_declare-as-cptr
@@ -20084,7 +20083,6 @@ root
       pass
         character
           buf -- f_mixin_pass_character_buf
-          cfi -- f_mixin_pass_character_cfi
       procedure-as-funptr -- f_mixin_procedure-as-funptr
       procedure-as-funptr-byreference -- f_mixin_procedure-as-funptr-byreference
       procedure-as-funptr-byvalue -- f_mixin_procedure-as-funptr-byvalue

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -6487,7 +6487,11 @@ f_function_char*_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6661,7 +6665,11 @@ f_function_char*_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_character_cfi_pointer'
   i_arg_names:
   - '{i_var}'
@@ -6907,7 +6915,11 @@ f_function_char_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -6948,7 +6960,11 @@ f_function_char_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_character_cfi_pointer'
   i_arg_names:
   - '{i_var}'
@@ -8842,9 +8858,12 @@ f_function_string&_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8884,9 +8903,12 @@ f_function_string&_cfi_allocatable_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8926,9 +8948,12 @@ f_function_string&_cfi_allocatable_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9102,7 +9127,11 @@ f_function_string&_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9159,7 +9188,11 @@ f_function_string&_cfi_pointer_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9216,7 +9249,11 @@ f_function_string&_cfi_pointer_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9935,9 +9972,12 @@ f_function_string*_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9977,9 +10017,12 @@ f_function_string*_cfi_allocatable_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10019,9 +10062,12 @@ f_function_string*_cfi_allocatable_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10126,7 +10172,11 @@ f_function_string*_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10183,7 +10233,11 @@ f_function_string*_cfi_pointer_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10240,7 +10294,11 @@ f_function_string*_cfi_pointer_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10927,8 +10985,11 @@ f_function_string_cfi_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10966,9 +11027,12 @@ f_function_string_cfi_allocatable_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11008,9 +11072,12 @@ f_function_string_cfi_allocatable_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_string_cfi_allocatable'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   - '  c_mixin_header_string'
-  - '  c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11184,7 +11251,11 @@ f_function_string_cfi_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11241,7 +11312,11 @@ f_function_string_cfi_pointer_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -11298,7 +11373,11 @@ f_function_string_cfi_pointer_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  c_mixin_arg_cfi'
+  - '  f_mixin_cfi_character-deferred-length'
+  - '    f_mixin_character-deferred-length'
+  - '    c_mixin_dummy_arg'
+  - '    c_mixin_character-deferred-length'
+  - '    c_mixin_arg_cfi'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -15386,6 +15465,31 @@ f_mixin_cdesc_pass:
   c_helper:
   - array_context
   owner: library
+f_mixin_cfi_character-deferred-length:
+  name: f_mixin_cfi_character-deferred-length
+  comments:
+  - Make the C wrapper argument a CFI_desc_t.
+  intent: mixin
+  f_arg_decl:
+  - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
+  f_arg_call:
+  - '{f_var}'
+  mixin_names:
+  - '  f_mixin_character-deferred-length'
+  - '  c_mixin_dummy_arg'
+  - '  c_mixin_character-deferred-length'
+  - '  c_mixin_arg_cfi'
+  i_arg_names:
+  - '{i_var}'
+  i_arg_decl:
+  - 'character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}'
+  c_arg_decl:
+  - CFI_cdesc_t *{c_var_cfi}
+  c_temps:
+  - cfi
+  iface_header:
+  - ISO_Fortran_binding.h
+  owner: library
 f_mixin_character-deferred-length:
   name: f_mixin_character-deferred-length
   intent: mixin
@@ -15577,15 +15681,6 @@ f_mixin_function_ptr:
   i_module:
     iso_c_binding:
     - C_PTR
-  owner: library
-f_mixin_function_string_cfi_allocatable:
-  name: f_mixin_function_string_cfi_allocatable
-  intent: mixin
-  f_arg_decl:
-  - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
-  f_arg_call:
-  - '{f_var}'
-  f_need_wrapper: true
   owner: library
 f_mixin_helper_array_string_allocatable:
   name: f_mixin_helper_array_string_allocatable
@@ -19940,6 +20035,8 @@ root
             allocate -- f_mixin_cdesc_out_native_allocate
             pointer -- f_mixin_cdesc_out_native_pointer
         pass -- f_mixin_cdesc_pass
+      cfi
+        character-deferred-length -- f_mixin_cfi_character-deferred-length
       character-deferred-length -- f_mixin_character-deferred-length
       declare-arg-char -- f_mixin_declare-arg-char
       declare-as-cptr -- f_mixin_declare-as-cptr
@@ -19952,9 +20049,6 @@ root
         c-ptr -- f_mixin_function_c-ptr
         char -- f_mixin_function_char
         ptr -- f_mixin_function_ptr
-        string
-          cfi
-            allocatable -- f_mixin_function_string_cfi_allocatable
       function-as-character-arg -- f_mixin_function-as-character-arg
       function-as-character-arg-var-len -- f_mixin_function-as-character-arg-var-len
       function-as-cptr -- f_mixin_function-as-cptr

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -84,7 +84,7 @@ c_ctor_shadow_capsule:
   - Pass function result as a capsule argument from Fortran to C.
   mixin_names:
   - '  f_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   intent: ctor
@@ -452,7 +452,7 @@ c_function_shadow&_capptr:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -497,7 +497,7 @@ c_function_shadow&_capptr_caller:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -542,7 +542,7 @@ c_function_shadow&_capptr_library:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -585,10 +585,10 @@ c_function_shadow&_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -623,10 +623,10 @@ c_function_shadow&_capsule_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -661,10 +661,10 @@ c_function_shadow&_capsule_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -701,7 +701,7 @@ c_function_shadow*_capptr:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -746,7 +746,7 @@ c_function_shadow*_capptr_caller:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -791,7 +791,7 @@ c_function_shadow*_capptr_library:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -836,7 +836,7 @@ c_function_shadow*_capptr_shared:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -879,10 +879,10 @@ c_function_shadow*_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   intent: function
   i_arg_names:
   - '{i_var}'
@@ -940,7 +940,7 @@ c_function_shadow<native>_capptr:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -991,7 +991,7 @@ c_function_shadow_capptr:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -1037,7 +1037,7 @@ c_function_smartptr<shadow>*_capptr:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -1082,7 +1082,7 @@ c_function_smartptr<shadow>_capptr:
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   - '  c_mixin_function-return-cvar'
   intent: function
   i_arg_names:
@@ -1126,10 +1126,10 @@ c_function_string:
   - Cannot return a char array by value.
   - Return a const pointer to std::string data.
   mixin_names:
-  - '  c_mixin_pass_capsule'
+  - '  c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_c-str'
-  - '  c_mixin_native_capsule_fill'
+  - '  c_mixin_capsule_fill_native'
   intent: function
   i_arg_names:
   - '{i_var_capsule}'
@@ -1981,7 +1981,7 @@ c_in_native*_cdesc:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
@@ -2867,7 +2867,7 @@ c_in_void*_cdesc:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: in
   i_arg_names:
@@ -3075,7 +3075,7 @@ c_inout_native*_cdesc:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: inout
   i_arg_names:
@@ -3670,7 +3670,7 @@ c_inout_void*_cdesc:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: inout
   i_arg_names:
@@ -3817,6 +3817,40 @@ c_mixin_c-str:
   - if (!{c_local_cxx}->empty()) {c_var} = {c_local_cxx}->c_str();
   c_return_type: const char *
   owner: library
+c_mixin_capsule_fill_cvar:
+  name: c_mixin_capsule_fill_cvar
+  comments:
+  - Assign to capsule in C wrapper.
+  intent: mixin
+  c_post_call:
+  - '{c_var}->addr  = {cxx_nonconst_ptr};'
+  - '{c_var}->idtor = {idtor};'
+  owner: library
+c_mixin_capsule_fill_native:
+  name: c_mixin_capsule_fill_native
+  comments:
+  - Assign to local capsule variable in C wrapper.
+  intent: mixin
+  c_post_call:
+  - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
+  - '{c_var_capsule}->idtor = {idtor};'
+  owner: library
+c_mixin_capsule_pass:
+  name: c_mixin_capsule_pass
+  comments:
+  - Pass capsule as argument to C wrapper.
+  intent: mixin
+  i_arg_names:
+  - '{i_var_capsule}'
+  i_arg_decl:
+  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
+  i_import:
+  - '{F_capsule_data_type}'
+  c_arg_decl:
+  - '{C_capsule_data_type} *{c_var_capsule}'
+  c_temps:
+  - capsule
+  owner: library
 c_mixin_cast-argument:
   name: c_mixin_cast-argument
   comments:
@@ -3827,8 +3861,8 @@ c_mixin_cast-argument:
   c_local:
   - cxx
   owner: library
-c_mixin_cdesc-char-fill-cvar:
-  name: c_mixin_cdesc-char-fill-cvar
+c_mixin_cdesc_char_fill_cvar:
+  name: c_mixin_cdesc_char_fill_cvar
   comments:
   - Fill cdesc from char * in the C wrapper.
   intent: mixin
@@ -3840,6 +3874,58 @@ c_mixin_cdesc-char-fill-cvar:
   - '{c_var_cdesc}->rank = 0;'
   c_helper:
   - type_defines
+  owner: library
+c_mixin_cdesc_function_string:
+  name: c_mixin_cdesc_function_string
+  comments:
+  - Fill cdesc from std::string using helper string_to_cdesc
+  - in the C wrapper.
+  intent: mixin
+  c_post_call:
+  - "{c_helper_string_to_cdesc}(\t{c_var_cdesc},\t {cxx_addr}{cxx_var});"
+  c_helper:
+  - string_to_cdesc
+  owner: library
+c_mixin_cdesc_inout_vector:
+  name: c_mixin_cdesc_inout_vector
+  comments:
+  - Accept array_type in C wrapper.
+  intent: mixin
+  i_arg_names:
+  - '{i_var}'
+  - '{i_var_size}'
+  - '{i_var_cdesc}'
+  i_arg_decl:
+  - '{targs[0].f_type}, intent(IN) :: {i_var}(*)'
+  - 'integer(C_SIZE_T), intent(IN), value :: {i_var_size}'
+  - 'type({F_array_type}), intent(OUT) :: {i_var_cdesc}'
+  i_import:
+  - '{F_array_type}'
+  i_module:
+    iso_c_binding:
+    - '{targs[0].f_kind}'
+    - C_SIZE_T
+  c_arg_decl:
+  - '{targs[0].cxx_type} *{c_var}'
+  - size_t {c_var_size}
+  - '{C_array_type} *{c_var_cdesc}'
+  c_temps:
+  - size
+  - cdesc
+  c_helper:
+  - array_context
+  owner: library
+c_mixin_cdesc_native_fill:
+  name: c_mixin_cdesc_native_fill
+  comments:
+  - Fill cdesc from native in the C wrapper.
+  intent: mixin
+  c_post_call:
+  - '{c_var_cdesc}->base_addr = {cxx_nonconst_ptr};'
+  - '{c_var_cdesc}->type = {sh_type};'
+  - '{c_var_cdesc}->elem_len = sizeof({cxx_type});'
+  - '{c_var_cdesc}->rank = {rank};{c_array_shape}'
+  - '{c_var_cdesc}->size = {c_array_size};'
   owner: library
 c_mixin_cfi-unpack-base-addr:
   name: c_mixin_cfi-unpack-base-addr
@@ -4034,15 +4120,6 @@ c_mixin_character_cfi_pointer:
   - len
   - err
   owner: library
-c_mixin_cvar-capsule-fill:
-  name: c_mixin_cvar-capsule-fill
-  comments:
-  - Assign to capsule in C wrapper.
-  intent: mixin
-  c_post_call:
-  - '{c_var}->addr  = {cxx_nonconst_ptr};'
-  - '{c_var}->idtor = {idtor};'
-  owner: library
 c_mixin_declare-arg:
   name: c_mixin_declare-arg
   intent: mixin
@@ -4158,17 +4235,6 @@ c_mixin_function_shadow_capptr:
     iso_c_binding:
     - C_PTR
   owner: library
-c_mixin_function_string_cdesc:
-  name: c_mixin_function_string_cdesc
-  comments:
-  - Fill cdesc from std::string using helper string_to_cdesc
-  - in the C wrapper.
-  intent: mixin
-  c_post_call:
-  - "{c_helper_string_to_cdesc}(\t{c_var_cdesc},\t {cxx_addr}{cxx_var});"
-  c_helper:
-  - string_to_cdesc
-  owner: library
 c_mixin_function_vector_malloc:
   name: c_mixin_function_vector_malloc
   comments:
@@ -4254,8 +4320,8 @@ c_mixin_inout_vector<native>_cdesc:
   - Fill cdesc with vector information.
   - Return address and size of vector data.
   mixin_names:
-  - '  f_mixin_inout_array_cdesc'
-  - '  c_mixin_inout_vector_cdesc'
+  - '  f_mixin_cdesc_inout_array'
+  - '  c_mixin_cdesc_inout_vector'
   - '  c_mixin_destructor_new-vector'
   - '  c_mixin_vector_cdesc_fill-cdesc'
   intent: mixin
@@ -4300,35 +4366,6 @@ c_mixin_inout_vector<native>_cdesc:
   destructor:
   - "std::vector<{cxx_T}> *cxx_ptr = \treinterpret_cast<std::vector<{cxx_T}> *>(ptr);"
   - delete cxx_ptr;
-  owner: library
-c_mixin_inout_vector_cdesc:
-  name: c_mixin_inout_vector_cdesc
-  comments:
-  - Accept array_type in C wrapper.
-  intent: mixin
-  i_arg_names:
-  - '{i_var}'
-  - '{i_var_size}'
-  - '{i_var_cdesc}'
-  i_arg_decl:
-  - '{targs[0].f_type}, intent(IN) :: {i_var}(*)'
-  - 'integer(C_SIZE_T), intent(IN), value :: {i_var_size}'
-  - 'type({F_array_type}), intent(OUT) :: {i_var_cdesc}'
-  i_import:
-  - '{F_array_type}'
-  i_module:
-    iso_c_binding:
-    - '{targs[0].f_kind}'
-    - C_SIZE_T
-  c_arg_decl:
-  - '{targs[0].cxx_type} *{c_var}'
-  - size_t {c_var_size}
-  - '{C_array_type} *{c_var_cdesc}'
-  c_temps:
-  - size
-  - cdesc
-  c_helper:
-  - array_context
   owner: library
 c_mixin_local-cvar-ptr:
   name: c_mixin_local-cvar-ptr
@@ -4397,27 +4434,6 @@ c_mixin_make-shared:
   impl_header:
   - <memory>
   owner: shared
-c_mixin_native_capsule_fill:
-  name: c_mixin_native_capsule_fill
-  comments:
-  - Assign to local capsule variable in C wrapper.
-  intent: mixin
-  c_post_call:
-  - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
-  - '{c_var_capsule}->idtor = {idtor};'
-  owner: library
-c_mixin_native_cdesc_fill-cdesc:
-  name: c_mixin_native_cdesc_fill-cdesc
-  comments:
-  - Fill cdesc from native in the C wrapper.
-  intent: mixin
-  c_post_call:
-  - '{c_var_cdesc}->base_addr = {cxx_nonconst_ptr};'
-  - '{c_var_cdesc}->type = {sh_type};'
-  - '{c_var_cdesc}->elem_len = sizeof({cxx_type});'
-  - '{c_var_cdesc}->rank = {rank};{c_array_shape}'
-  - '{c_var_cdesc}->size = {c_array_size};'
-  owner: library
 c_mixin_native_cfi_allocatable:
   name: c_mixin_native_cfi_allocatable
   comments:
@@ -4526,22 +4542,6 @@ c_mixin_out_vector_buf_malloc:
   - size_t *{c_var_size}
   c_temps:
   - size
-  owner: library
-c_mixin_pass_capsule:
-  name: c_mixin_pass_capsule
-  comments:
-  - Pass capsule as argument to C wrapper.
-  intent: mixin
-  i_arg_names:
-  - '{i_var_capsule}'
-  i_arg_decl:
-  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
-  i_import:
-  - '{F_capsule_data_type}'
-  c_arg_decl:
-  - '{C_capsule_data_type} *{c_var_capsule}'
-  c_temps:
-  - capsule
   owner: library
 c_mixin_shadow:
   name: c_mixin_shadow
@@ -4903,7 +4903,7 @@ c_out_native*_cdesc:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
@@ -5115,7 +5115,7 @@ c_out_string**_cdesc_copy:
   - '[see also f_out_vector_&_cdesc_allocatable_targ_string_scalar]'
   mixin_names:
   - '  f_mixin_str_array'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar-address'
   intent: out
   i_arg_names:
@@ -5329,7 +5329,7 @@ c_out_vector<native>&_cdesc:
   notes:
   - Not supported for C wrappers.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  f_mixin_out_vector<native>_copy'
   - '  c_mixin_out_vector<native>_cdesc'
   - '    c_mixin_destructor_new-vector'
@@ -5466,7 +5466,7 @@ c_out_vector<native>*_cdesc:
   notes:
   - Not supported for C wrappers.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  f_mixin_out_vector<native>_copy'
   - '  c_mixin_out_vector<native>_cdesc'
   - '    c_mixin_destructor_new-vector'
@@ -5630,7 +5630,7 @@ c_out_vector<string>&_cdesc:
   - This one needs to use targs.
   mixin_names:
   - '  f_mixin_str_array'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
@@ -5664,10 +5664,10 @@ c_out_vector<string>&_cdesc_allocatable:
   - Release memory from capsule.
   - Pass dereference of local cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  f_mixin_out_array_cdesc_allocatable'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  f_mixin_cdesc_out_char_array_allocatable'
   - '  f_mixin_helper_vector_string_allocatable'
   - '  f_mixin_capsule_dtor'
   - '  c_mixin_arg-call-cxx-deref'
@@ -5695,7 +5695,7 @@ c_out_vector<string>&_cdesc_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_native_capsule_fill
+  - // XXX - Use code from c_mixin_capsule_fill_native
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_temps:
@@ -5799,7 +5799,7 @@ c_out_void*_cdesc:
   - Pass cdesc as argument to C wrapper.
   - Pass cxx variable to library.
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   intent: out
   i_arg_names:
@@ -5936,7 +5936,7 @@ f_ctor_shadow_capsule:
   f_need_wrapper: true
   mixin_names:
   - '  f_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_as-intent-out'
   i_arg_names:
@@ -5976,7 +5976,7 @@ f_ctor_shadow_capsule_shared:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_destructor_new-shadow-shared'
   - '  c_mixin_make-shared'
@@ -6384,9 +6384,9 @@ f_function_char*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_char_cdesc_allocate'
-  - '  c_mixin_cdesc-char-fill-cvar'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_char_allocate'
+  - '  c_mixin_cdesc_char_fill_cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -6442,9 +6442,9 @@ f_function_char*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_cdesc-char-fill-cvar'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -6804,9 +6804,9 @@ f_function_char_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_char_cdesc_allocate'
-  - '  c_mixin_cdesc-char-fill-cvar'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_char_allocate'
+  - '  c_mixin_cdesc_char_fill_cvar'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -6862,9 +6862,9 @@ f_function_char_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_cdesc-char-fill-cvar'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7165,13 +7165,13 @@ f_function_native*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  f_mixin_native_cdesc_allocate'
-  - '  f_mixin_use_capsule'
-  - '    f_mixin_pass_capsule'
-  - '      c_mixin_pass_capsule'
-  - '    c_mixin_native_capsule_fill'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_native_fill'
+  - '  f_mixin_cdesc_native_allocate'
+  - '  f_mixin_capsule_use'
+  - '    f_mixin_capsule_pass'
+  - '      c_mixin_capsule_pass'
+  - '    c_mixin_capsule_fill_native'
   - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -7235,9 +7235,9 @@ f_function_native*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  f_mixin_native_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_native_fill'
+  - '  f_mixin_cdesc_native_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -7306,12 +7306,12 @@ f_function_native*_cdesc_pointer_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_arg_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_native_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_arg'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_native_fill'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_native_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   - '{i_var_capsule}'
@@ -7614,10 +7614,10 @@ f_function_shadow&_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7659,10 +7659,10 @@ f_function_shadow&_capsule_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7704,10 +7704,10 @@ f_function_shadow&_capsule_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7749,10 +7749,10 @@ f_function_shadow*_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7794,10 +7794,10 @@ f_function_shadow*_capsule_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7839,10 +7839,10 @@ f_function_shadow*_capsule_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7908,10 +7908,10 @@ f_function_shadow<native>_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -7959,10 +7959,10 @@ f_function_shadow_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8005,10 +8005,10 @@ f_function_smartptr<shadow>*_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-local'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8050,10 +8050,10 @@ f_function_smartptr<shadow>_capsule:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_function_shadow_capsule'
+  - '  f_mixin_capsule_function_shadow'
   - '  c_mixin_shadow'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_cvar-capsule-fill'
+  - '  c_mixin_capsule_fill_cvar'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8479,12 +8479,12 @@ f_function_string&_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_function_string_cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -8554,12 +8554,12 @@ f_function_string&_cdesc_allocatable_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_function_string_cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -8629,12 +8629,12 @@ f_function_string&_cdesc_allocatable_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_function_string_cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -8695,9 +8695,9 @@ f_function_string&_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -8749,9 +8749,9 @@ f_function_string&_cdesc_pointer_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -8803,9 +8803,9 @@ f_function_string&_cdesc_pointer_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9572,12 +9572,12 @@ f_function_string*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_function_string_cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -9647,12 +9647,12 @@ f_function_string*_cdesc_allocatable_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_function_string_cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -9722,12 +9722,12 @@ f_function_string*_cdesc_allocatable_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_function_string_cdesc'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -9788,9 +9788,9 @@ f_function_string*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9842,9 +9842,9 @@ f_function_string*_cdesc_pointer_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -9896,9 +9896,9 @@ f_function_string*_cdesc_pointer_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -10680,15 +10680,15 @@ f_function_string_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_destructor_new-string'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_allocate'
-  - '  f_mixin_use_capsule'
-  - '    f_mixin_pass_capsule'
-  - '      c_mixin_pass_capsule'
-  - '    c_mixin_native_capsule_fill'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_allocate'
+  - '  f_mixin_capsule_use'
+  - '    f_mixin_capsule_pass'
+  - '      c_mixin_capsule_pass'
+  - '    c_mixin_capsule_fill_native'
   - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -10770,15 +10770,15 @@ f_function_string_cdesc_allocatable_caller:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_destructor_new-string'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_allocate'
-  - '  f_mixin_use_capsule'
-  - '    f_mixin_pass_capsule'
-  - '      c_mixin_pass_capsule'
-  - '    c_mixin_native_capsule_fill'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_allocate'
+  - '  f_mixin_capsule_use'
+  - '    f_mixin_capsule_pass'
+  - '      c_mixin_capsule_pass'
+  - '    c_mixin_capsule_fill_native'
   - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -10860,15 +10860,15 @@ f_function_string_cdesc_allocatable_library:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_destructor_new-string'
-  - '  c_mixin_function_string_cdesc'
-  - '  f_mixin_char_cdesc_allocate'
-  - '  f_mixin_use_capsule'
-  - '    f_mixin_pass_capsule'
-  - '      c_mixin_pass_capsule'
-  - '    c_mixin_native_capsule_fill'
+  - '  c_mixin_cdesc_function_string'
+  - '  f_mixin_cdesc_char_allocate'
+  - '  f_mixin_capsule_use'
+  - '    f_mixin_capsule_pass'
+  - '      c_mixin_capsule_pass'
+  - '    c_mixin_capsule_fill_native'
   - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -11402,9 +11402,9 @@ f_function_struct*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  f_mixin_native_cdesc_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_native_fill'
+  - '  f_mixin_cdesc_native_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -11496,7 +11496,7 @@ f_function_vector<native>_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_destructor_new-vector'
   - '  c_mixin_vector_cdesc_fill-cdesc'
   i_arg_names:
@@ -11644,9 +11644,9 @@ f_getter_native*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_native_cdesc_pointer'
-  - '  f_mixin_getter_cdesc'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_native_pointer'
+  - '  f_mixin_cdesc_getter'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -11723,8 +11723,8 @@ f_getter_string_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_char_cdesc_allocate'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_char_allocate'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -11779,9 +11779,9 @@ f_getter_struct**_cdesc_raw:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_native_cdesc_raw'
-  - '  f_mixin_getter_cdesc'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_native_raw'
+  - '  f_mixin_cdesc_getter'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -11841,9 +11841,9 @@ f_getter_struct*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_function-to-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_native_cdesc_pointer'
-  - '  f_mixin_getter_cdesc'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_native_pointer'
+  - '  f_mixin_cdesc_getter'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -12436,7 +12436,7 @@ f_in_native*_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -13763,7 +13763,7 @@ f_in_void*_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -14137,7 +14137,7 @@ f_inout_native*_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -14747,8 +14747,8 @@ f_inout_vector<native>&_cdesc:
   - copy_array
   mixin_names:
   - '  c_mixin_inout_vector<native>_cdesc'
-  - '    f_mixin_inout_array_cdesc'
-  - '    c_mixin_inout_vector_cdesc'
+  - '    f_mixin_cdesc_inout_array'
+  - '    c_mixin_cdesc_inout_vector'
   - '    c_mixin_destructor_new-vector'
   - '    c_mixin_vector_cdesc_fill-cdesc'
   - '  c_mixin_arg-call-cxx-deref'
@@ -14831,8 +14831,8 @@ f_inout_vector<native>&_cdesc_allocatable:
   - copy_array
   mixin_names:
   - '  c_mixin_inout_vector<native>_cdesc'
-  - '    f_mixin_inout_array_cdesc'
-  - '    c_mixin_inout_vector_cdesc'
+  - '    f_mixin_cdesc_inout_array'
+  - '    c_mixin_cdesc_inout_vector'
   - '    c_mixin_destructor_new-vector'
   - '    c_mixin_vector_cdesc_fill-cdesc'
   - '  c_mixin_arg-call-cxx-deref'
@@ -15018,7 +15018,7 @@ f_inout_void*_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -15060,8 +15060,15 @@ f_mixin_arg-character-array-cfi:
   iface_header:
   - ISO_Fortran_binding.h
   owner: library
-f_mixin_arg_capsule:
-  name: f_mixin_arg_capsule
+f_mixin_as-intent-out:
+  name: f_mixin_as-intent-out
+  intent: mixin
+  fmtdict:
+    f_intent: OUT
+    f_intent_attr: ', intent(OUT)'
+  owner: library
+f_mixin_capsule_arg:
+  name: f_mixin_capsule_arg
   comments:
   - Pass capsule as argument to C wrapper.
   - Add a capsule argument to the Fortran wrapper.
@@ -15080,7 +15087,7 @@ f_mixin_arg_capsule:
   - capsule_helper
   f_need_wrapper: true
   mixin_names:
-  - '  c_mixin_pass_capsule'
+  - '  c_mixin_capsule_pass'
   i_arg_names:
   - '{i_var_capsule}'
   i_arg_decl:
@@ -15094,13 +15101,6 @@ f_mixin_arg_capsule:
   fmtdict:
     f_var_capsule: Crv
   owner: library
-f_mixin_as-intent-out:
-  name: f_mixin_as-intent-out
-  intent: mixin
-  fmtdict:
-    f_intent: OUT
-    f_intent_attr: ', intent(OUT)'
-  owner: library
 f_mixin_capsule_dtor:
   name: f_mixin_capsule_dtor
   comments:
@@ -15111,8 +15111,86 @@ f_mixin_capsule_dtor:
   f_helper:
   - capsule_dtor
   owner: library
-f_mixin_char_cdesc_allocate:
-  name: f_mixin_char_cdesc_allocate
+f_mixin_capsule_function_shadow:
+  name: f_mixin_capsule_function_shadow
+  comments:
+  - Pass function result as a capsule argument from Fortran to C.
+  intent: mixin
+  f_arg_decl:
+  - '{f_type} :: {f_var}'
+  f_arg_call:
+  - '{f_var}%{F_derived_member}'
+  f_need_wrapper: true
+  owner: library
+f_mixin_capsule_pass:
+  name: f_mixin_capsule_pass
+  comments:
+  - Pass capsule as argument to C wrapper.
+  - Create a local Fortran capsule.
+  intent: mixin
+  f_declare:
+  - 'type({F_capsule_data_type}) :: {f_var_capsule}'
+  f_arg_call:
+  - '{f_var_capsule}'
+  f_temps:
+  - capsule
+  f_helper:
+  - array_context
+  f_need_wrapper: true
+  mixin_names:
+  - '  c_mixin_capsule_pass'
+  i_arg_names:
+  - '{i_var_capsule}'
+  i_arg_decl:
+  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
+  i_import:
+  - '{F_capsule_data_type}'
+  c_arg_decl:
+  - '{C_capsule_data_type} *{c_var_capsule}'
+  c_temps:
+  - capsule
+  owner: library
+f_mixin_capsule_use:
+  name: f_mixin_capsule_use
+  comments:
+  - Pass capsule as argument to C wrapper.
+  - Create a local Fortran capsule.
+  - Assign to local capsule variable in C wrapper.
+  - Release memory from capsule.
+  intent: mixin
+  f_declare:
+  - 'type({F_capsule_data_type}) :: {f_var_capsule}'
+  f_arg_call:
+  - '{f_var_capsule}'
+  f_post_call:
+  - call {f_helper_capsule_dtor}({f_var_capsule})
+  f_temps:
+  - capsule
+  f_helper:
+  - array_context
+  - capsule_dtor
+  f_need_wrapper: true
+  mixin_names:
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  c_mixin_capsule_fill_native'
+  - '  f_mixin_capsule_dtor'
+  i_arg_names:
+  - '{i_var_capsule}'
+  i_arg_decl:
+  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
+  i_import:
+  - '{F_capsule_data_type}'
+  c_arg_decl:
+  - '{C_capsule_data_type} *{c_var_capsule}'
+  c_post_call:
+  - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
+  - '{c_var_capsule}->idtor = {idtor};'
+  c_temps:
+  - capsule
+  owner: library
+f_mixin_cdesc_char_allocate:
+  name: f_mixin_cdesc_char_allocate
   comments:
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
@@ -15127,8 +15205,8 @@ f_mixin_char_cdesc_allocate:
   c_helper:
   - copy_string
   owner: library
-f_mixin_char_cdesc_pointer:
-  name: f_mixin_char_cdesc_pointer
+f_mixin_cdesc_char_pointer:
+  name: f_mixin_cdesc_char_pointer
   comments:
   - Assign Fortran pointer from cdesc using helper pointer_string.
   intent: mixin
@@ -15141,6 +15219,172 @@ f_mixin_char_cdesc_pointer:
     - c_f_pointer
   f_helper:
   - pointer_string
+  owner: library
+f_mixin_cdesc_getter:
+  name: f_mixin_cdesc_getter
+  comments:
+  - Save pointer struct members in a cdesc
+  - along with shape information.
+  intent: mixin
+  c_call:
+  - '{c_var_cdesc}->base_addr = {CXX_this}->{field_name};'
+  - '{c_var_cdesc}->type = {sh_type};'
+  - '{c_var_cdesc}->elem_len = sizeof({cxx_type});'
+  - '{c_var_cdesc}->rank = {rank};{c_array_shape}'
+  - '{c_var_cdesc}->size = {c_array_size};'
+  c_helper:
+  - type_defines
+  - array_context
+  owner: library
+f_mixin_cdesc_inout_array:
+  name: f_mixin_cdesc_inout_array
+  comments:
+  - Declare local Fortran array_type argument.
+  intent: mixin
+  f_declare:
+  - 'type({F_array_type}) :: {f_var_cdesc}'
+  f_arg_call:
+  - '{f_var}'
+  - size({f_var}, kind=C_SIZE_T)
+  - '{f_var_cdesc}'
+  f_module:
+    iso_c_binding:
+    - C_SIZE_T
+  f_temps:
+  - cdesc
+  f_helper:
+  - array_context
+  owner: library
+f_mixin_cdesc_native_allocate:
+  name: f_mixin_cdesc_native_allocate
+  comments:
+  - Allocate Fortran native array, then fill from cdesc
+  - using helper copy_array.
+  intent: mixin
+  f_arg_decl:
+  - '{f_type}{f_intent_attr}{f_deref_attr}, target :: {f_var}{f_dimension}'
+  f_post_call:
+  - allocate({f_var}{f_array_allocate})
+  - "call {f_helper_copy_array}(\t{f_var_cdesc},\t C_LOC({f_var}),\t size({f_var},\t\
+    \ kind=C_SIZE_T))"
+  f_module:
+    '{f_module_name}':
+    - '{f_kind}'
+    iso_c_binding:
+    - C_LOC
+    - C_SIZE_T
+  f_helper:
+  - copy_array
+  c_helper:
+  - copy_array
+  owner: library
+f_mixin_cdesc_native_pointer:
+  name: f_mixin_cdesc_native_pointer
+  comments:
+  - Set Fortran pointer to native array.
+  intent: mixin
+  f_arg_decl:
+  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}'
+  f_post_call:
+  - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {f_result_var}{f_array_shape})"
+  f_module:
+    '{f_module_name}':
+    - '{f_kind}'
+    iso_c_binding:
+    - c_f_pointer
+  owner: library
+f_mixin_cdesc_native_raw:
+  name: f_mixin_cdesc_native_raw
+  comments:
+  - Set Fortran pointer to pointers to arrays.
+  intent: mixin
+  f_arg_decl:
+  - 'type(C_PTR), pointer :: {f_var}{f_assumed_shape}'
+  f_post_call:
+  - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {f_result_var}{f_array_shape})"
+  f_module:
+    iso_c_binding:
+    - C_PTR
+    - c_f_pointer
+  owner: library
+f_mixin_cdesc_out_char_array_allocatable:
+  name: f_mixin_cdesc_out_char_array_allocatable
+  comments:
+  - Allocate Fortran array from cdesc.
+  intent: mixin
+  f_arg_name:
+  - '{f_var}'
+  f_arg_decl:
+  - 'character({f_char_len}){f_intent_attr}{f_deref_attr}, target :: {f_var}{f_assumed_shape}'
+  f_post_call:
+  - allocate({f_char_type}{f_var}({f_var_cdesc}%size))
+  - '{f_var_cdesc}%base_addr = C_LOC({f_var})'
+  f_module:
+    iso_c_binding:
+    - C_LOC
+  owner: library
+f_mixin_cdesc_out_native_allocate:
+  name: f_mixin_cdesc_out_native_allocate
+  comments:
+  - Allocate Fortran native array for argument
+  - then fill from cdesc using helper copy_array.
+  intent: mixin
+  f_post_call:
+  - allocate({f_var}{f_array_allocate})
+  - "call {f_helper_copy_array}(\t{f_var_cdesc},\t C_LOC({f_var}),\t {f_var_cdesc}%size)"
+  f_module:
+    iso_c_binding:
+    - C_LOC
+  f_helper:
+  - copy_array
+  c_helper:
+  - copy_array
+  fmtdict:
+    f_deref_attr: ', allocatable, target'
+  owner: library
+f_mixin_cdesc_out_native_pointer:
+  name: f_mixin_cdesc_out_native_pointer
+  comments:
+  - Set Fortran pointer to native array.
+  intent: mixin
+  f_arg_name:
+  - '{f_var}'
+  f_arg_decl:
+  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}'
+  f_post_call:
+  - call c_f_pointer({f_var_cdesc}%base_addr, {f_var}{f_array_shape})
+  f_module:
+    '{f_module_name}':
+    - '{f_kind}'
+    iso_c_binding:
+    - c_f_pointer
+  owner: library
+f_mixin_cdesc_pass:
+  name: f_mixin_cdesc_pass
+  comments:
+  - Pass cdesc as argument to C wrapper.
+  intent: mixin
+  f_declare:
+  - 'type({F_array_type}) :: {f_var_cdesc}'
+  f_arg_call:
+  - '{f_var_cdesc}'
+  f_temps:
+  - cdesc
+  f_helper:
+  - array_context
+  f_need_wrapper: true
+  i_arg_names:
+  - '{i_var_cdesc}'
+  i_arg_decl:
+  - 'type({F_array_type}), intent(OUT) :: {i_var_cdesc}'
+  i_import:
+  - '{F_array_type}'
+  c_arg_decl:
+  - '{C_array_type} *{c_var_cdesc}'
+  c_temps:
+  - cdesc
+  c_helper:
+  - array_context
   owner: library
 f_mixin_character-deferred-length:
   name: f_mixin_character-deferred-length
@@ -15334,17 +15578,6 @@ f_mixin_function_ptr:
     iso_c_binding:
     - C_PTR
   owner: library
-f_mixin_function_shadow_capsule:
-  name: f_mixin_function_shadow_capsule
-  comments:
-  - Pass function result as a capsule argument from Fortran to C.
-  intent: mixin
-  f_arg_decl:
-  - '{f_type} :: {f_var}'
-  f_arg_call:
-  - '{f_var}%{F_derived_member}'
-  f_need_wrapper: true
-  owner: library
 f_mixin_function_string_cfi_allocatable:
   name: f_mixin_function_string_cfi_allocatable
   intent: mixin
@@ -15353,22 +15586,6 @@ f_mixin_function_string_cfi_allocatable:
   f_arg_call:
   - '{f_var}'
   f_need_wrapper: true
-  owner: library
-f_mixin_getter_cdesc:
-  name: f_mixin_getter_cdesc
-  comments:
-  - Save pointer struct members in a cdesc
-  - along with shape information.
-  intent: mixin
-  c_call:
-  - '{c_var_cdesc}->base_addr = {CXX_this}->{field_name};'
-  - '{c_var_cdesc}->type = {sh_type};'
-  - '{c_var_cdesc}->elem_len = sizeof({cxx_type});'
-  - '{c_var_cdesc}->rank = {rank};{c_array_shape}'
-  - '{c_var_cdesc}->size = {c_array_size};'
-  c_helper:
-  - type_defines
-  - array_context
   owner: library
 f_mixin_helper_array_string_allocatable:
   name: f_mixin_helper_array_string_allocatable
@@ -15413,7 +15630,7 @@ f_mixin_helper_vector_string_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_native_capsule_fill
+  - // XXX - Use code from c_mixin_capsule_fill_native
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_local:
@@ -15532,25 +15749,6 @@ f_mixin_in_vector_buf:
   c_temps:
   - size
   owner: library
-f_mixin_inout_array_cdesc:
-  name: f_mixin_inout_array_cdesc
-  comments:
-  - Declare local Fortran array_type argument.
-  intent: mixin
-  f_declare:
-  - 'type({F_array_type}) :: {f_var_cdesc}'
-  f_arg_call:
-  - '{f_var}'
-  - size({f_var}, kind=C_SIZE_T)
-  - '{f_var_cdesc}'
-  f_module:
-    iso_c_binding:
-    - C_SIZE_T
-  f_temps:
-  - cdesc
-  f_helper:
-  - array_context
-  owner: library
 f_mixin_interface-as-cptr:
   name: f_mixin_interface-as-cptr
   intent: mixin
@@ -15609,110 +15807,6 @@ f_mixin_logical-out:
   f_post_call:
   - '{f_var} = {f_var_cxx}  ! coerce to logical'
   owner: library
-f_mixin_native_cdesc_allocate:
-  name: f_mixin_native_cdesc_allocate
-  comments:
-  - Allocate Fortran native array, then fill from cdesc
-  - using helper copy_array.
-  intent: mixin
-  f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr}, target :: {f_var}{f_dimension}'
-  f_post_call:
-  - allocate({f_var}{f_array_allocate})
-  - "call {f_helper_copy_array}(\t{f_var_cdesc},\t C_LOC({f_var}),\t size({f_var},\t\
-    \ kind=C_SIZE_T))"
-  f_module:
-    '{f_module_name}':
-    - '{f_kind}'
-    iso_c_binding:
-    - C_LOC
-    - C_SIZE_T
-  f_helper:
-  - copy_array
-  c_helper:
-  - copy_array
-  owner: library
-f_mixin_native_cdesc_pointer:
-  name: f_mixin_native_cdesc_pointer
-  comments:
-  - Set Fortran pointer to native array.
-  intent: mixin
-  f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}'
-  f_post_call:
-  - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {f_result_var}{f_array_shape})"
-  f_module:
-    '{f_module_name}':
-    - '{f_kind}'
-    iso_c_binding:
-    - c_f_pointer
-  owner: library
-f_mixin_native_cdesc_raw:
-  name: f_mixin_native_cdesc_raw
-  comments:
-  - Set Fortran pointer to pointers to arrays.
-  intent: mixin
-  f_arg_decl:
-  - 'type(C_PTR), pointer :: {f_var}{f_assumed_shape}'
-  f_post_call:
-  - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {f_result_var}{f_array_shape})"
-  f_module:
-    iso_c_binding:
-    - C_PTR
-    - c_f_pointer
-  owner: library
-f_mixin_out_array_cdesc_allocatable:
-  name: f_mixin_out_array_cdesc_allocatable
-  comments:
-  - Allocate Fortran array from cdesc.
-  intent: mixin
-  f_arg_name:
-  - '{f_var}'
-  f_arg_decl:
-  - 'character({f_char_len}){f_intent_attr}{f_deref_attr}, target :: {f_var}{f_assumed_shape}'
-  f_post_call:
-  - allocate({f_char_type}{f_var}({f_var_cdesc}%size))
-  - '{f_var_cdesc}%base_addr = C_LOC({f_var})'
-  f_module:
-    iso_c_binding:
-    - C_LOC
-  owner: library
-f_mixin_out_native_cdesc_allocate:
-  name: f_mixin_out_native_cdesc_allocate
-  comments:
-  - Allocate Fortran native array for argument
-  - then fill from cdesc using helper copy_array.
-  intent: mixin
-  f_post_call:
-  - allocate({f_var}{f_array_allocate})
-  - "call {f_helper_copy_array}(\t{f_var_cdesc},\t C_LOC({f_var}),\t {f_var_cdesc}%size)"
-  f_module:
-    iso_c_binding:
-    - C_LOC
-  f_helper:
-  - copy_array
-  c_helper:
-  - copy_array
-  fmtdict:
-    f_deref_attr: ', allocatable, target'
-  owner: library
-f_mixin_out_native_cdesc_pointer:
-  name: f_mixin_out_native_cdesc_pointer
-  comments:
-  - Set Fortran pointer to native array.
-  intent: mixin
-  f_arg_name:
-  - '{f_var}'
-  f_arg_decl:
-  - '{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}'
-  f_post_call:
-  - call c_f_pointer({f_var_cdesc}%base_addr, {f_var}{f_array_shape})
-  f_module:
-    '{f_module_name}':
-    - '{f_kind}'
-    iso_c_binding:
-    - c_f_pointer
-  owner: library
 f_mixin_out_vector<native>_copy:
   name: f_mixin_out_vector<native>_copy
   comments:
@@ -15762,61 +15856,6 @@ f_mixin_out_vector_buf:
   - size_t *{c_var_size}
   c_temps:
   - size
-  owner: library
-f_mixin_pass_capsule:
-  name: f_mixin_pass_capsule
-  comments:
-  - Pass capsule as argument to C wrapper.
-  - Create a local Fortran capsule.
-  intent: mixin
-  f_declare:
-  - 'type({F_capsule_data_type}) :: {f_var_capsule}'
-  f_arg_call:
-  - '{f_var_capsule}'
-  f_temps:
-  - capsule
-  f_helper:
-  - array_context
-  f_need_wrapper: true
-  mixin_names:
-  - '  c_mixin_pass_capsule'
-  i_arg_names:
-  - '{i_var_capsule}'
-  i_arg_decl:
-  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
-  i_import:
-  - '{F_capsule_data_type}'
-  c_arg_decl:
-  - '{C_capsule_data_type} *{c_var_capsule}'
-  c_temps:
-  - capsule
-  owner: library
-f_mixin_pass_cdesc:
-  name: f_mixin_pass_cdesc
-  comments:
-  - Pass cdesc as argument to C wrapper.
-  intent: mixin
-  f_declare:
-  - 'type({F_array_type}) :: {f_var_cdesc}'
-  f_arg_call:
-  - '{f_var_cdesc}'
-  f_temps:
-  - cdesc
-  f_helper:
-  - array_context
-  f_need_wrapper: true
-  i_arg_names:
-  - '{i_var_cdesc}'
-  i_arg_decl:
-  - 'type({F_array_type}), intent(OUT) :: {i_var_cdesc}'
-  i_import:
-  - '{F_array_type}'
-  c_arg_decl:
-  - '{C_array_type} *{c_var_cdesc}'
-  c_temps:
-  - cdesc
-  c_helper:
-  - array_context
   owner: library
 f_mixin_pass_character_buf:
   name: f_mixin_pass_character_buf
@@ -15937,45 +15976,6 @@ f_mixin_unknown:
   - ===>i_result_decl<===
   c_arg_decl:
   - ===>c_arg_decl<===
-  owner: library
-f_mixin_use_capsule:
-  name: f_mixin_use_capsule
-  comments:
-  - Pass capsule as argument to C wrapper.
-  - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
-  - Release memory from capsule.
-  intent: mixin
-  f_declare:
-  - 'type({F_capsule_data_type}) :: {f_var_capsule}'
-  f_arg_call:
-  - '{f_var_capsule}'
-  f_post_call:
-  - call {f_helper_capsule_dtor}({f_var_capsule})
-  f_temps:
-  - capsule
-  f_helper:
-  - array_context
-  - capsule_dtor
-  f_need_wrapper: true
-  mixin_names:
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  c_mixin_native_capsule_fill'
-  - '  f_mixin_capsule_dtor'
-  i_arg_names:
-  - '{i_var_capsule}'
-  i_arg_decl:
-  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
-  i_import:
-  - '{F_capsule_data_type}'
-  c_arg_decl:
-  - '{C_capsule_data_type} *{c_var_capsule}'
-  c_post_call:
-  - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
-  - '{c_var_capsule}->idtor = {idtor};'
-  c_temps:
-  - capsule
   owner: library
 f_none_bool:
   name: f_none_bool
@@ -16306,9 +16306,9 @@ f_out_char**_cdesc_pointer:
   f_need_wrapper: true
   mixin_names:
   - '  f_mixin_dummy_arg'
-  - '  f_mixin_char_cdesc_pointer'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_cdesc-char-fill-cvar'
+  - '  f_mixin_cdesc_char_pointer'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_char_fill_cvar'
   - '  c_mixin_local-cvar-ptr'
   - '  c_mixin_arg-call-cvar-address'
   i_arg_names:
@@ -16675,11 +16675,11 @@ f_out_native*&_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  f_mixin_out_native_cdesc_pointer'
+  - '  c_mixin_cdesc_native_fill'
+  - '  f_mixin_cdesc_out_native_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -16733,11 +16733,11 @@ f_out_native*&_cdesc_pointer:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  f_mixin_out_native_cdesc_pointer'
+  - '  c_mixin_cdesc_native_fill'
+  - '  f_mixin_cdesc_out_native_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -16838,15 +16838,15 @@ f_out_native**_cdesc_allocatable:
   f_need_wrapper: true
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_pass_cdesc'
-  - '  c_mixin_native_cdesc_fill-cdesc'
+  - '  f_mixin_cdesc_pass'
+  - '  c_mixin_cdesc_native_fill'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar-address'
-  - '  f_mixin_out_native_cdesc_allocate'
-  - '  f_mixin_use_capsule'
-  - '    f_mixin_pass_capsule'
-  - '      c_mixin_pass_capsule'
-  - '    c_mixin_native_capsule_fill'
+  - '  f_mixin_cdesc_out_native_allocate'
+  - '  f_mixin_capsule_use'
+  - '    f_mixin_capsule_pass'
+  - '      c_mixin_capsule_pass'
+  - '    c_mixin_capsule_fill_native'
   - '    f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -16915,11 +16915,11 @@ f_out_native**_cdesc_pointer:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar-address'
-  - '  c_mixin_native_cdesc_fill-cdesc'
-  - '  f_mixin_out_native_cdesc_pointer'
+  - '  c_mixin_cdesc_native_fill'
+  - '  f_mixin_cdesc_out_native_pointer'
   i_arg_names:
   - '{i_var_cdesc}'
   i_arg_decl:
@@ -17121,7 +17121,7 @@ f_out_native*_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -17344,13 +17344,13 @@ f_out_string**_cdesc_allocatable:
   - capsule_dtor
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  f_mixin_out_array_cdesc_allocatable'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  f_mixin_cdesc_out_char_array_allocatable'
   - '  f_mixin_helper_array_string_allocatable'
   - '  c_mixin_arg-call-cvar-address'
-  - '  c_mixin_native_capsule_fill'
+  - '  c_mixin_capsule_fill_native'
   - '  f_mixin_capsule_dtor'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -17422,7 +17422,7 @@ f_out_string**_cdesc_copy:
   f_need_wrapper: true
   mixin_names:
   - '  f_mixin_str_array'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar-address'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -17752,7 +17752,7 @@ f_out_vector<native>&_cdesc:
   - copy_array
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  f_mixin_out_vector<native>_copy'
   - '  c_mixin_out_vector<native>_cdesc'
   - '    c_mixin_destructor_new-vector'
@@ -17824,7 +17824,7 @@ f_out_vector<native>&_cdesc_allocatable:
   - copy_array
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_out_vector<native>_cdesc'
   - '    c_mixin_destructor_new-vector'
   - '    c_mixin_vector_cdesc_fill-cdesc'
@@ -17893,7 +17893,7 @@ f_out_vector<native>*_cdesc:
   - copy_array
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  f_mixin_out_vector<native>_copy'
   - '  c_mixin_out_vector<native>_cdesc'
   - '    c_mixin_destructor_new-vector'
@@ -17965,7 +17965,7 @@ f_out_vector<native>*_cdesc_allocatable:
   - copy_array
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_out_vector<native>_cdesc'
   - '    c_mixin_destructor_new-vector'
   - '    c_mixin_vector_cdesc_fill-cdesc'
@@ -18035,7 +18035,7 @@ f_out_vector<string>&_cdesc:
   f_need_wrapper: true
   mixin_names:
   - '  f_mixin_str_array'
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -18096,10 +18096,10 @@ f_out_vector<string>&_cdesc_allocatable:
   - capsule_dtor
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
-  - '  f_mixin_pass_capsule'
-  - '    c_mixin_pass_capsule'
-  - '  f_mixin_out_array_cdesc_allocatable'
+  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_capsule_pass'
+  - '    c_mixin_capsule_pass'
+  - '  f_mixin_cdesc_out_char_array_allocatable'
   - '  f_mixin_helper_vector_string_allocatable'
   - '  f_mixin_capsule_dtor'
   - '  c_mixin_arg-call-cxx-deref'
@@ -18126,7 +18126,7 @@ f_out_vector<string>&_cdesc_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_native_capsule_fill
+  - // XXX - Use code from c_mixin_capsule_fill_native
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_temps:
@@ -18295,7 +18295,7 @@ f_out_void*_cdesc:
   - array_context
   f_need_wrapper: true
   mixin_names:
-  - '  f_mixin_pass_cdesc'
+  - '  f_mixin_cdesc_pass'
   - '  c_mixin_arg-call-cvar'
   i_arg_names:
   - '{i_var_cdesc}'
@@ -19511,8 +19511,22 @@ root
       arg-call-cxx-deref -- c_mixin_arg-call-cxx-deref
       as-intent-out -- c_mixin_as-intent-out
       c-str -- c_mixin_c-str
+      capsule
+        fill
+          cvar -- c_mixin_capsule_fill_cvar
+          native -- c_mixin_capsule_fill_native
+        pass -- c_mixin_capsule_pass
       cast-argument -- c_mixin_cast-argument
-      cdesc-char-fill-cvar -- c_mixin_cdesc-char-fill-cvar
+      cdesc
+        char
+          fill
+            cvar -- c_mixin_cdesc_char_fill_cvar
+        function
+          string -- c_mixin_cdesc_function_string
+        inout
+          vector -- c_mixin_cdesc_inout_vector
+        native
+          fill -- c_mixin_cdesc_native_fill
       cfi-unpack-base-addr -- c_mixin_cfi-unpack-base-addr
       cfi-unpack-base-addr-cxx -- c_mixin_cfi-unpack-base-addr-cxx
       cfi-unpack-len -- c_mixin_cfi-unpack-len
@@ -19528,7 +19542,6 @@ root
         cfi
           pointer -- c_mixin_character_cfi_pointer
       character-deferred-length -- c_mixin_character-deferred-length
-      cvar-capsule-fill -- c_mixin_cvar-capsule-fill
       declare-arg -- c_mixin_declare-arg
       declare-arg-char -- c_mixin_declare-arg-char
       declare-fortran-result -- c_mixin_declare-fortran-result
@@ -19542,8 +19555,6 @@ root
       function
         shadow
           capptr -- c_mixin_function_shadow_capptr
-        string
-          cdesc -- c_mixin_function_string_cdesc
         vector
           malloc -- c_mixin_function_vector_malloc
       function-assign-to-local -- c_mixin_function-assign-to-local
@@ -19557,8 +19568,6 @@ root
         character
           buf -- c_mixin_in_character_buf
       inout
-        vector
-          cdesc -- c_mixin_inout_vector_cdesc
         vector<native>
           cdesc -- c_mixin_inout_vector<native>_cdesc
       local-cvar-ptr -- c_mixin_local-cvar-ptr
@@ -19568,10 +19577,6 @@ root
       local-string-init-trim -- c_mixin_local-string-init-trim
       make-shared -- c_mixin_make-shared
       native
-        capsule
-          fill -- c_mixin_native_capsule_fill
-        cdesc
-          fill-cdesc -- c_mixin_native_cdesc_fill-cdesc
         cfi
           allocatable -- c_mixin_native_cfi_allocatable
           pointer -- c_mixin_native_cfi_pointer
@@ -19583,8 +19588,6 @@ root
             malloc -- c_mixin_out_vector_buf_malloc
         vector<native>
           cdesc -- c_mixin_out_vector<native>_cdesc
-      pass
-        capsule -- c_mixin_pass_capsule
       shadow -- c_mixin_shadow
       string-char-copy-to-arg -- c_mixin_string-char-copy-to-arg
       string-copy-out -- c_mixin_string-copy-out
@@ -19909,16 +19912,34 @@ root
         cdesc -- f_inout_void*_cdesc
       void** -- f_inout_void**
     mixin
-      arg
-        capsule -- f_mixin_arg_capsule
       arg-character-array-cfi -- f_mixin_arg-character-array-cfi
       as-intent-out -- f_mixin_as-intent-out
       capsule
+        arg -- f_mixin_capsule_arg
         dtor -- f_mixin_capsule_dtor
-      char
-        cdesc
-          allocate -- f_mixin_char_cdesc_allocate
-          pointer -- f_mixin_char_cdesc_pointer
+        function
+          shadow -- f_mixin_capsule_function_shadow
+        pass -- f_mixin_capsule_pass
+        use -- f_mixin_capsule_use
+      cdesc
+        char
+          allocate -- f_mixin_cdesc_char_allocate
+          pointer -- f_mixin_cdesc_char_pointer
+        getter -- f_mixin_cdesc_getter
+        inout
+          array -- f_mixin_cdesc_inout_array
+        native
+          allocate -- f_mixin_cdesc_native_allocate
+          pointer -- f_mixin_cdesc_native_pointer
+          raw -- f_mixin_cdesc_native_raw
+        out
+          char
+            array
+              allocatable -- f_mixin_cdesc_out_char_array_allocatable
+          native
+            allocate -- f_mixin_cdesc_out_native_allocate
+            pointer -- f_mixin_cdesc_out_native_pointer
+        pass -- f_mixin_cdesc_pass
       character-deferred-length -- f_mixin_character-deferred-length
       declare-arg-char -- f_mixin_declare-arg-char
       declare-as-cptr -- f_mixin_declare-as-cptr
@@ -19931,8 +19952,6 @@ root
         c-ptr -- f_mixin_function_c-ptr
         char -- f_mixin_function_char
         ptr -- f_mixin_function_ptr
-        shadow
-          capsule -- f_mixin_function_shadow_capsule
         string
           cfi
             allocatable -- f_mixin_function_string_cfi_allocatable
@@ -19941,8 +19960,6 @@ root
       function-as-cptr -- f_mixin_function-as-cptr
       function-interface-as-cptr -- f_mixin_function-interface-as-cptr
       function-to-subroutine -- f_mixin_function-to-subroutine
-      getter
-        cdesc -- f_mixin_getter_cdesc
       helper
         array
           string
@@ -19959,35 +19976,18 @@ root
             buf -- f_mixin_in_string_array_buf
         vector
           buf -- f_mixin_in_vector_buf
-      inout
-        array
-          cdesc -- f_mixin_inout_array_cdesc
       interface-as-cptr -- f_mixin_interface-as-cptr
       interface-as-cptr-array -- f_mixin_interface-as-cptr-array
       interface-as-cptr-value -- f_mixin_interface-as-cptr-value
       logical-in -- f_mixin_logical-in
       logical-local-var -- f_mixin_logical-local-var
       logical-out -- f_mixin_logical-out
-      native
-        cdesc
-          allocate -- f_mixin_native_cdesc_allocate
-          pointer -- f_mixin_native_cdesc_pointer
-          raw -- f_mixin_native_cdesc_raw
       out
-        array
-          cdesc
-            allocatable -- f_mixin_out_array_cdesc_allocatable
-        native
-          cdesc
-            allocate -- f_mixin_out_native_cdesc_allocate
-            pointer -- f_mixin_out_native_cdesc_pointer
         vector
           buf -- f_mixin_out_vector_buf
         vector<native>
           copy -- f_mixin_out_vector<native>_copy
       pass
-        capsule -- f_mixin_pass_capsule
-        cdesc -- f_mixin_pass_cdesc
         character
           buf -- f_mixin_pass_character_buf
           cfi -- f_mixin_pass_character_cfi
@@ -19998,8 +19998,6 @@ root
       str
         array -- f_mixin_str_array
       unknown -- f_mixin_unknown
-      use
-        capsule -- f_mixin_use_capsule
     none
       bool -- f_none_bool
       bool* -- f_none_bool*

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -552,7 +552,7 @@ void VEC_vector_string_fill_allocatable_bufferify(
         SHT_arg_cdesc->elem_len = VEC_ShroudVectorStringOutSize(*SHC_arg_cxx);
     }
     SHT_arg_cdesc->size      = SHC_arg_cxx->size();
-    // XXX - Use code from c_mixin_native_capsule_fill
+    // XXX - Use code from c_mixin_capsule_fill_native
     SHT_arg_capsule->addr  = SHC_arg_cxx;
     SHT_arg_capsule->idtor = 0;
     // splicer end function.vector_string_fill_allocatable_bufferify
@@ -593,7 +593,7 @@ void VEC_vector_string_fill_allocatable_len_bufferify(
         SHT_arg_cdesc->elem_len = VEC_ShroudVectorStringOutSize(*SHC_arg_cxx);
     }
     SHT_arg_cdesc->size      = SHC_arg_cxx->size();
-    // XXX - Use code from c_mixin_native_capsule_fill
+    // XXX - Use code from c_mixin_capsule_fill_native
     SHT_arg_capsule->addr  = SHC_arg_cxx;
     SHT_arg_capsule->idtor = 0;
     // splicer end function.vector_string_fill_allocatable_len_bufferify

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -595,7 +595,7 @@
         "name":"#### capsule mixin #########################################"
     },
     {
-        "name": "c_mixin_pass_capsule",
+        "name": "c_mixin_capsule_pass",
         "comments": [
             "Pass capsule as argument to C wrapper."
         ],
@@ -620,7 +620,7 @@
         ]
     },
     {
-        "name": "f_mixin_pass_capsule",
+        "name": "f_mixin_capsule_pass",
         "comments": [
             "Create a local Fortran capsule." 
         ],
@@ -629,7 +629,7 @@
             "after copying the values into Fortran memory."
         ],
         "mixin": [
-            "c_mixin_pass_capsule"
+            "c_mixin_capsule_pass"
         ],
         "f_helper": [
             "array_context"
@@ -646,7 +646,7 @@
         "f_need_wrapper": true
     },
     {
-        "name": "f_mixin_arg_capsule",
+        "name": "f_mixin_capsule_arg",
         "comments": [
             "Add a capsule argument to the Fortran wrapper.",
             "Pass the capsule as argument to C wrapper."
@@ -658,7 +658,7 @@
             "The user is responsible to release the memory in the capsule."
         ],
         "mixin": [
-            "c_mixin_pass_capsule"
+            "c_mixin_capsule_pass"
         ],
         "f_helper": [
             "array_context",
@@ -694,7 +694,7 @@
         ]
     },
     {
-        "name": "c_mixin_cvar-capsule-fill",
+        "name": "c_mixin_capsule_fill_cvar",
         "comments": [
             "Assign to capsule in C wrapper."
         ],
@@ -704,7 +704,7 @@
         ]
     },
     {
-        "name": "c_mixin_native_capsule_fill",
+        "name": "c_mixin_capsule_fill_native",
         "comments": [
             "Assign to local capsule variable in C wrapper."
         ],
@@ -714,7 +714,7 @@
         ]
     },
     {
-        "name": "f_mixin_function_shadow_capsule",
+        "name": "f_mixin_capsule_function_shadow",
         "comments": [
             "Pass function result as a capsule argument from Fortran to C."
         ],
@@ -743,10 +743,10 @@
         }
     },
     {
-        "name": "f_mixin_use_capsule",
+        "name": "f_mixin_capsule_use",
         "mixin": [
-            "f_mixin_pass_capsule",
-            "c_mixin_native_capsule_fill",
+            "f_mixin_capsule_pass",
+            "c_mixin_capsule_fill_native",
             "f_mixin_capsule_dtor"
         ]
     },
@@ -754,7 +754,7 @@
         "name":"#### cdesc mixin ###########################################"
     },
     {
-        "name": "f_mixin_pass_cdesc",
+        "name": "f_mixin_cdesc_pass",
         "comments": [
             "Pass cdesc as argument to C wrapper."
         ],
@@ -795,7 +795,7 @@
         ]
     },
     {
-        "name": "f_mixin_inout_array_cdesc",
+        "name": "f_mixin_cdesc_inout_array",
         "comments": [
             "Declare local Fortran array_type argument."
         ],
@@ -823,7 +823,7 @@
         ]
     },
     {
-        "name": "c_mixin_native_cdesc_fill-cdesc",
+        "name": "c_mixin_cdesc_native_fill",
         "comments": [
             "Fill cdesc from native in the C wrapper."
         ],
@@ -836,7 +836,7 @@
         ]
     },
     {
-        "name": "c_mixin_cdesc-char-fill-cvar",
+        "name": "c_mixin_cdesc_char_fill_cvar",
         "comments": [
             "Fill cdesc from char * in the C wrapper."
         ],
@@ -852,7 +852,7 @@
         ]
     },
     {
-        "name": "c_mixin_function_string_cdesc",
+        "name": "c_mixin_cdesc_function_string",
         "comments": [
             "Fill cdesc from std::string using helper string_to_cdesc",
             "in the C wrapper."
@@ -865,7 +865,7 @@
         ]
     },
     {
-        "name": "f_mixin_native_cdesc_allocate",
+        "name": "f_mixin_cdesc_native_allocate",
         "comments": [
             "Allocate Fortran native array, then fill from cdesc",
             "using helper copy_array."
@@ -894,7 +894,7 @@
         ]
     },
     {
-        "name": "f_mixin_out_native_cdesc_allocate",
+        "name": "f_mixin_cdesc_out_native_allocate",
         "comments": [
             "Allocate Fortran native array for argument",
             "then fill from cdesc using helper copy_array."
@@ -922,7 +922,7 @@
         }
     },
     {
-        "name": "f_mixin_native_cdesc_pointer",
+        "name": "f_mixin_cdesc_native_pointer",
         "comments": [
             "Set Fortran pointer to native array."
         ],
@@ -942,7 +942,7 @@
         ]
     },
     {
-        "name": "f_mixin_native_cdesc_raw",
+        "name": "f_mixin_cdesc_native_raw",
         "comments": [
             "Set Fortran pointer to pointers to arrays."
         ],
@@ -963,7 +963,7 @@
         ]
     },
     {
-        "name": "f_mixin_out_native_cdesc_pointer",
+        "name": "f_mixin_cdesc_out_native_pointer",
         "comments": [
             "Set Fortran pointer to native array."
         ],
@@ -986,7 +986,7 @@
         ]
     },
     {
-        "name": "f_mixin_char_cdesc_allocate",
+        "name": "f_mixin_cdesc_char_allocate",
         "comments": [
             "Allocate Fortran CHARACTER scalar, then fill from cdesc",
             "using helper copy_string."
@@ -1006,7 +1006,7 @@
         ]
     },
     {
-        "name": "f_mixin_char_cdesc_pointer",
+        "name": "f_mixin_cdesc_char_pointer",
         "comments": [
             "Assign Fortran pointer from cdesc using helper pointer_string."
         ],
@@ -1026,7 +1026,7 @@
         ]
     },
     {
-        "name": "f_mixin_getter_cdesc",
+        "name": "f_mixin_cdesc_getter",
         "comments": [
             "Save pointer struct members in a cdesc",
             "along with shape information."
@@ -1238,7 +1238,7 @@
         ]
     },
     {
-        "name": "c_mixin_inout_vector_cdesc",
+        "name": "c_mixin_cdesc_inout_vector",
         "comments": [
             "Accept array_type in C wrapper."
         ],
@@ -1436,11 +1436,11 @@
             "f_out_native*&_cdesc_pointer"
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_out_native**",
             "c_mixin_arg-call-cvar",
-            "c_mixin_native_cdesc_fill-cdesc",
-            "f_mixin_out_native_cdesc_pointer"
+            "c_mixin_cdesc_native_fill",
+            "f_mixin_cdesc_out_native_pointer"
         ]
     },
     {
@@ -1452,12 +1452,12 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "f_mixin_pass_cdesc",
-            "c_mixin_native_cdesc_fill-cdesc",
+            "f_mixin_cdesc_pass",
+            "c_mixin_cdesc_native_fill",
             "c_mixin_out_native**",
             "c_mixin_arg-call-cvar-address",
-            "f_mixin_out_native_cdesc_allocate",
-            "f_mixin_use_capsule"
+            "f_mixin_cdesc_out_native_allocate",
+            "f_mixin_capsule_use"
         ]
     },
     {
@@ -1468,11 +1468,11 @@
             "with a Fortran pointer."
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_out_native**",
             "c_mixin_arg-call-cvar-address",
-            "c_mixin_native_cdesc_fill-cdesc",
-            "f_mixin_out_native_cdesc_pointer"
+            "c_mixin_cdesc_native_fill",
+            "f_mixin_cdesc_out_native_pointer"
         ]
     },
     {
@@ -1491,7 +1491,7 @@
             "f_inout_void*_cdesc"
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_arg-call-cvar"
         ],
         "f_arg_name": [
@@ -1579,10 +1579,10 @@
         "name": "f_function_native*_cdesc_allocatable",
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "c_mixin_native_cdesc_fill-cdesc",
-            "f_mixin_native_cdesc_allocate",
-            "f_mixin_use_capsule"
+            "f_mixin_cdesc_pass",
+            "c_mixin_cdesc_native_fill",
+            "f_mixin_cdesc_native_allocate",
+            "f_mixin_capsule_use"
         ]
     },
     {
@@ -1607,9 +1607,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "c_mixin_native_cdesc_fill-cdesc",
-            "f_mixin_native_cdesc_pointer"
+            "f_mixin_cdesc_pass",
+            "c_mixin_cdesc_native_fill",
+            "f_mixin_cdesc_native_pointer"
         ]
     },
     {
@@ -1620,11 +1620,11 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "f_mixin_arg_capsule",
-            "c_mixin_native_cdesc_fill-cdesc",
-            "c_mixin_native_capsule_fill",
-            "f_mixin_native_cdesc_pointer"
+            "f_mixin_cdesc_pass",
+            "f_mixin_capsule_arg",
+            "c_mixin_cdesc_native_fill",
+            "c_mixin_capsule_fill_native",
+            "f_mixin_cdesc_native_pointer"
         ]
     },
     {
@@ -2139,7 +2139,7 @@
         ]
     },
     {
-        "name": "f_mixin_out_array_cdesc_allocatable",
+        "name": "f_mixin_cdesc_out_char_array_allocatable",
         "comments": [
             "Allocate Fortran array from cdesc."
         ],
@@ -2490,9 +2490,9 @@
         ],
         "mixin": [
             "f_mixin_dummy_arg",
-            "f_mixin_char_cdesc_pointer",
-            "f_mixin_pass_cdesc",
-            "c_mixin_cdesc-char-fill-cvar",
+            "f_mixin_cdesc_char_pointer",
+            "f_mixin_cdesc_pass",
+            "c_mixin_cdesc_char_fill_cvar",
             "c_mixin_local-cvar-ptr",
             "c_mixin_arg-call-cvar-address"
         ]
@@ -2504,9 +2504,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "f_mixin_char_cdesc_allocate",
-            "c_mixin_cdesc-char-fill-cvar"
+            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_char_allocate",
+            "c_mixin_cdesc_char_fill_cvar"
         ]
     },
     {
@@ -2516,9 +2516,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "c_mixin_cdesc-char-fill-cvar",
-            "f_mixin_char_cdesc_pointer"
+            "f_mixin_cdesc_pass",
+            "c_mixin_cdesc_char_fill_cvar",
+            "f_mixin_cdesc_char_pointer"
         ]
     },
     {
@@ -2717,9 +2717,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "c_mixin_function_string_cdesc",
-            "f_mixin_char_cdesc_pointer"
+            "f_mixin_cdesc_pass",
+            "c_mixin_cdesc_function_string",
+            "f_mixin_cdesc_char_pointer"
         ]
     },
     {
@@ -2923,10 +2923,10 @@
             "Return a const pointer to std::string data."
         ],
         "mixin": [
-            "c_mixin_pass_capsule",
+            "c_mixin_capsule_pass",
             "c_mixin_function-assign-to-new",
             "c_mixin_c-str",
-            "c_mixin_native_capsule_fill"
+            "c_mixin_capsule_fill_native"
         ]
     },
     {
@@ -2980,11 +2980,11 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "f_mixin_pass_capsule",
-            "c_mixin_function_string_cdesc",
-            "c_mixin_native_capsule_fill",
-            "f_mixin_char_cdesc_allocate",
+            "f_mixin_cdesc_pass",
+            "f_mixin_capsule_pass",
+            "c_mixin_cdesc_function_string",
+            "c_mixin_capsule_fill_native",
+            "f_mixin_cdesc_char_allocate",
             "f_mixin_capsule_dtor"
         ]
     },
@@ -3063,12 +3063,12 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_function-assign-to-new",
             "c_mixin_destructor_new-string",
-            "c_mixin_function_string_cdesc",
-            "f_mixin_char_cdesc_allocate",
-            "f_mixin_use_capsule"
+            "c_mixin_cdesc_function_string",
+            "f_mixin_cdesc_char_allocate",
+            "f_mixin_capsule_use"
         ]
     },
     {
@@ -3083,7 +3083,7 @@
         ],
         "mixin": [
             "f_mixin_str_array",
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_arg-call-cvar-address"
         ],
         "f_helper": [
@@ -3120,12 +3120,12 @@
     {
         "name": "f_out_string**_cdesc_allocatable",
         "mixin": [
-            "f_mixin_pass_cdesc",
-            "f_mixin_pass_capsule",
-            "f_mixin_out_array_cdesc_allocatable",
+            "f_mixin_cdesc_pass",
+            "f_mixin_capsule_pass",
+            "f_mixin_cdesc_out_char_array_allocatable",
             "f_mixin_helper_array_string_allocatable",
             "c_mixin_arg-call-cvar-address",
-            "c_mixin_native_capsule_fill",
+            "c_mixin_capsule_fill_native",
             "f_mixin_capsule_dtor"
         ]
     },
@@ -3360,7 +3360,7 @@
             "c_out_vector<native>*_cdesc"
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "f_mixin_out_vector<native>_copy",
             "c_mixin_out_vector<native>_cdesc",
             "c_mixin_arg-call-cxx"
@@ -3375,7 +3375,7 @@
             "c_out_vector<native>&_cdesc"
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "f_mixin_out_vector<native>_copy",
             "c_mixin_out_vector<native>_cdesc",
             "c_mixin_arg-call-cxx-deref"
@@ -3387,8 +3387,8 @@
     {
         "name": "c_mixin_inout_vector<native>_cdesc",
         "mixin": [
-            "f_mixin_inout_array_cdesc",
-            "c_mixin_inout_vector_cdesc",
+            "f_mixin_cdesc_inout_array",
+            "c_mixin_cdesc_inout_vector",
             "c_mixin_destructor_new-vector",
             "c_mixin_vector_cdesc_fill-cdesc"
         ],
@@ -3414,7 +3414,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_destructor_new-vector",
             "c_mixin_vector_cdesc_fill-cdesc"
         ],
@@ -3558,7 +3558,7 @@
             "{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});",
             "-}}",
             "{c_var_cdesc}->size      = {c_local_cxx}->size();",
-            "// XXX - Use code from c_mixin_native_capsule_fill",
+            "// XXX - Use code from c_mixin_capsule_fill_native",
             "{c_var_capsule}->addr  = {c_local_cxx};",
             "{c_var_capsule}->idtor = {idtor};"
         ],
@@ -3716,7 +3716,7 @@
         ],
         "mixin": [
             "f_mixin_str_array",
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_arg-call-cvar"
         ],
         "f_helper": [
@@ -3742,9 +3742,9 @@
             "c_out_vector<string>&_cdesc_allocatable"
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
-            "f_mixin_pass_capsule",
-            "f_mixin_out_array_cdesc_allocatable",
+            "f_mixin_cdesc_pass",
+            "f_mixin_capsule_pass",
+            "f_mixin_cdesc_out_char_array_allocatable",
             "f_mixin_helper_vector_string_allocatable",
             "f_mixin_capsule_dtor",
             "c_mixin_arg-call-cxx-deref"
@@ -3804,7 +3804,7 @@
             "Copy into allocated array."
         ],
         "mixin": [
-            "f_mixin_pass_cdesc",
+            "f_mixin_cdesc_pass",
             "c_mixin_out_vector<native>_cdesc",
             "c_mixin_arg-call-cxx-deref"
         ],
@@ -3939,10 +3939,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_shadow_capsule",
+            "f_mixin_capsule_function_shadow",
             "c_mixin_shadow",
             "c_mixin_function-assign-to-local",
-            "c_mixin_cvar-capsule-fill"
+            "c_mixin_capsule_fill_cvar"
         ]
     },
     {
@@ -3997,7 +3997,7 @@
             "c_mixin_shadow",
             "c_mixin_as-intent-out",
             "c_mixin_function-assign-to-local",
-            "c_mixin_cvar-capsule-fill",
+            "c_mixin_capsule_fill_cvar",
             "c_mixin_function-return-cvar"
         ]
     },
@@ -4023,10 +4023,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_shadow_capsule",
+            "f_mixin_capsule_function_shadow",
             "c_mixin_shadow",
             "c_mixin_function-assign-to-new",
-            "c_mixin_cvar-capsule-fill"
+            "c_mixin_capsule_fill_cvar"
         ]
     },
     {
@@ -4045,7 +4045,7 @@
             "c_mixin_shadow",
             "c_mixin_as-intent-out",
             "c_mixin_function-assign-to-new",
-            "c_mixin_cvar-capsule-fill",
+            "c_mixin_capsule_fill_cvar",
             "c_mixin_function-return-cvar"
         ]
     },
@@ -4056,7 +4056,7 @@
         ],
         "mixin": [
             "f_mixin_as-intent-out",
-            "f_mixin_function_shadow_capsule",
+            "f_mixin_capsule_function_shadow",
             "c_mixin_shadow",
             "c_mixin_as-intent-out"
         ],
@@ -4112,7 +4112,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_shadow_capsule",
+            "f_mixin_capsule_function_shadow",
             "c_mixin_shadow",
             "c_mixin_destructor_new-shadow-shared",
             "c_mixin_make-shared"
@@ -4139,10 +4139,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_shadow_capsule",
+            "f_mixin_capsule_function_shadow",
             "c_mixin_shadow",
             "c_mixin_function-assign-to-new",
-            "c_mixin_cvar-capsule-fill"
+            "c_mixin_capsule_fill_cvar"
         ]
     },
     {
@@ -4151,10 +4151,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_shadow_capsule",
+            "f_mixin_capsule_function_shadow",
             "c_mixin_shadow",
             "c_mixin_function-assign-to-local",
-            "c_mixin_cvar-capsule-fill"
+            "c_mixin_capsule_fill_cvar"
         ]
     },
     {
@@ -4169,7 +4169,7 @@
             "c_mixin_shadow",
             "c_mixin_as-intent-out",
             "c_mixin_function-assign-to-new",
-            "c_mixin_cvar-capsule-fill",
+            "c_mixin_capsule_fill_cvar",
             "c_mixin_function-return-cvar"
         ]
     },
@@ -4182,7 +4182,7 @@
             "c_mixin_shadow",
             "c_mixin_as-intent-out",
             "c_mixin_function-assign-to-local",
-            "c_mixin_cvar-capsule-fill",
+            "c_mixin_capsule_fill_cvar",
             "c_mixin_function-return-cvar"
         ]
     },
@@ -4424,18 +4424,18 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "f_mixin_native_cdesc_pointer",
-            "f_mixin_getter_cdesc"
+            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_native_pointer",
+            "f_mixin_cdesc_getter"
         ]
     },
     {
         "name": "f_getter_struct**_cdesc_raw",
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "f_mixin_native_cdesc_raw",
-            "f_mixin_getter_cdesc"
+            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_native_raw",
+            "f_mixin_cdesc_getter"
         ]
     },
     {
@@ -4445,8 +4445,8 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_pass_cdesc",
-            "f_mixin_char_cdesc_allocate"
+            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_char_allocate"
         ],
         "c_call": [
             "{c_var_cdesc}->base_addr =\t const_cast<char *>(\t{CXX_this}->{field_name}.data());",

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -4507,6 +4507,22 @@
         ]
     },
     {
+        "name": "f_mixin_cfi_character-deferred-length",
+        "notes": [
+            "Pass a character deferred length argument down to C",
+            "This may be used with function result so do not mixin f_mixin_dummy_arg."
+        ],
+        "mixin": [
+            "f_mixin_character-deferred-length",
+            "c_mixin_dummy_arg",
+            "c_mixin_character-deferred-length",
+            "c_mixin_arg_cfi"
+        ],
+        "f_arg_call": [
+            "{f_var}"
+        ]
+    },
+    {
         "name": "c_mixin_cfi-unpack-base-addr",
         "notes": [
             "Unpack the base_addr from the CFI_desc_t variable."
@@ -4703,19 +4719,6 @@
         ]
     },
     {
-        "name": "f_mixin_function_string_cfi_allocatable",
-        "notes": [
-            "similar to f_char_scalar_allocatable."
-        ],
-        "f_need_wrapper": true,
-        "f_arg_decl": [
-            "character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ]
-    },
-    {
         "name":"##### cfi ##################################################"
     },
     {
@@ -4728,22 +4731,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "c_mixin_arg_cfi"
+            "f_mixin_cfi_character-deferred-length"
         ],
         "f_need_wrapper": true,
-        "f_arg_decl": [
-            "character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}"
-        ],
-        "c_pre_call": [],
         "c_post_call": [
             "if ({cxx_var} != {nullptr}) {{+",
             "int SH_ret = CFI_allocate({c_var_cfi}, \t(CFI_index_t *) 0, \t(CFI_index_t *) 0, \tstrlen({cxx_var}));",
@@ -4760,22 +4750,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "c_mixin_arg_cfi",
+            "f_mixin_cfi_character-deferred-length",
             "c_mixin_character_cfi_pointer"
         ],
-        "f_need_wrapper": true,
-        "f_arg_decl": [
-            "character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}"
-        ]
+        "f_need_wrapper": true
     },
     {
         "alias": [
@@ -5039,21 +5017,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "c_mixin_arg_cfi"
+            "f_mixin_cfi_character-deferred-length"
         ],
         "f_need_wrapper": true,
-        "f_arg_decl": [
-            "character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}"
-        ],
         "c_pre_call": [],
         "c_post_call": [
             "int {c_local_err};",
@@ -5092,16 +5058,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_string_cfi_allocatable",
-            "c_mixin_header_string",
-            "c_mixin_arg_cfi"
+            "f_mixin_cfi_character-deferred-length",
+            "c_mixin_header_string"
         ],
-        "i_arg_decl": [
-            "character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
+        "f_need_wrapper": true,
         "c_post_call": [
             "int SH_ret = CFI_allocate({c_var_cfi}, \t(CFI_index_t *) 0, \t(CFI_index_t *) 0, \t{cxx_var}{cxx_member}length());",
             "if (SH_ret == CFI_SUCCESS) {{+",
@@ -5116,16 +5076,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_function_string_cfi_allocatable",
-            "c_mixin_arg_cfi"
+            "f_mixin_cfi_character-deferred-length"
         ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "character(len=:){i_intent_attr}{f_deref_attr} :: {i_var}"
-        ],
-        "c_pre_call": [],
+        "f_need_wrapper": true,
         "c_post_call": [
             "int SH_ret = CFI_allocate({c_var_cfi}, \t(CFI_index_t *) 0, \t(CFI_index_t *) 0, \t{cxx_var}.length());",
             "if (SH_ret == CFI_SUCCESS) {{+",

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -4482,7 +4482,7 @@
         "name":"##### cfi mixin ############################################"
     },
     {
-        "name": "f_mixin_pass_character_cfi",
+        "name": "f_mixin_cfi_pass_character",
         "comments": [
             "Pass argument to C wrapper"
         ],
@@ -4492,7 +4492,7 @@
         ]
     },
     {
-        "name": "c_mixin_arg_cfi",
+        "name": "c_mixin_cfi_arg",
         "comments": [
             "Make the C wrapper argument a CFI_desc_t."
         ],
@@ -4516,7 +4516,7 @@
             "f_mixin_character-deferred-length",
             "c_mixin_dummy_arg",
             "c_mixin_character-deferred-length",
-            "c_mixin_arg_cfi"
+            "c_mixin_cfi_arg"
         ],
         "f_arg_call": [
             "{f_var}"
@@ -4569,7 +4569,7 @@
         ]
     },
     {
-        "name": "c_mixin_char-copy-to-arg-cfi",
+        "name": "c_mixin_cfi_copy-to-arg",
         "comments": [
             "Copy cxx variable into c variable."
         ],
@@ -4586,12 +4586,12 @@
         ]
     },
     {
-        "name": "c_mixin_arg_character_cfi",
+        "name": "c_mixin_cfi_arg_character",
         "comments": [
             "Character argument passed as CFI_desc_t."
         ],
         "mixin": [
-            "c_mixin_arg_cfi"
+            "c_mixin_cfi_arg"
         ],
         "i_arg_decl": [
             "character(len=*){i_intent_attr} :: {i_var}"
@@ -4601,7 +4601,7 @@
         ]
     },
     {
-        "name": "f_mixin_arg-character-array-cfi",
+        "name": "f_mixin_cfi_arg-character-array",
         "comments": [
             "Character array argument passed as CFI_desc_t."
         ],
@@ -4609,7 +4609,7 @@
             "XXX - does the interface need kind=C_CHAR and/or len=:"
         ],
         "mixin": [
-            "c_mixin_arg_cfi"
+            "c_mixin_cfi_arg"
         ],
         "f_arg_name": [
             "{f_var}"
@@ -4625,12 +4625,12 @@
         ]
     },
     {
-        "name": "c_mixin_arg_native_cfi",
+        "name": "c_mixin_cfi_arg_native",
         "comments": [
             "Native argument which use CFI_desc_t."
         ],
         "mixin": [
-            "c_mixin_arg_cfi"
+            "c_mixin_cfi_arg"
         ],
         "i_arg_decl": [
             "{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}"
@@ -4645,7 +4645,7 @@
         ]
     },
     {
-        "name": "c_mixin_native_cfi_allocatable",
+        "name": "c_mixin_cfi_native_allocatable",
         "comments": [
             "Allocate copy of C pointer (requires +dimension)."
         ],
@@ -4663,7 +4663,7 @@
         ]
     },
     {
-        "name": "c_mixin_native_cfi_pointer",
+        "name": "c_mixin_cfi_native_pointer",
         "comments": [
             "Convert C pointer to Fortran pointer."
         ],
@@ -4690,7 +4690,7 @@
         ]
     },
     {
-        "name": "c_mixin_character_cfi_pointer",
+        "name": "c_mixin_cfi_character_pointer",
         "comments": [
             "Convert C pointer to deferred-length CHARACTER Fortran scalar pointer."
         ],
@@ -4751,7 +4751,7 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_cfi_character-deferred-length",
-            "c_mixin_character_cfi_pointer"
+            "c_mixin_cfi_character_pointer"
         ],
         "f_need_wrapper": true
     },
@@ -4762,7 +4762,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_native_cfi",
+            "c_mixin_cfi_arg_native",
             "c_mixin_cfi-unpack-base-addr-cxx",
             "c_mixin_arg-call-cxx"
         ]
@@ -4771,7 +4771,7 @@
         "name": "f_in_char*_cfi",
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_char-alloc",
@@ -4787,7 +4787,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_char-malloc",
@@ -4800,7 +4800,7 @@
         "name": "f_inout_char*_cfi",
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_char-blank-fill",
@@ -4816,8 +4816,8 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_declare-fortran-result",
-            "f_mixin_pass_character_cfi",
-            "c_mixin_arg_character_cfi",
+            "f_mixin_cfi_pass_character",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_arg-call-cxx",
@@ -4835,8 +4835,8 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_function-as-character-arg",
-            "f_mixin_pass_character_cfi",
-            "c_mixin_arg_character_cfi",
+            "f_mixin_cfi_pass_character",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_arg-call-cxx",
@@ -4847,7 +4847,7 @@
     {
         "name": "f_in_char**_cfi",
         "mixin": [
-            "f_mixin_arg-character-array-cfi",
+            "f_mixin_cfi_arg-character-array",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len-size",
             "c_mixin_char-array-alloc",
@@ -4864,10 +4864,10 @@
             "f_mixin_character-deferred-length",
             "c_mixin_dummy_arg",
             "c_mixin_character-deferred-length",
-            "c_mixin_arg_cfi",
+            "c_mixin_cfi_arg",
             "c_mixin_local-cvar-ptr",
             "c_mixin_arg-call-cvar-address",
-            "c_mixin_character_cfi_pointer"
+            "c_mixin_cfi_character_pointer"
         ]
     },
     {
@@ -4877,7 +4877,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_local-string-init-trim",
@@ -4893,7 +4893,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_local-string-init-trim",
@@ -4907,7 +4907,7 @@
         "mixin": [
             "f_mixin_declare-fortran-arg",
             "c_mixin_local-string",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_arg-call-cxx-address",
@@ -4924,7 +4924,7 @@
         "mixin": [
             "f_mixin_declare-fortran-arg",
             "c_mixin_local-string",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_arg-call-cxx",
@@ -4937,7 +4937,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_local-string-init-trim",
@@ -4954,7 +4954,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_character_cfi",
+            "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
             "c_mixin_cfi-unpack-len",
             "c_mixin_local-string-init-trim",
@@ -4971,11 +4971,11 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_declare-fortran-result",
-            "f_mixin_pass_character_cfi",
-            "c_mixin_arg_character_cfi",
+            "f_mixin_cfi_pass_character",
+            "c_mixin_cfi_arg_character",
             "c_mixin_arg-call-cxx",
             "c_mixin_function-assign-to-local",
-            "c_mixin_char-copy-to-arg-cfi"
+            "c_mixin_cfi_copy-to-arg"
         ]
     },
     {
@@ -4992,11 +4992,11 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_function-as-character-arg",
-            "f_mixin_pass_character_cfi",
-            "c_mixin_arg_character_cfi",
+            "f_mixin_cfi_pass_character",
+            "c_mixin_cfi_arg_character",
             "c_mixin_arg-call-cxx",
             "c_mixin_function-assign-to-local",
-            "c_mixin_char-copy-to-arg-cfi"
+            "c_mixin_cfi_copy-to-arg"
         ]
     },
     {
@@ -5094,7 +5094,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_cfi",
+            "c_mixin_cfi_arg",
             "c_mixin_out_string**",
             "c_mixin_arg-call-cxx-address"
         ],
@@ -5112,7 +5112,7 @@
         "name": "f_out_string**_cfi_copy",
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_cfi",
+            "c_mixin_cfi_arg",
             "c_mixin_out_string**",
             "c_mixin_arg-call-cxx-address"
         ],
@@ -5133,10 +5133,10 @@
         "name": "f_out_native**_cfi_allocatable",
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_native_cfi",
+            "c_mixin_cfi_arg_native",
             "c_mixin_local-cxx-ptr",
             "c_mixin_arg-call-cxx-address",
-            "c_mixin_native_cfi_allocatable"
+            "c_mixin_cfi_native_allocatable"
         ],
         "i_arg_decl": [
             "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
@@ -5149,10 +5149,10 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "c_mixin_arg_native_cfi",
+            "c_mixin_cfi_arg_native",
             "c_mixin_local-cxx-ptr",
             "c_mixin_arg-call-cxx-address",
-            "c_mixin_native_cfi_pointer"
+            "c_mixin_cfi_native_pointer"
         ],
         "i_arg_decl": [
             "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
@@ -5167,10 +5167,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "c_mixin_arg_native_cfi",
+            "c_mixin_cfi_arg_native",
             "c_mixin_arg-call-cxx",
             "c_mixin_function-assign-to-local",
-            "c_mixin_native_cfi_allocatable"
+            "c_mixin_cfi_native_allocatable"
         ],
         "f_module": {
             "{f_module_name}": [
@@ -5196,10 +5196,10 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "c_mixin_arg_native_cfi",
+            "c_mixin_cfi_arg_native",
             "c_mixin_arg-call-cxx",
             "c_mixin_function-assign-to-local",
-            "c_mixin_native_cfi_pointer"
+            "c_mixin_cfi_native_pointer"
         ],
         "f_module": {
             "{f_module_name}": [

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -407,20 +407,6 @@
         "c_return_type": "void"
     },
     {
-        "name": "f_mixin_declare-fortran-result",
-        "notes": [
-            "Fortran function result."
-        ],
-        "f_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ]
-        },
-        "f_arg_decl": [
-            "{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_dimension}"
-        ]
-    },
-    {
         "name": "c_mixin_declare-fortran-result",
         "notes": [
             "Fortran function result.",
@@ -1328,7 +1314,7 @@
         ],
         "mixin": [
             "f_mixin_function",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "c_mixin_declare-fortran-result"
         ]
     },
@@ -1339,7 +1325,7 @@
         ],
         "mixin": [
             "f_mixin_function",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "c_mixin_declare-fortran-result"
         ],
         "c_return_type": "{c_type}",
@@ -1768,7 +1754,7 @@
         ],
         "mixin": [
             "f_mixin_function",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "c_mixin_declare-fortran-result"
         ],
         "f_need_wrapper": true
@@ -1804,7 +1790,7 @@
             "XXX - f entries are the same as the i entries, share?"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-result"
+            "f_mixin_declare-local-variable"
         ],
         "i_module": {
             "iso_c_binding": [
@@ -1936,7 +1922,7 @@
         ],
         "mixin": [
             "f_mixin_function",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "c_mixin_declare-fortran-result"
         ],
         "c_post_call": [
@@ -2437,7 +2423,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "f_mixin_pass_character_buf",
             "c_mixin_in_character_buf",
             "c_mixin_arg-call-cvar",
@@ -3028,7 +3014,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "f_mixin_pass_character_buf",
             "c_mixin_in_character_buf",
             "c_mixin_arg-call-cvar",
@@ -3050,7 +3036,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "f_mixin_pass_character_buf",
             "c_mixin_in_character_buf",
             "c_mixin_string-char-copy-to-arg",
@@ -4279,7 +4265,7 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_declare-interface-arg",
-            "f_mixin_declare-fortran-result"
+            "f_mixin_declare-local-variable"
         ],
         "f_arg_call": [
             "{f_var}"
@@ -4365,7 +4351,7 @@
     {
         "name": "f_getter_bool",
         "mixin": [
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "c_mixin_declare-fortran-result"
         ],
         "f_arg_call": [],
@@ -4397,7 +4383,7 @@
             "c_getter_native*"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "c_mixin_declare-fortran-result"
         ],
         "f_arg_call": [],
@@ -4841,7 +4827,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "f_mixin_cfi_pass_character",
             "c_mixin_cfi_arg_character",
             "c_mixin_cfi-unpack-base-addr",
@@ -4996,7 +4982,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
-            "f_mixin_declare-fortran-result",
+            "f_mixin_declare-local-variable",
             "f_mixin_cfi_pass_character",
             "c_mixin_cfi_arg_character",
             "c_mixin_arg-call-cxx",

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -94,6 +94,32 @@
         ]
     },
     {
+        "name": "f_mixin_declare-local-variable",
+        "comments": [
+            "Declare a Fortran variable."
+        ],
+        "notes": [
+            "Used with function results."
+        ],
+        "f_module": {
+            "{f_module_name}": [
+                "{f_kind}"
+            ]
+        },
+        "f_arg_decl": [
+            "{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}"
+        ]
+    },
+    {
+        "name": "f_mixin_arg-call-fvar",
+        "comments": [
+            "Pass Fortran variable to C wrapper."
+        ],
+        "f_arg_call": [
+            "{f_var}"
+        ]
+    },
+    {
         "sphinx-start-after": "f_mixin_declare-fortran-arg",
         "name": "f_mixin_declare-fortran-arg",
         "notes": [
@@ -4633,7 +4659,7 @@
             "c_mixin_cfi_arg"
         ],
         "i_arg_decl": [
-            "{f_type}{i_intent_attr} :: {i_var}{f_assumed_shape}"
+            "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
         ],
         "i_module": {
             "iso_c_binding": [
@@ -5137,9 +5163,6 @@
             "c_mixin_local-cxx-ptr",
             "c_mixin_arg-call-cxx-address",
             "c_mixin_cfi_native_allocatable"
-        ],
-        "i_arg_decl": [
-            "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
         ]
     },
     {
@@ -5153,9 +5176,6 @@
             "c_mixin_local-cxx-ptr",
             "c_mixin_arg-call-cxx-address",
             "c_mixin_cfi_native_pointer"
-        ],
-        "i_arg_decl": [
-            "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
         ]
     },
     {
@@ -5167,24 +5187,12 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-local-variable",
+            "f_mixin_arg-call-fvar",
             "c_mixin_cfi_arg_native",
             "c_mixin_arg-call-cxx",
             "c_mixin_function-assign-to-local",
             "c_mixin_cfi_native_allocatable"
-        ],
-        "f_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ]
-        },
-        "f_arg_decl": [
-            "{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ],
-        "i_arg_decl": [
-            "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
         ]
     },
     {
@@ -5196,27 +5204,15 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-local-variable",
+            "f_mixin_arg-call-fvar",
             "c_mixin_cfi_arg_native",
             "c_mixin_arg-call-cxx",
             "c_mixin_function-assign-to-local",
             "c_mixin_cfi_native_pointer"
         ],
-        "f_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ]
-        },
-        "f_arg_decl": [
-            "{f_type}{f_intent_attr}{f_deref_attr} :: {f_var}{f_assumed_shape}"
-        ],
         "f_pre_call": [
             "nullify({f_var})"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ],
-        "i_arg_decl": [
-            "{i_type}{i_intent_attr}{f_deref_attr} :: {i_var}{f_assumed_shape}"
         ]
     },
     {


### PR DESCRIPTION
Rename some mixin groups so that `cdesc`, `capsule`, and `cfi` groups will sort together. Ideally it would make it easier to find related mixin groups.