### PR TITLE
Refactor fc-statements.yaml groups 

### DIFF
--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -1960,7 +1960,8 @@ c_in_native**:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr-value'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   i_dummy_arg:
   - '{i_var}'
   i_dummy_decl:
@@ -5364,7 +5365,8 @@ c_out_native**:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   i_dummy_arg:
   - '{i_var}'
   i_dummy_decl:
@@ -5393,7 +5395,8 @@ c_out_native***:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   i_dummy_arg:
   - '{i_var}'
   i_dummy_decl:
@@ -5422,7 +5425,8 @@ c_out_native**_raw:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   i_dummy_arg:
   - '{i_var}'
   i_dummy_decl:
@@ -14822,7 +14826,8 @@ f_in_native**:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr-value'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   f_dummy_arg:
   - '{f_var}'
   f_dummy_decl:
@@ -18101,18 +18106,6 @@ f_mixin_declare-arg-char:
   f_dummy_decl:
   - 'character, value{f_intent_attr} :: {f_var}'
   sphinx-end-before: f_mixin_declare-arg-char
-f_mixin_declare-as-cptr:
-  sphinx-start-after: f_mixin_declare-as-cptr
-  name: f_mixin_declare-as-cptr
-  intent: mixin
-  f_dummy_arg:
-  - '{f_var}'
-  f_dummy_decl:
-  - 'type(C_PTR){f_intent_attr} :: {f_var}'
-  f_module:
-    iso_c_binding:
-    - C_PTR
-  sphinx-end-before: f_mixin_declare-as-cptr
 f_mixin_declare-character-arg:
   sphinx-start-after: f_mixin_declare-character-arg
   name: f_mixin_declare-character-arg
@@ -19599,7 +19592,8 @@ f_out_native***_raw:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   f_dummy_arg:
   - '{f_var}'
   f_dummy_decl:
@@ -19918,7 +19912,8 @@ f_out_native**_raw:
   - '  c_mixin_declare-arg'
   - '  c_mixin_arg-call-cvar'
   - '  f_mixin_interface-as-cptr'
-  - '  f_mixin_declare-as-cptr'
+  - '  f_mixin_dummy_arg'
+  - '  f_mixin_declare-arg-as-cptr'
   f_dummy_arg:
   - '{f_var}'
   f_dummy_decl:
@@ -23184,7 +23179,6 @@ root
       deallocate -- f_mixin_deallocate
       declare-arg-as-cptr -- f_mixin_declare-arg-as-cptr
       declare-arg-char -- f_mixin_declare-arg-char
-      declare-as-cptr -- f_mixin_declare-as-cptr
       declare-character-arg -- f_mixin_declare-character-arg
       declare-fortran-arg -- f_mixin_declare-fortran-arg
       declare-interface-arg -- f_mixin_declare-interface-arg

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -1138,7 +1138,7 @@ c_function_string:
   - '  c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_c-str'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   i_dummy_arg:
   - '{i_var_capsule}'
   i_dummy_decl:
@@ -1987,7 +1987,7 @@ c_in_native*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -2921,7 +2921,7 @@ c_in_void*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -3154,7 +3154,7 @@ c_inout_native*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -3801,7 +3801,7 @@ c_inout_void*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -3916,6 +3916,16 @@ c_mixin_c-str:
   - const char *{c_var} = NULL;
   - if (!{c_local_cxx}->empty()) {c_var} = {c_local_cxx}->c_str();
   sphinx-end-before: c_mixin_c-str
+c_mixin_capsule_fill_arg:
+  sphinx-start-after: c_mixin_capsule_fill_arg
+  name: c_mixin_capsule_fill_arg
+  intent: mixin
+  comments:
+  - Assign to local capsule variable in C wrapper.
+  c_post_call:
+  - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
+  - '{c_var_capsule}->idtor = {idtor};'
+  sphinx-end-before: c_mixin_capsule_fill_arg
 c_mixin_capsule_fill_cvar:
   sphinx-start-after: c_mixin_capsule_fill_cvar
   name: c_mixin_capsule_fill_cvar
@@ -3926,16 +3936,6 @@ c_mixin_capsule_fill_cvar:
   - '{c_var}->addr  = {cxx_nonconst_ptr};'
   - '{c_var}->idtor = {idtor};'
   sphinx-end-before: c_mixin_capsule_fill_cvar
-c_mixin_capsule_fill_native:
-  sphinx-start-after: c_mixin_capsule_fill_native
-  name: c_mixin_capsule_fill_native
-  intent: mixin
-  comments:
-  - Assign to local capsule variable in C wrapper.
-  c_post_call:
-  - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
-  - '{c_var_capsule}->idtor = {idtor};'
-  sphinx-end-before: c_mixin_capsule_fill_native
 c_mixin_capsule_pass:
   sphinx-start-after: c_mixin_capsule_pass
   name: c_mixin_capsule_pass
@@ -3966,9 +3966,9 @@ c_mixin_cast-argument:
   c_local:
   - cxx
   sphinx-end-before: c_mixin_cast-argument
-c_mixin_cdesc_char_fill_cvar:
-  sphinx-start-after: c_mixin_cdesc_char_fill_cvar
-  name: c_mixin_cdesc_char_fill_cvar
+c_mixin_cdesc_fill_char:
+  sphinx-start-after: c_mixin_cdesc_fill_char
+  name: c_mixin_cdesc_fill_char
   intent: mixin
   comments:
   - Fill cdesc from char * in the C wrapper.
@@ -3990,7 +3990,7 @@ c_mixin_cdesc_char_fill_cvar:
   lang_cxx:
     impl_header:
     - <cstring>
-  sphinx-end-before: c_mixin_cdesc_char_fill_cvar
+  sphinx-end-before: c_mixin_cdesc_fill_char
 c_mixin_cdesc_fill_string_local:
   sphinx-start-after: c_mixin_cdesc_fill_string_local
   name: c_mixin_cdesc_fill_string_local
@@ -5439,7 +5439,7 @@ c_out_native*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -5667,7 +5667,7 @@ c_out_string**_cdesc_copy:
   mixin_names:
   - '  f_mixin_str_array'
   - '  f_mixin_cdesc_char_fill'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_local-string*'
   - '  c_mixin_arg-call-cvar-address'
   i_dummy_arg:
@@ -5907,7 +5907,7 @@ c_out_vector<native>&_cdesc:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_copy_array'
   - '  c_mixin_new_vector<native>'
   - '    c_mixin_destructor_new-vector'
@@ -6063,7 +6063,7 @@ c_out_vector<native>*_cdesc:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_copy_array'
   - '  c_mixin_new_vector<native>'
   - '    c_mixin_destructor_new-vector'
@@ -6246,7 +6246,7 @@ c_out_vector<string>&_cdesc:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
   - '  f_mixin_cdesc_char_fill'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_arg-call-cvar'
   i_dummy_arg:
   - '{i_var_cdesc}'
@@ -6286,7 +6286,7 @@ c_out_vector<string>&_cdesc_allocatable:
   - Pass dereference of local cxx variable to library.
   mixin_names:
   - '  f_mixin_declare-character-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_cdesc_allocate_1d_character'
@@ -6316,7 +6316,7 @@ c_out_vector<string>&_cdesc_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_capsule_fill_native
+  - // XXX - Use code from c_mixin_capsule_fill_arg
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_temps:
@@ -6441,7 +6441,7 @@ c_out_void*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -6976,10 +6976,10 @@ f_function_char*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_allocate'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   f_dummy_decl:
   - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
@@ -7043,10 +7043,10 @@ f_function_char*_cdesc_funcarg_allocatable:
   - '    f_mixin_as-intent-out'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_allocate'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   f_dummy_arg:
   - '{f_var}'
@@ -7114,9 +7114,9 @@ f_function_char*_cdesc_funcarg_pointer:
   - '    f_mixin_as-intent-out'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   - '  f_mixin_cdesc_char_pointer'
   f_dummy_arg:
@@ -7179,9 +7179,9 @@ f_function_char*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   - '  f_mixin_cdesc_char_pointer'
   f_dummy_decl:
@@ -7779,10 +7779,10 @@ f_function_char_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_allocate'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   f_dummy_decl:
   - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
@@ -7846,10 +7846,10 @@ f_function_char_cdesc_funcarg_allocatable:
   - '    f_mixin_as-intent-out'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_allocate'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   f_dummy_arg:
   - '{f_var}'
@@ -7917,9 +7917,9 @@ f_function_char_cdesc_funcarg_pointer:
   - '    f_mixin_as-intent-out'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   - '  f_mixin_cdesc_char_pointer'
   f_dummy_arg:
@@ -7982,9 +7982,9 @@ f_function_char_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   - '  f_mixin_cdesc_char_pointer'
   f_dummy_decl:
@@ -8485,7 +8485,7 @@ f_function_native*_cdesc_allocatable:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_declare-local-variable'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
   - '  c_mixin_cdesc_native_fill'
   - '  f_mixin_allocate'
@@ -8493,7 +8493,7 @@ f_function_native*_cdesc_allocatable:
   - '  f_mixin_capsule_use'
   - '    f_mixin_capsule_pass'
   - '      c_mixin_capsule_pass'
-  - '    c_mixin_capsule_fill_native'
+  - '    c_mixin_capsule_fill_arg'
   - '    f_mixin_capsule_dtor'
   f_dummy_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_target_attr}{f_optional_attr}
@@ -8571,7 +8571,7 @@ f_function_native*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
   - '  c_mixin_cdesc_native_fill'
   - '  f_mixin_cdesc_native_pointer'
@@ -8640,12 +8640,12 @@ f_function_native*_cdesc_pointer_caller:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
-  - '  f_mixin_capsule_arg'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
+  - '  f_mixin_add_capsule_arg_to_fwrapper'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-cvar'
   - '  c_mixin_cdesc_native_fill'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_native_pointer'
   f_dummy_arg:
   - '{f_var_capsule}'
@@ -9904,12 +9904,12 @@ f_function_string&_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   f_dummy_decl:
@@ -9984,12 +9984,12 @@ f_function_string&_cdesc_allocatable_caller:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   f_dummy_decl:
@@ -10064,12 +10064,12 @@ f_function_string&_cdesc_allocatable_library:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   f_dummy_decl:
@@ -10139,7 +10139,7 @@ f_function_string&_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
   - '  f_mixin_cdesc_char_pointer'
@@ -10195,7 +10195,7 @@ f_function_string&_cdesc_pointer_caller:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
   - '  f_mixin_cdesc_char_pointer'
@@ -10251,7 +10251,7 @@ f_function_string&_cdesc_pointer_library:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
   - '  f_mixin_cdesc_char_pointer'
@@ -11110,12 +11110,12 @@ f_function_string*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   f_dummy_decl:
@@ -11190,12 +11190,12 @@ f_function_string*_cdesc_allocatable_caller:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   f_dummy_decl:
@@ -11270,12 +11270,12 @@ f_function_string*_cdesc_allocatable_library:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_cdesc_char_allocate'
   - '  f_mixin_capsule_dtor'
   f_dummy_decl:
@@ -11345,7 +11345,7 @@ f_function_string*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
   - '  f_mixin_cdesc_char_pointer'
@@ -11401,7 +11401,7 @@ f_function_string*_cdesc_pointer_caller:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
   - '  f_mixin_cdesc_char_pointer'
@@ -11457,7 +11457,7 @@ f_function_string*_cdesc_pointer_library:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-local'
   - '  c_mixin_cdesc_function_string'
   - '  f_mixin_cdesc_char_pointer'
@@ -12333,7 +12333,7 @@ f_function_string_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_destructor_new-string'
   - '  c_mixin_cdesc_function_string'
@@ -12341,7 +12341,7 @@ f_function_string_cdesc_allocatable:
   - '  f_mixin_capsule_use'
   - '    f_mixin_capsule_pass'
   - '      c_mixin_capsule_pass'
-  - '    c_mixin_capsule_fill_native'
+  - '    c_mixin_capsule_fill_arg'
   - '    f_mixin_capsule_dtor'
   f_dummy_decl:
   - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
@@ -12426,7 +12426,7 @@ f_function_string_cdesc_allocatable_caller:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_destructor_new-string'
   - '  c_mixin_cdesc_function_string'
@@ -12434,7 +12434,7 @@ f_function_string_cdesc_allocatable_caller:
   - '  f_mixin_capsule_use'
   - '    f_mixin_capsule_pass'
   - '      c_mixin_capsule_pass'
-  - '    c_mixin_capsule_fill_native'
+  - '    c_mixin_capsule_fill_arg'
   - '    f_mixin_capsule_dtor'
   f_dummy_decl:
   - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
@@ -12519,7 +12519,7 @@ f_function_string_cdesc_allocatable_library:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_destructor_new-string'
   - '  c_mixin_cdesc_function_string'
@@ -12527,7 +12527,7 @@ f_function_string_cdesc_allocatable_library:
   - '  f_mixin_capsule_use'
   - '    f_mixin_capsule_pass'
   - '      c_mixin_capsule_pass'
-  - '    c_mixin_capsule_fill_native'
+  - '    c_mixin_capsule_fill_arg'
   - '    f_mixin_capsule_dtor'
   f_dummy_decl:
   - 'character(len=:){f_intent_attr}{f_deref_attr} :: {f_var}'
@@ -12608,13 +12608,13 @@ f_function_string_cdesc_pointer:
   usage:
   - std::string func() +deref(pointer)+owner(caller)
   mixin_names:
-  - '  f_mixin_capsule_arg'
+  - '  f_mixin_add_capsule_arg_to_fwrapper'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-new'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  c_mixin_cdesc_fill_string_local'
   - '    c_mixin_header_cstring'
   - '  f_mixin_cdesc_char_pointer'
@@ -12997,7 +12997,7 @@ f_function_string_cfi_pointer:
   usage:
   - std::string func() +deref(allocatable)
   mixin_names:
-  - '  f_mixin_capsule_arg'
+  - '  f_mixin_add_capsule_arg_to_fwrapper'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
@@ -13008,7 +13008,7 @@ f_function_string_cfi_pointer:
   - '    c_mixin_cfi_arg'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_cfi_string*_pointer'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   f_dummy_arg:
   - '{f_var_capsule}'
   f_dummy_decl:
@@ -13098,7 +13098,7 @@ f_function_string_cfi_pointer_caller:
   usage:
   - std::string func() +deref(allocatable)
   mixin_names:
-  - '  f_mixin_capsule_arg'
+  - '  f_mixin_add_capsule_arg_to_fwrapper'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
@@ -13109,7 +13109,7 @@ f_function_string_cfi_pointer_caller:
   - '    c_mixin_cfi_arg'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_cfi_string*_pointer'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   f_dummy_arg:
   - '{f_var_capsule}'
   f_dummy_decl:
@@ -13199,7 +13199,7 @@ f_function_string_cfi_pointer_library:
   usage:
   - std::string func() +deref(allocatable)
   mixin_names:
-  - '  f_mixin_capsule_arg'
+  - '  f_mixin_add_capsule_arg_to_fwrapper'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
@@ -13210,7 +13210,7 @@ f_function_string_cfi_pointer_library:
   - '    c_mixin_cfi_arg'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_cfi_string*_pointer'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   f_dummy_arg:
   - '{f_var_capsule}'
   f_dummy_decl:
@@ -13299,12 +13299,12 @@ f_function_string_raw:
   - std::string func() +deref(raw)
   mixin_names:
   - '  f_mixin_function_ptr'
-  - '  f_mixin_capsule_arg'
+  - '  f_mixin_add_capsule_arg_to_fwrapper'
   - '    c_mixin_capsule_pass'
   - '  c_mixin_function-return-cvar'
   - '  c_mixin_function-assign-to-new'
   - '  c_mixin_declare-string-data-cvar'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   f_dummy_arg:
   - '{f_var_capsule}'
   f_dummy_decl:
@@ -13408,7 +13408,7 @@ f_function_struct*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_function-assign-to-cvar'
   - '  c_mixin_cdesc_native_fill'
   - '  f_mixin_cdesc_native_pointer'
@@ -13512,7 +13512,7 @@ f_function_vector<native>_cdesc_allocatable:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_allocate_1d'
   - '  c_mixin_destructor_new-vector'
   - '  c_mixin_cdesc_vector_fill'
@@ -13710,7 +13710,7 @@ f_getter_char*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_allocate'
   - '  c_mixin_getter_char*'
   - '  c_mixin_getter_char*_len'
@@ -13779,7 +13779,7 @@ f_getter_char*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_pointer'
   - '  c_mixin_getter_char*'
   - '  c_mixin_getter_char*_len'
@@ -13871,7 +13871,7 @@ f_getter_native*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_pointer'
   - '  c_mixin_cdesc_getter'
   f_dummy_decl:
@@ -14032,7 +14032,7 @@ f_getter_string_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_allocate'
   - '  c_mixin_getter_string'
   f_dummy_decl:
@@ -14095,7 +14095,7 @@ f_getter_string_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_char_pointer'
   - '  c_mixin_getter_string'
   f_dummy_decl:
@@ -14156,7 +14156,7 @@ f_getter_struct**_cdesc_raw:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_raw'
   - '  c_mixin_cdesc_getter'
   f_dummy_decl:
@@ -14216,7 +14216,7 @@ f_getter_struct*_cdesc_pointer:
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_pointer'
   - '  c_mixin_cdesc_getter'
   f_dummy_decl:
@@ -14845,7 +14845,7 @@ f_in_native*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -16231,7 +16231,7 @@ f_in_void*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -16638,7 +16638,7 @@ f_inout_native*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -17572,7 +17572,7 @@ f_inout_void*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -17619,6 +17619,42 @@ f_inout_void*_cdesc:
   - array_context
   - type_defines
   sphinx-end-before: f_inout_void*_cdesc
+f_mixin_add_capsule_arg_to_fwrapper:
+  sphinx-start-after: f_mixin_add_capsule_arg_to_fwrapper
+  name: f_mixin_add_capsule_arg_to_fwrapper
+  intent: mixin
+  comments:
+  - Pass capsule as argument to C wrapper.
+  - Add a capsule argument to the Fortran wrapper.
+  - Pass the capsule as argument to C wrapper.
+  mixin_names:
+  - '  c_mixin_capsule_pass'
+  f_dummy_arg:
+  - '{f_var_capsule}'
+  f_dummy_decl:
+  - 'type({F_capsule_type}), intent(OUT) :: {f_var_capsule}'
+  f_arg_call:
+  - '{f_var_capsule}%mem'
+  f_temps:
+  - capsule
+  f_need_wrapper: true
+  i_dummy_arg:
+  - '{i_var_capsule}'
+  i_dummy_decl:
+  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
+  i_import:
+  - '{F_capsule_data_type}'
+  c_prototype:
+  - '{C_capsule_data_type} *{c_var_capsule}'
+  c_temps:
+  - capsule
+  fmtdict:
+    f_var_capsule: Crv
+  helper:
+  - capsule_data_helper
+  - array_context
+  - capsule_helper
+  sphinx-end-before: f_mixin_add_capsule_arg_to_fwrapper
 f_mixin_allocate:
   sphinx-start-after: f_mixin_allocate
   name: f_mixin_allocate
@@ -17660,42 +17696,6 @@ f_mixin_call-cwrapper-as-subroutine:
     i_intent: OUT
     i_intent_attr: ', intent(OUT)'
   sphinx-end-before: f_mixin_call-cwrapper-as-subroutine
-f_mixin_capsule_arg:
-  sphinx-start-after: f_mixin_capsule_arg
-  name: f_mixin_capsule_arg
-  intent: mixin
-  comments:
-  - Pass capsule as argument to C wrapper.
-  - Add a capsule argument to the Fortran wrapper.
-  - Pass the capsule as argument to C wrapper.
-  mixin_names:
-  - '  c_mixin_capsule_pass'
-  f_dummy_arg:
-  - '{f_var_capsule}'
-  f_dummy_decl:
-  - 'type({F_capsule_type}), intent(OUT) :: {f_var_capsule}'
-  f_arg_call:
-  - '{f_var_capsule}%mem'
-  f_temps:
-  - capsule
-  f_need_wrapper: true
-  i_dummy_arg:
-  - '{i_var_capsule}'
-  i_dummy_decl:
-  - 'type({F_capsule_data_type}), intent(OUT) :: {i_var_capsule}'
-  i_import:
-  - '{F_capsule_data_type}'
-  c_prototype:
-  - '{C_capsule_data_type} *{c_var_capsule}'
-  c_temps:
-  - capsule
-  fmtdict:
-    f_var_capsule: Crv
-  helper:
-  - capsule_data_helper
-  - array_context
-  - capsule_helper
-  sphinx-end-before: f_mixin_capsule_arg
 f_mixin_capsule_dtor:
   sphinx-start-after: f_mixin_capsule_dtor
   name: f_mixin_capsule_dtor
@@ -17761,7 +17761,7 @@ f_mixin_capsule_use:
   mixin_names:
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_capsule_dtor'
   f_local_decl:
   - 'type({F_capsule_data_type}) :: {f_var_capsule}'
@@ -17969,9 +17969,9 @@ f_mixin_cdesc_out_native_pointer:
     iso_c_binding:
     - c_f_pointer
   sphinx-end-before: f_mixin_cdesc_out_native_pointer
-f_mixin_cdesc_pass:
-  sphinx-start-after: f_mixin_cdesc_pass
-  name: f_mixin_cdesc_pass
+f_mixin_cdesc_pass_to_cwrapper:
+  sphinx-start-after: f_mixin_cdesc_pass_to_cwrapper
+  name: f_mixin_cdesc_pass_to_cwrapper
   intent: mixin
   comments:
   - Pass cdesc as argument to C wrapper.
@@ -17994,7 +17994,7 @@ f_mixin_cdesc_pass:
   - cdesc
   helper:
   - array_context
-  sphinx-end-before: f_mixin_cdesc_pass
+  sphinx-end-before: f_mixin_cdesc_pass_to_cwrapper
 f_mixin_cfi_arg-character-array:
   sphinx-start-after: f_mixin_cfi_arg-character-array
   name: f_mixin_cfi_arg-character-array
@@ -18346,7 +18346,7 @@ f_mixin_helper_vector_string_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_capsule_fill_native
+  - // XXX - Use code from c_mixin_capsule_fill_arg
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_local:
@@ -19082,8 +19082,8 @@ f_out_char**_cdesc_pointer:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_cdesc_char_pointer'
-  - '  f_mixin_cdesc_pass'
-  - '  c_mixin_cdesc_char_fill_cvar'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
+  - '  c_mixin_cdesc_fill_char'
   - '    c_mixin_header_cstring'
   - '  c_mixin_local-cvar-ptr'
   - '  c_mixin_arg-call-cvar-address'
@@ -19470,7 +19470,7 @@ f_out_native*&_cdesc:
   usage:
   - double *&arg +dimension(isize)+intent(out)
   mixin_names:
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar'
   - '  c_mixin_cdesc_native_fill'
@@ -19529,7 +19529,7 @@ f_out_native*&_cdesc_pointer:
   usage:
   - double *&arg +dimension(isize)+intent(out)
   mixin_names:
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar'
   - '  c_mixin_cdesc_native_fill'
@@ -19633,7 +19633,7 @@ f_out_native**_cdesc_allocatable:
   - int **arg +deref(allocatable)+dimension(10)+intent(out)
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_cdesc_native_fill'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar-address'
@@ -19642,7 +19642,7 @@ f_out_native**_cdesc_allocatable:
   - '  f_mixin_capsule_use'
   - '    f_mixin_capsule_pass'
   - '      c_mixin_capsule_pass'
-  - '    c_mixin_capsule_fill_native'
+  - '    c_mixin_capsule_fill_arg'
   - '    f_mixin_capsule_dtor'
   f_dummy_arg:
   - '{f_var}'
@@ -19722,7 +19722,7 @@ f_out_native**_cdesc_pointer:
   usage:
   - int **arg +intent(out)+deref(pointer)
   mixin_names:
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_out_native**'
   - '  c_mixin_arg-call-cvar-address'
   - '  c_mixin_cdesc_native_fill'
@@ -19944,7 +19944,7 @@ f_out_native*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -20179,14 +20179,14 @@ f_out_string**_cdesc_allocatable:
   - Release memory from capsule.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_cdesc_allocate_1d_character'
   - '  f_mixin_helper_array_string_allocatable'
   - '    c_mixin_local-string*'
   - '  c_mixin_arg-call-cvar-address'
-  - '  c_mixin_capsule_fill_native'
+  - '  c_mixin_capsule_fill_arg'
   - '  f_mixin_capsule_dtor'
   f_dummy_arg:
   - '{f_var}'
@@ -20269,7 +20269,7 @@ f_out_string**_cdesc_copy:
   mixin_names:
   - '  f_mixin_str_array'
   - '  f_mixin_cdesc_char_fill'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_local-string*'
   - '  c_mixin_arg-call-cvar-address'
   f_dummy_arg:
@@ -20641,7 +20641,7 @@ f_out_vector<native>&_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_allocate_1d'
   - '  f_mixin_cdesc_copy_array'
   - '  c_mixin_new_vector<native>'
@@ -20718,7 +20718,7 @@ f_out_vector<native>&_cdesc_copy:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_copy_array'
   - '  c_mixin_new_vector<native>'
   - '    c_mixin_destructor_new-vector'
@@ -20794,7 +20794,7 @@ f_out_vector<native>*_cdesc_allocatable:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_allocate_1d'
   - '  f_mixin_cdesc_copy_array'
   - '  c_mixin_new_vector<native>'
@@ -20871,7 +20871,7 @@ f_out_vector<native>*_cdesc_copy:
   mixin_names:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_copy_array'
   - '  c_mixin_new_vector<native>'
   - '    c_mixin_destructor_new-vector'
@@ -20945,7 +20945,7 @@ f_out_vector<string>&_cdesc_allocatable:
   - Pass dereference of local cxx variable to library.
   mixin_names:
   - '  f_mixin_declare-character-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_capsule_pass'
   - '    c_mixin_capsule_pass'
   - '  f_mixin_cdesc_allocate_1d_character'
@@ -20997,7 +20997,7 @@ f_out_vector<string>&_cdesc_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_capsule_fill_native
+  - // XXX - Use code from c_mixin_capsule_fill_arg
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_temps:
@@ -21027,7 +21027,7 @@ f_out_vector<string>&_cdesc_copy:
   - '  f_mixin_dummy_arg'
   - '  f_mixin_template_native_arg1'
   - '  f_mixin_cdesc_char_fill'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  c_mixin_arg-call-cvar'
   f_dummy_arg:
   - '{f_var}'
@@ -21217,7 +21217,7 @@ f_out_void*_cdesc:
   - See cdesc.yaml test GetScalar1.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
-  - '  f_mixin_cdesc_pass'
+  - '  f_mixin_cdesc_pass_to_cwrapper'
   - '  f_mixin_cdesc_native_fill'
   - '  c_mixin_cdesc_unpack-base-addr'
   - '  c_mixin_arg-call-cvar'
@@ -22677,15 +22677,13 @@ root
       c-str -- c_mixin_c-str
       capsule
         fill
+          arg -- c_mixin_capsule_fill_arg
           cvar -- c_mixin_capsule_fill_cvar
-          native -- c_mixin_capsule_fill_native
         pass -- c_mixin_capsule_pass
       cast-argument -- c_mixin_cast-argument
       cdesc
-        char
-          fill
-            cvar -- c_mixin_cdesc_char_fill_cvar
         fill
+          char -- c_mixin_cdesc_fill_char
           string
             local -- c_mixin_cdesc_fill_string_local
         function
@@ -23130,12 +23128,16 @@ root
         cdesc -- f_inout_void*_cdesc
       void** -- f_inout_void**
     mixin
+      add
+        capsule
+          arg
+            to
+              fwrapper -- f_mixin_add_capsule_arg_to_fwrapper
       allocate -- f_mixin_allocate
       arg-call-fvar -- f_mixin_arg-call-fvar
       as-intent-out -- f_mixin_as-intent-out
       call-cwrapper-as-subroutine -- f_mixin_call-cwrapper-as-subroutine
       capsule
-        arg -- f_mixin_capsule_arg
         dtor -- f_mixin_capsule_dtor
         function
           shadow -- f_mixin_capsule_function_shadow
@@ -23160,7 +23162,9 @@ root
         out
           native
             pointer -- f_mixin_cdesc_out_native_pointer
-        pass -- f_mixin_cdesc_pass
+        pass
+          to
+            cwrapper -- f_mixin_cdesc_pass_to_cwrapper
       cfi
         arg-character-array -- f_mixin_cfi_arg-character-array
         character-deferred-length -- f_mixin_cfi_character-deferred-length

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -409,7 +409,7 @@ c_function_shadow&_capptr:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -457,7 +457,7 @@ c_function_shadow&_capptr_caller:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -505,7 +505,7 @@ c_function_shadow&_capptr_library:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -553,7 +553,7 @@ c_function_shadow&_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -592,7 +592,7 @@ c_function_shadow&_capsule_caller:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -631,7 +631,7 @@ c_function_shadow&_capsule_library:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -670,7 +670,7 @@ c_function_shadow*_capptr:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -718,7 +718,7 @@ c_function_shadow*_capptr_caller:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -766,7 +766,7 @@ c_function_shadow*_capptr_library:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -814,7 +814,7 @@ c_function_shadow*_capptr_shared:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - std::shared_ptr with a shadow class.
   mixin_names:
@@ -862,7 +862,7 @@ c_function_shadow*_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -920,7 +920,7 @@ c_function_shadow<native>_capptr:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Allocate a C wrapper result on the heap.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return an instance by value.
   - Create memory in c_pre_call so it will survive the return.
@@ -976,7 +976,7 @@ c_function_shadow_capptr:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Allocate a C wrapper result on the heap.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return an instance by value.
   - Create memory in c_pre_call so it will survive the return.
@@ -1032,7 +1032,7 @@ c_function_smartptr<shadow>*_capptr:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   mixin_names:
   - '  c_mixin_function_shadow_capptr'
   - '  c_mixin_shadow'
@@ -1078,7 +1078,7 @@ c_function_smartptr<shadow>_capptr:
   - Pass function result as a capsule field of shadow class
   - from Fortran to C.
   - Allocate a C wrapper result on the heap.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Used with std::shared_ptr<Object>* createChildA(void)
   mixin_names:
@@ -1130,7 +1130,7 @@ c_function_string:
   comments:
   - Pass capsule as argument to C wrapper.
   - Allocate a C wrapper result on the heap.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   notes:
   - Cannot return a char array by value.
   - Return a const pointer to std::string data.
@@ -3921,7 +3921,7 @@ c_mixin_capsule_fill_arg:
   name: c_mixin_capsule_fill_arg
   intent: mixin
   comments:
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   c_post_call:
   - '{c_var_capsule}->addr  = {cxx_nonconst_ptr};'
   - '{c_var_capsule}->idtor = {idtor};'
@@ -3931,11 +3931,21 @@ c_mixin_capsule_fill_cvar:
   name: c_mixin_capsule_fill_cvar
   intent: mixin
   comments:
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   c_post_call:
   - '{c_var}->addr  = {cxx_nonconst_ptr};'
   - '{c_var}->idtor = {idtor};'
   sphinx-end-before: c_mixin_capsule_fill_cvar
+c_mixin_capsule_fill_local:
+  sphinx-start-after: c_mixin_capsule_fill_local
+  name: c_mixin_capsule_fill_local
+  intent: mixin
+  comments:
+  - Assign local variable's capsule values to capsule argument in C wrapper.
+  c_post_call:
+  - '{c_var_capsule}->addr  = {c_local_cxx};'
+  - '{c_var_capsule}->idtor = {idtor};'
+  sphinx-end-before: c_mixin_capsule_fill_local
 c_mixin_capsule_pass:
   sphinx-start-after: c_mixin_capsule_pass
   name: c_mixin_capsule_pass
@@ -6282,6 +6292,7 @@ c_out_vector<string>&_cdesc_allocatable:
   - Allocate Fortran character array from cdesc.
   - Allocate a vector<string> variable.
   - Copy into Fortran allocated memory.
+  - Assign local variable's capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   - Pass dereference of local cxx variable to library.
   mixin_names:
@@ -6291,6 +6302,7 @@ c_out_vector<string>&_cdesc_allocatable:
   - '    c_mixin_capsule_pass'
   - '  f_mixin_cdesc_allocate_1d_character'
   - '  f_mixin_helper_vector_string_allocatable'
+  - '  c_mixin_capsule_fill_local'
   - '  f_mixin_capsule_dtor'
   - '  c_mixin_arg-call-cxx-deref'
   i_dummy_arg:
@@ -6316,7 +6328,6 @@ c_out_vector<string>&_cdesc_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_capsule_fill_arg
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_temps:
@@ -8479,7 +8490,7 @@ f_function_native*_cdesc_allocatable:
   - Copy into Fortran argument.
   - Pass capsule as argument to C wrapper.
   - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
@@ -8630,7 +8641,7 @@ f_function_native*_cdesc_pointer_caller:
   - Pass the capsule as argument to C wrapper.
   - Call function and assign to a c variable.
   - Fill cdesc from native in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Set Fortran pointer to native array.
   notes:
   - A capsule argument is added which contains information used to
@@ -9016,7 +9027,7 @@ f_function_shadow&_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -9062,7 +9073,7 @@ f_function_shadow&_capsule_caller:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -9108,7 +9119,7 @@ f_function_shadow&_capsule_library:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -9154,7 +9165,7 @@ f_function_shadow*_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -9200,7 +9211,7 @@ f_function_shadow*_capsule_caller:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -9246,7 +9257,7 @@ f_function_shadow*_capsule_library:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return a C_capsule_data_type.
   mixin_names:
@@ -9314,7 +9325,7 @@ f_function_shadow<native>_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Allocate a C wrapper result on the heap.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return an instance by value.
   - Create memory in c_pre_call so it will survive the return.
@@ -9368,7 +9379,7 @@ f_function_shadow_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Allocate a C wrapper result on the heap.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Return an instance by value.
   - Create memory in c_pre_call so it will survive the return.
@@ -9422,7 +9433,7 @@ f_function_smartptr<shadow>*_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Call function and assign to a local C++ variable.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   mixin_names:
   - '  f_mixin_call-cwrapper-as-subroutine'
   - '    c_mixin_as-intent-out'
@@ -9466,7 +9477,7 @@ f_function_smartptr<shadow>_capsule:
   - Call the C wrapper as a subroutine.
   - Pass function result as a capsule argument from Fortran to C.
   - Allocate a C wrapper result on the heap.
-  - Assign to capsule in C wrapper.
+  - Assign capsule values to argument in C wrapper.
   notes:
   - Used with std::shared_ptr<Object>* createChildA(void)
   mixin_names:
@@ -9897,7 +9908,7 @@ f_function_string&_cdesc_allocatable:
   - Call function and assign to a local C++ variable.
   - Fill cdesc from std::string using helper string_to_cdesc
   - in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
   - Release memory from capsule.
@@ -9977,7 +9988,7 @@ f_function_string&_cdesc_allocatable_caller:
   - Call function and assign to a local C++ variable.
   - Fill cdesc from std::string using helper string_to_cdesc
   - in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
   - Release memory from capsule.
@@ -10057,7 +10068,7 @@ f_function_string&_cdesc_allocatable_library:
   - Call function and assign to a local C++ variable.
   - Fill cdesc from std::string using helper string_to_cdesc
   - in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
   - Release memory from capsule.
@@ -11103,7 +11114,7 @@ f_function_string*_cdesc_allocatable:
   - Call function and assign to a local C++ variable.
   - Fill cdesc from std::string using helper string_to_cdesc
   - in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
   - Release memory from capsule.
@@ -11183,7 +11194,7 @@ f_function_string*_cdesc_allocatable_caller:
   - Call function and assign to a local C++ variable.
   - Fill cdesc from std::string using helper string_to_cdesc
   - in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
   - Release memory from capsule.
@@ -11263,7 +11274,7 @@ f_function_string*_cdesc_allocatable_library:
   - Call function and assign to a local C++ variable.
   - Fill cdesc from std::string using helper string_to_cdesc
   - in the C wrapper.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Allocate Fortran CHARACTER scalar, then fill from cdesc
   - using helper copy_string.
   - Release memory from capsule.
@@ -12326,7 +12337,7 @@ f_function_string_cdesc_allocatable:
   - using helper copy_string.
   - Pass capsule as argument to C wrapper.
   - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   usage:
   - std::string func() +deref(allocatable)
@@ -12419,7 +12430,7 @@ f_function_string_cdesc_allocatable_caller:
   - using helper copy_string.
   - Pass capsule as argument to C wrapper.
   - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   usage:
   - std::string func() +deref(allocatable)
@@ -12512,7 +12523,7 @@ f_function_string_cdesc_allocatable_library:
   - using helper copy_string.
   - Pass capsule as argument to C wrapper.
   - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   usage:
   - std::string func() +deref(allocatable)
@@ -12602,7 +12613,7 @@ f_function_string_cdesc_pointer:
   - Call the C wrapper as a subroutine.
   - Pass cdesc as argument to C wrapper.
   - Allocate a C wrapper result on the heap.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Fill cdesc from local std::string variable in the C wrapper.
   - Assign Fortran pointer from cdesc using helper pointer_string.
   usage:
@@ -12990,7 +13001,7 @@ f_function_string_cfi_pointer:
   - Call the C wrapper as a subroutine.
   - Make the C wrapper argument a CFI_desc_t.
   - Allocate a C wrapper result on the heap.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   notes:
   - Return a pointer to a new variable
   - which the caller must release via the capsule.
@@ -13091,7 +13102,7 @@ f_function_string_cfi_pointer_caller:
   - Call the C wrapper as a subroutine.
   - Make the C wrapper argument a CFI_desc_t.
   - Allocate a C wrapper result on the heap.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   notes:
   - Return a pointer to a new variable
   - which the caller must release via the capsule.
@@ -13192,7 +13203,7 @@ f_function_string_cfi_pointer_library:
   - Call the C wrapper as a subroutine.
   - Make the C wrapper argument a CFI_desc_t.
   - Allocate a C wrapper result on the heap.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   notes:
   - Return a pointer to a new variable
   - which the caller must release via the capsule.
@@ -13294,7 +13305,7 @@ f_function_string_raw:
   - Allocate a C wrapper result on the heap.
   - Assign std::string.data to cvar.
   - Always uses const.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   usage:
   - std::string func() +deref(raw)
   mixin_names:
@@ -17756,7 +17767,7 @@ f_mixin_capsule_use:
   comments:
   - Pass capsule as argument to C wrapper.
   - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   mixin_names:
   - '  f_mixin_capsule_pass'
@@ -18346,9 +18357,6 @@ f_mixin_helper_vector_string_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_capsule_fill_arg
-  - '{c_var_capsule}->addr  = {c_local_cxx};'
-  - '{c_var_capsule}->idtor = {idtor};'
   c_local:
   - cxx
   helper:
@@ -19624,7 +19632,7 @@ f_out_native**_cdesc_allocatable:
   - Copy into Fortran argument.
   - Pass capsule as argument to C wrapper.
   - Create a local Fortran capsule.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   notes:
   - Argument returns a pointer to an array which is copied into a
@@ -20175,7 +20183,7 @@ f_out_string**_cdesc_allocatable:
   - Assign to std::string pointer from C++ function.
   - Copy into Fortran allocated memory.
   - Pass address of cxx variable to library.
-  - Assign to local capsule variable in C wrapper.
+  - Assign capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   mixin_names:
   - '  f_mixin_declare-fortran-arg'
@@ -20941,6 +20949,7 @@ f_out_vector<string>&_cdesc_allocatable:
   - Allocate Fortran character array from cdesc.
   - Allocate a vector<string> variable.
   - Copy into Fortran allocated memory.
+  - Assign local variable's capsule values to capsule argument in C wrapper.
   - Release memory from capsule.
   - Pass dereference of local cxx variable to library.
   mixin_names:
@@ -20950,6 +20959,7 @@ f_out_vector<string>&_cdesc_allocatable:
   - '    c_mixin_capsule_pass'
   - '  f_mixin_cdesc_allocate_1d_character'
   - '  f_mixin_helper_vector_string_allocatable'
+  - '  c_mixin_capsule_fill_local'
   - '  f_mixin_capsule_dtor'
   - '  c_mixin_arg-call-cxx-deref'
   f_dummy_arg:
@@ -20997,7 +21007,6 @@ f_out_vector<string>&_cdesc_allocatable:
   - '{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});'
   - -}}
   - '{c_var_cdesc}->size      = {c_local_cxx}->size();'
-  - // XXX - Use code from c_mixin_capsule_fill_arg
   - '{c_var_capsule}->addr  = {c_local_cxx};'
   - '{c_var_capsule}->idtor = {idtor};'
   c_temps:
@@ -22679,6 +22688,7 @@ root
         fill
           arg -- c_mixin_capsule_fill_arg
           cvar -- c_mixin_capsule_fill_cvar
+          local -- c_mixin_capsule_fill_local
         pass -- c_mixin_capsule_pass
       cast-argument -- c_mixin_cast-argument
       cdesc

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -549,7 +549,7 @@ void VEC_vector_string_fill_allocatable_bufferify(
         SHT_arg_cdesc->elem_len = VEC_ShroudVectorStringOutSize(*SHC_arg_cxx);
     }
     SHT_arg_cdesc->size      = SHC_arg_cxx->size();
-    // XXX - Use code from c_mixin_capsule_fill_native
+    // XXX - Use code from c_mixin_capsule_fill_arg
     SHT_arg_capsule->addr  = SHC_arg_cxx;
     SHT_arg_capsule->idtor = 0;
     // splicer end function.vector_string_fill_allocatable_bufferify
@@ -590,7 +590,7 @@ void VEC_vector_string_fill_allocatable_len_bufferify(
         SHT_arg_cdesc->elem_len = VEC_ShroudVectorStringOutSize(*SHC_arg_cxx);
     }
     SHT_arg_cdesc->size      = SHC_arg_cxx->size();
-    // XXX - Use code from c_mixin_capsule_fill_native
+    // XXX - Use code from c_mixin_capsule_fill_arg
     SHT_arg_capsule->addr  = SHC_arg_cxx;
     SHT_arg_capsule->idtor = 0;
     // splicer end function.vector_string_fill_allocatable_len_bufferify

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -549,7 +549,6 @@ void VEC_vector_string_fill_allocatable_bufferify(
         SHT_arg_cdesc->elem_len = VEC_ShroudVectorStringOutSize(*SHC_arg_cxx);
     }
     SHT_arg_cdesc->size      = SHC_arg_cxx->size();
-    // XXX - Use code from c_mixin_capsule_fill_arg
     SHT_arg_capsule->addr  = SHC_arg_cxx;
     SHT_arg_capsule->idtor = 0;
     // splicer end function.vector_string_fill_allocatable_bufferify
@@ -590,7 +589,6 @@ void VEC_vector_string_fill_allocatable_len_bufferify(
         SHT_arg_cdesc->elem_len = VEC_ShroudVectorStringOutSize(*SHC_arg_cxx);
     }
     SHT_arg_cdesc->size      = SHC_arg_cxx->size();
-    // XXX - Use code from c_mixin_capsule_fill_arg
     SHT_arg_capsule->addr  = SHC_arg_cxx;
     SHT_arg_capsule->idtor = 0;
     // splicer end function.vector_string_fill_allocatable_len_bufferify

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -838,7 +838,10 @@
     {
         "name": "c_mixin_capsule_fill_cvar",
         "comments": [
-            "Assign to capsule in C wrapper."
+            "Assign capsule values to argument in C wrapper."
+        ],
+        "notes": [
+            "The argument may be a capulse or a class struct."
         ],
         "c_post_call": [
             "{c_var}->addr  = {cxx_nonconst_ptr};",
@@ -848,10 +851,20 @@
     {
         "name": "c_mixin_capsule_fill_arg",
         "comments": [
-            "Assign to local capsule variable in C wrapper."
+            "Assign capsule values to capsule argument in C wrapper."
         ],
         "c_post_call": [
             "{c_var_capsule}->addr  = {cxx_nonconst_ptr};",
+            "{c_var_capsule}->idtor = {idtor};"
+        ]
+    },
+    {
+        "name": "c_mixin_capsule_fill_local",
+        "comments": [
+            "Assign local variable's capsule values to capsule argument in C wrapper."
+        ],
+        "c_post_call": [
+            "{c_var_capsule}->addr  = {c_local_cxx};",
             "{c_var_capsule}->idtor = {idtor};"
         ]
     },
@@ -3874,10 +3887,7 @@
             "-}} else {{+",
             "{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});",
             "-}}",
-            "{c_var_cdesc}->size      = {c_local_cxx}->size();",
-            "// XXX - Use code from c_mixin_capsule_fill_arg",
-            "{c_var_capsule}->addr  = {c_local_cxx};",
-            "{c_var_capsule}->idtor = {idtor};"
+            "{c_var_cdesc}->size      = {c_local_cxx}->size();"
         ],
         "c_local": [
             "cxx"
@@ -4051,6 +4061,7 @@
             "f_mixin_capsule_pass",
             "f_mixin_cdesc_allocate_1d_character",
             "f_mixin_helper_vector_string_allocatable",
+            "c_mixin_capsule_fill_local",
             "f_mixin_capsule_dtor",
             "c_mixin_arg-call-cxx-deref"
         ]

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -777,7 +777,7 @@
         ]
     },
     {
-        "name": "f_mixin_capsule_arg",
+        "name": "f_mixin_add_capsule_arg_to_fwrapper",
         "comments": [
             "Add a capsule argument to the Fortran wrapper.",
             "Pass the capsule as argument to C wrapper."
@@ -846,7 +846,7 @@
         ]
     },
     {
-        "name": "c_mixin_capsule_fill_native",
+        "name": "c_mixin_capsule_fill_arg",
         "comments": [
             "Assign to local capsule variable in C wrapper."
         ],
@@ -891,7 +891,7 @@
         "name": "f_mixin_capsule_use",
         "mixin": [
             "f_mixin_capsule_pass",
-            "c_mixin_capsule_fill_native",
+            "c_mixin_capsule_fill_arg",
             "f_mixin_capsule_dtor"
         ]
     },
@@ -899,7 +899,7 @@
         "name":"#### cdesc mixin ###########################################"
     },
     {
-        "name": "f_mixin_cdesc_pass",
+        "name": "f_mixin_cdesc_pass_to_cwrapper",
         "comments": [
             "Pass cdesc as argument to C wrapper."
         ],
@@ -1032,7 +1032,7 @@
         ]
     },
     {
-        "name": "c_mixin_cdesc_char_fill_cvar",
+        "name": "c_mixin_cdesc_fill_char",
         "comments": [
             "Fill cdesc from char * in the C wrapper."
         ],
@@ -1693,7 +1693,7 @@
             "f_out_native*&_cdesc_pointer"
         ],
         "mixin": [
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_out_native**",
             "c_mixin_arg-call-cvar",
             "c_mixin_cdesc_native_fill",
@@ -1714,7 +1714,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_cdesc_native_fill",
             "c_mixin_out_native**",
             "c_mixin_arg-call-cvar-address",
@@ -1733,7 +1733,7 @@
             "int **arg +intent(out)+deref(pointer)"
         ],
         "mixin": [
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_out_native**",
             "c_mixin_arg-call-cvar-address",
             "c_mixin_cdesc_native_fill",
@@ -1762,7 +1762,7 @@
         ],
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_native_fill",
             "c_mixin_cdesc_unpack-base-addr",
             "c_mixin_arg-call-cvar"
@@ -1816,7 +1816,7 @@
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
             "f_mixin_declare-local-variable",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-cvar",
             "c_mixin_cdesc_native_fill",
             "f_mixin_allocate",
@@ -1850,7 +1850,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-cvar",
             "c_mixin_cdesc_native_fill",
             "f_mixin_cdesc_native_pointer"
@@ -1867,11 +1867,11 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
-            "f_mixin_capsule_arg",
+            "f_mixin_cdesc_pass_to_cwrapper",
+            "f_mixin_add_capsule_arg_to_fwrapper",
             "c_mixin_function-assign-to-cvar",
             "c_mixin_cdesc_native_fill",
-            "c_mixin_capsule_fill_native",
+            "c_mixin_capsule_fill_arg",
             "f_mixin_cdesc_native_pointer"
         ]
     },
@@ -2773,8 +2773,8 @@
         "mixin": [
             "f_mixin_dummy_arg",
             "f_mixin_cdesc_char_pointer",
-            "f_mixin_cdesc_pass",
-            "c_mixin_cdesc_char_fill_cvar",
+            "f_mixin_cdesc_pass_to_cwrapper",
+            "c_mixin_cdesc_fill_char",
             "c_mixin_local-cvar-ptr",
             "c_mixin_arg-call-cvar-address"
         ],
@@ -2787,10 +2787,10 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_char_allocate",
             "c_mixin_function-assign-to-cvar",
-            "c_mixin_cdesc_char_fill_cvar"
+            "c_mixin_cdesc_fill_char"
         ]
     },
     {
@@ -2800,9 +2800,9 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-cvar",
-            "c_mixin_cdesc_char_fill_cvar",
+            "c_mixin_cdesc_fill_char",
             "f_mixin_cdesc_char_pointer"
         ]
     },
@@ -2817,10 +2817,10 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_char_allocate",
             "c_mixin_function-assign-to-cvar",
-            "c_mixin_cdesc_char_fill_cvar"
+            "c_mixin_cdesc_fill_char"
         ]
     },
     {
@@ -2834,9 +2834,9 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-cvar",
-            "c_mixin_cdesc_char_fill_cvar",
+            "c_mixin_cdesc_fill_char",
             "f_mixin_cdesc_char_pointer"
         ]
     },
@@ -3079,7 +3079,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-local",
             "c_mixin_cdesc_function_string",
             "f_mixin_cdesc_char_pointer"
@@ -3294,7 +3294,7 @@
             "c_mixin_capsule_pass",
             "c_mixin_function-assign-to-new",
             "c_mixin_c-str",
-            "c_mixin_capsule_fill_native"
+            "c_mixin_capsule_fill_arg"
         ]
     },
     {
@@ -3348,11 +3348,11 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_capsule_pass",
             "c_mixin_function-assign-to-local",
             "c_mixin_cdesc_function_string",
-            "c_mixin_capsule_fill_native",
+            "c_mixin_capsule_fill_arg",
             "f_mixin_cdesc_char_allocate",
             "f_mixin_capsule_dtor"
         ]
@@ -3433,7 +3433,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-new",
             "c_mixin_destructor_new-string",
             "c_mixin_cdesc_function_string",
@@ -3449,11 +3449,11 @@
             "std::string func() +deref(pointer)+owner(caller)"
         ],
         "mixin": [
-            "f_mixin_capsule_arg",
+            "f_mixin_add_capsule_arg_to_fwrapper",
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_function-assign-to-new",
-            "c_mixin_capsule_fill_native",
+            "c_mixin_capsule_fill_arg",
             "c_mixin_cdesc_fill_string_local",
             "f_mixin_cdesc_char_pointer"
         ]
@@ -3465,11 +3465,11 @@
         ],
         "mixin": [
             "f_mixin_function_ptr",
-            "f_mixin_capsule_arg",
+            "f_mixin_add_capsule_arg_to_fwrapper",
             "c_mixin_function-return-cvar",
             "c_mixin_function-assign-to-new",
             "c_mixin_declare-string-data-cvar",
-            "c_mixin_capsule_fill_native"
+            "c_mixin_capsule_fill_arg"
         ]
     },
     {
@@ -3486,7 +3486,7 @@
             "f_mixin_str_array",
             "#f_mixin_declare-fortran-arg",
             "f_mixin_cdesc_char_fill",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_local-string*",
             "c_mixin_arg-call-cvar-address"
         ],
@@ -3518,12 +3518,12 @@
         "name": "f_out_string**_cdesc_allocatable",
         "mixin": [
             "f_mixin_declare-fortran-arg",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_capsule_pass",
             "f_mixin_cdesc_allocate_1d_character",
             "f_mixin_helper_array_string_allocatable",
             "c_mixin_arg-call-cvar-address",
-            "c_mixin_capsule_fill_native",
+            "c_mixin_capsule_fill_arg",
             "f_mixin_capsule_dtor"
         ]
     },
@@ -3723,7 +3723,7 @@
         "mixin": [
             "f_mixin_dummy_arg",
             "f_mixin_template_native_arg1",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_copy_array",
             "c_mixin_new_vector<native>",
             "c_mixin_arg-call-cxx"
@@ -3740,7 +3740,7 @@
         "mixin": [
             "f_mixin_dummy_arg",
             "f_mixin_template_native_arg1",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_copy_array",
             "c_mixin_new_vector<native>",
             "c_mixin_arg-call-cxx-deref"
@@ -3774,7 +3774,7 @@
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
             "f_mixin_template_native_arg1",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_allocate_1d",
             "c_mixin_destructor_new-vector",
             "c_mixin_cdesc_vector_fill",
@@ -3875,7 +3875,7 @@
             "{c_var_cdesc}->elem_len = {c_helper_vector_string_out_len}(*{c_local_cxx});",
             "-}}",
             "{c_var_cdesc}->size      = {c_local_cxx}->size();",
-            "// XXX - Use code from c_mixin_capsule_fill_native",
+            "// XXX - Use code from c_mixin_capsule_fill_arg",
             "{c_var_capsule}->addr  = {c_local_cxx};",
             "{c_var_capsule}->idtor = {idtor};"
         ],
@@ -4025,7 +4025,7 @@
             "f_mixin_dummy_arg",
             "f_mixin_template_native_arg1",
             "f_mixin_cdesc_char_fill",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "c_mixin_arg-call-cvar"
         ],
         "c_pre_call": [
@@ -4047,7 +4047,7 @@
         ],
         "mixin": [
             "f_mixin_declare-character-arg",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_capsule_pass",
             "f_mixin_cdesc_allocate_1d_character",
             "f_mixin_helper_vector_string_allocatable",
@@ -4076,7 +4076,7 @@
         "mixin": [
             "f_mixin_dummy_arg",
             "f_mixin_template_native_arg1",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_allocate_1d",
             "f_mixin_cdesc_copy_array",
             "c_mixin_new_vector<native>",
@@ -4729,7 +4729,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_native_pointer",
             "c_mixin_cdesc_getter"
         ]
@@ -4741,7 +4741,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_char_allocate",
             "c_mixin_getter_char*",
             "c_mixin_getter_char*_len",
@@ -4755,7 +4755,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_char_pointer",
             "c_mixin_getter_char*",
             "c_mixin_getter_char*_len",
@@ -4781,7 +4781,7 @@
         "name": "f_getter_struct**_cdesc_raw",
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_native_raw",
             "c_mixin_cdesc_getter"
         ]
@@ -4794,7 +4794,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_char_allocate",
             "c_mixin_getter_string"
         ],
@@ -4813,7 +4813,7 @@
         ],
         "mixin": [
             "f_mixin_call-cwrapper-as-subroutine",
-            "f_mixin_cdesc_pass",
+            "f_mixin_cdesc_pass_to_cwrapper",
             "f_mixin_cdesc_char_pointer",
             "c_mixin_getter_string"
         ],
@@ -5507,12 +5507,12 @@
             "std::string func() +deref(allocatable)"
         ],
         "mixin": [
-            "f_mixin_capsule_arg",
+            "f_mixin_add_capsule_arg_to_fwrapper",
             "f_mixin_call-cwrapper-as-subroutine",
             "f_mixin_cfi_character-deferred-length",
             "c_mixin_function-assign-to-new",
             "c_mixin_cfi_string*_pointer",
-            "c_mixin_capsule_fill_native"
+            "c_mixin_capsule_fill_arg"
         ],
         "f_need_wrapper": true
     },

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -115,23 +115,6 @@
         ]
     },
     {
-        "name": "f_mixin_declare-as-cptr",
-        "notes": [
-            "Used when there is no direct mapping to Fortran."
-        ],
-        "f_dummy_arg": [
-            "{f_var}"
-        ],
-        "f_dummy_decl": [
-            "type(C_PTR){f_intent_attr} :: {f_var}"
-        ],
-        "f_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        }
-    },
-    {
         "name": "f_mixin_declare-arg-as-cptr",
         "notes": [
             "Used when there is no direct mapping to Fortran.",
@@ -1657,7 +1640,8 @@
             "c_mixin_declare-arg",
             "c_mixin_arg-call-cvar",
             "f_mixin_interface-as-cptr-value",
-            "f_mixin_declare-as-cptr"
+            "f_mixin_dummy_arg",
+            "f_mixin_declare-arg-as-cptr"
         ]
     },
     {
@@ -1680,7 +1664,8 @@
             "c_mixin_declare-arg",
             "c_mixin_arg-call-cvar",
             "f_mixin_interface-as-cptr",
-            "f_mixin_declare-as-cptr"
+            "f_mixin_dummy_arg",
+            "f_mixin_declare-arg-as-cptr"
         ]
     },
     {


### PR DESCRIPTION
Work to move some behavior to a single group and use via mixins.
