### PR TITLE
Update PyYAML dependency for Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ info:
 
 ########################################################################
 # For development:
+# module load python/2.7.18
+# module load python/3.10.8
+# module load python/3.12.2
+
 # make virtualenv
 # make develop
 # module load gcc/6.1.0   or newer

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # What does your project relate to?
@@ -100,7 +102,10 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['PyYAML>=4.2b1, <=5.4.1'],  # Upper limit for Python2
+    install_requires=[
+        "PyYAML>=4.2b1, <=5.4.1; python_version<'3.0'", # Restrict PyYAML for Python 2.7
+        "PyYAML>=6.0; python_version>='3.0'",  # Use newer versions for Python 3
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/shroud/error.py
+++ b/shroud/error.py
@@ -9,6 +9,8 @@
 Keep track of the current state of the application so that
 errors can be reported with a context.
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 from .declstr import gen_decl
 

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -603,7 +603,7 @@ def main_with_args(args):
     try:
         statements.update_fc_statements_for_language(
             newlibrary.language, user_statements.get("fc", {}))
-        whelpers.add_all_helpers(newlibrary)
+        whelpers.add_all_helpers(newlibrary, statements)
         wrap = newlibrary.wrap
 
         metaattrs.process_metaattrs(newlibrary, "share")

--- a/shroud/metaattrs.py
+++ b/shroud/metaattrs.py
@@ -185,7 +185,7 @@ class FillMeta(object):
                     # This causes Fortran to dereference the C_PTR
                     # Otherwise a void * argument becomes void **
                     if meta["assumedtype"]:
-                        # assumed-type interoperates with a C argument declared as “void *”
+                        # assumed-type interoperates with a C argument declared as "void *"
                         pass
                     elif len(arg.declarator.pointer) == 1:
                         meta["value"] = True  # void *

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -6,6 +6,9 @@
 
 """
 """
+from __future__ import print_function
+from __future__ import absolute_import
+
 from . import error
 from . import whelpers
 from .util import wformat
@@ -29,7 +32,9 @@ except ImportError:
     from pkg_resources import resource_filename
     def read_json_resource(name):
         fp = open(resource_filename('shroud', name), 'rb')
-        stmts = json._load(fp)
+        #stmts = json._load(fp)
+        # Use pyYAML to load json to avoid unicode issues.
+        stmts = yaml.safe_load(fp)
         return stmts
     def read_yaml_resource(name):
         fp = open(resource_filename('shroud', name), 'rb')

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -24,6 +24,11 @@ except AttributeError:
     Sequence = collections.Sequence
 OrderedDict = collections.OrderedDict
 
+try:
+    from collections.abc import Mapping  # For Python 3.10+
+except ImportError:
+    from collections import Mapping  # For Python 3.9 and earlier
+
 fmt = string.Formatter()
 
 # See AstNode.eval_template for updating AST node fmtdict.
@@ -102,7 +107,7 @@ def un_camel(name):
 # http://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
 def update(d, u):
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, Mapping):
             r = update(d.get(k, {}), v)
             d[k] = r
         else:

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -49,8 +49,10 @@ the conversion has failed.
 #
 # This also applies to derived types which are bind(C).
 
+from __future__ import print_function
+from __future__ import absolute_import
 
-from . import statements
+#from . import statements  # This is recursive
 from . import typemap
 from . import util
 
@@ -69,7 +71,7 @@ literalinclude = False
 PYHelpers = {}
 
 
-def add_all_helpers(library):
+def add_all_helpers(library, statements):
     """Create helper functions.
     Create helpers for all types.
     """


### PR DESCRIPTION
The current limit on the PyYAML version does not work with newer versions of Python. setup.py provides syntax to specify dependencies based on python_version.

Also make a fix for Python 3.10 for collections.abc.Mapping.

Tested Python 2.7. It has rotted some and is not working. Added a few fixes.

Found a recursive import: statements - whelpers - statements Added a kludge by passing in statements module to the function in whelpers that needed it.

Import fc-statements.py with pyYAML instead of json to avoid unicode issues.

#392