### PR TITLE
Define PY_SSIZE_T_CLEAN

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
 #        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
-        python-version: [3.9]
+        python-version: [3.12]
 
     steps:
     - name: Check out repository

--- a/regression/reference/arrayclass/pyarrayclassmodule.hpp
+++ b/regression/reference/arrayclass/pyarrayclassmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYARRAYCLASSMODULE_HPP
 #define PYARRAYCLASSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/ccomplex/pyccomplexmodule.h
+++ b/regression/reference/ccomplex/pyccomplexmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYCCOMPLEXMODULE_H
 #define PYCCOMPLEXMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/char-cxx/pycharmodule.hpp
+++ b/regression/reference/char-cxx/pycharmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYCHARMODULE_HPP
 #define PYCHARMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/classes/pyclassesmodule.hpp
+++ b/regression/reference/classes/pyclassesmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYCLASSESMODULE_HPP
 #define PYCLASSESMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/clibrary/pyClibrarymodule.h
+++ b/regression/reference/clibrary/pyClibrarymodule.h
@@ -7,6 +7,7 @@
 #ifndef PYCLIBRARYMODULE_H
 #define PYCLIBRARYMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/cxxlibrary/pycxxlibrarymodule.hpp
+++ b/regression/reference/cxxlibrary/pycxxlibrarymodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYCXXLIBRARYMODULE_HPP
 #define PYCXXLIBRARYMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/debugfalse/pyTutorialmodule.hpp
+++ b/regression/reference/debugfalse/pyTutorialmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTUTORIALMODULE_HPP
 #define PYTUTORIALMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "tutorial.hpp"

--- a/regression/reference/enum-c/pyenummodule.h
+++ b/regression/reference/enum-c/pyenummodule.h
@@ -7,6 +7,7 @@
 #ifndef PYENUMMODULE_H
 #define PYENUMMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/enum-cxx/pyenummodule.hpp
+++ b/regression/reference/enum-cxx/pyenummodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYENUMMODULE_HPP
 #define PYENUMMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/error-fmt/pyerrormodule.hpp
+++ b/regression/reference/error-fmt/pyerrormodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYERRORMODULE_HPP
 #define PYERRORMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/error-generate/pyerrormodule.hpp
+++ b/regression/reference/error-generate/pyerrormodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYERRORMODULE_HPP
 #define PYERRORMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/error/pyerrormodule.hpp
+++ b/regression/reference/error/pyerrormodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYERRORMODULE_HPP
 #define PYERRORMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/example/pyUserLibrarymodule.hpp
+++ b/regression/reference/example/pyUserLibrarymodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYUSERLIBRARYMODULE_HPP
 #define PYUSERLIBRARYMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/forward/pyforwardmodule.hpp
+++ b/regression/reference/forward/pyforwardmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYFORWARDMODULE_HPP
 #define PYFORWARDMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -2347,7 +2347,7 @@
                         "PyArg_kwlist": "const_cast<char **>(SHT_kwlist)",
                         "PyArg_vargs": "&name",
                         "PyBuild_format": "s#i",
-                        "PyBuild_vargs": "SH_name.data(),\t SH_name.size(),\t value"
+                        "PyBuild_vargs": "SH_name.data(),\t (Py_ssize_t) SH_name.size(),\t value"
                     }
                 }
             },

--- a/regression/reference/names/pytestnamesmodule.hpp
+++ b/regression/reference/names/pytestnamesmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTESTNAMESMODULE_HPP
 #define PYTESTNAMESMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/namespace/pynsmodule.hpp
+++ b/regression/reference/namespace/pynsmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYNSMODULE_HPP
 #define PYNSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/namespacedoc/pywrappedmodule.hpp
+++ b/regression/reference/namespacedoc/pywrappedmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYWRAPPEDMODULE_HPP
 #define PYWRAPPEDMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // splicer begin header.include

--- a/regression/reference/none/def_types.yaml
+++ b/regression/reference/none/def_types.yaml
@@ -489,7 +489,7 @@ typemap:
       - <string>
       PY_format: s
       PY_ctor: PyString_FromStringAndSize({ctor_expr})
-      PY_build_arg: "{cxx_var}{cxx_member}data(), {cxx_var}{cxx_member}size()"
+      PY_build_arg: "{cxx_var}{cxx_member}data(), (Py_ssize_t) {cxx_var}{cxx_member}size()"
       PY_build_format: s#
       LUA_type: LUA_TSTRING
       LUA_pop: lua_tostring({LUA_state_var}, {LUA_index})

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -745,7 +745,7 @@
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushstring({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TSTRING",
-            "PY_build_arg": "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()",
+            "PY_build_arg": "{cxx_var}{cxx_member}data(),\t (Py_ssize_t) {cxx_var}{cxx_member}size()",
             "PY_build_format": "s#",
             "PY_ctor": "PyString_FromStringAndSize({ctor_expr})",
             "PY_format": "s",

--- a/regression/reference/ownership/pyownershipmodule.hpp
+++ b/regression/reference/ownership/pyownershipmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYOWNERSHIPMODULE_HPP
 #define PYOWNERSHIPMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/pointers-list-c/pypointersmodule.h
+++ b/regression/reference/pointers-list-c/pypointersmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYPOINTERSMODULE_H
 #define PYPOINTERSMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/pointers-list-cxx/pypointersmodule.hpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYPOINTERSMODULE_HPP
 #define PYPOINTERSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/pointers-numpy-c/pypointersmodule.h
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYPOINTERSMODULE_H
 #define PYPOINTERSMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.hpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYPOINTERSMODULE_HPP
 #define PYPOINTERSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/preprocess/pypreprocessmodule.hpp
+++ b/regression/reference/preprocess/pypreprocessmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYPREPROCESSMODULE_HPP
 #define PYPREPROCESSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/python-only/pyTutorialmodule.hpp
+++ b/regression/reference/python-only/pyTutorialmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTUTORIALMODULE_HPP
 #define PYTUTORIALMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/strings/pystringsmodule.cpp
+++ b/regression/reference/strings/pystringsmodule.cpp
@@ -731,8 +731,8 @@ PY_acceptStringPointerLen(
     acceptStringPointerLen(&SH_arg1, &nlen);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("s#i", SH_arg1.data(), SH_arg1.size(),
-        nlen);
+    SHTPy_rv = Py_BuildValue("s#i", SH_arg1.data(),
+        (Py_ssize_t) SH_arg1.size(), nlen);
 
     return SHTPy_rv;
 // splicer end function.acceptStringPointerLen
@@ -774,8 +774,8 @@ PY_fetchStringPointerLen(
     fetchStringPointerLen(&SH_arg1, &nlen);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("s#i", SH_arg1.data(), SH_arg1.size(),
-        nlen);
+    SHTPy_rv = Py_BuildValue("s#i", SH_arg1.data(),
+        (Py_ssize_t) SH_arg1.size(), nlen);
 
     return SHTPy_rv;
 // splicer end function.fetchStringPointerLen
@@ -858,8 +858,9 @@ PY_returnStrings(
     returnStrings(SH_arg1, SH_arg2);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("s#s#", SH_arg1.data(), SH_arg1.size(),
-        SH_arg2.data(), SH_arg2.size());
+    SHTPy_rv = Py_BuildValue("s#s#", SH_arg1.data(),
+        (Py_ssize_t) SH_arg1.size(), SH_arg2.data(),
+        (Py_ssize_t) SH_arg2.size());
 
     return SHTPy_rv;
 // splicer end function.returnStrings

--- a/regression/reference/strings/pystringsmodule.hpp
+++ b/regression/reference/strings/pystringsmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYSTRINGSMODULE_HPP
 #define PYSTRINGSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -4650,7 +4650,7 @@
                         "PyArg_kwlist": "const_cast<char **>(SHT_kwlist)",
                         "PyArg_vargs": "&arg1",
                         "PyBuild_format": "s#i",
-                        "PyBuild_vargs": "SH_arg1.data(),\t SH_arg1.size(),\t nlen"
+                        "PyBuild_vargs": "SH_arg1.data(),\t (Py_ssize_t) SH_arg1.size(),\t nlen"
                     }
                 }
             },
@@ -5035,7 +5035,7 @@
                         "PY_error_return": "nullptr",
                         "PY_ml_flags": "METH_NOARGS",
                         "PyBuild_format": "s#i",
-                        "PyBuild_vargs": "SH_arg1.data(),\t SH_arg1.size(),\t nlen"
+                        "PyBuild_vargs": "SH_arg1.data(),\t (Py_ssize_t) SH_arg1.size(),\t nlen"
                     }
                 }
             },
@@ -5508,7 +5508,7 @@
                         "PY_error_return": "nullptr",
                         "PY_ml_flags": "METH_NOARGS",
                         "PyBuild_format": "s#s#",
-                        "PyBuild_vargs": "SH_arg1.data(),\t SH_arg1.size(),\t SH_arg2.data(),\t SH_arg2.size()"
+                        "PyBuild_vargs": "SH_arg1.data(),\t (Py_ssize_t) SH_arg1.size(),\t SH_arg2.data(),\t (Py_ssize_t) SH_arg2.size()"
                     }
                 }
             },

--- a/regression/reference/struct-class-c/pystructmodule.h
+++ b/regression/reference/struct-class-c/pystructmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_H
 #define PYSTRUCTMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/struct-class-cxx/pystructmodule.hpp
+++ b/regression/reference/struct-class-cxx/pystructmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_HPP
 #define PYSTRUCTMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/struct-list-cxx/pystructmodule.hpp
+++ b/regression/reference/struct-list-cxx/pystructmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_HPP
 #define PYSTRUCTMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/struct-numpy-c/pystructmodule.h
+++ b/regression/reference/struct-numpy-c/pystructmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_H
 #define PYSTRUCTMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/struct-numpy-cxx/pystructmodule.hpp
+++ b/regression/reference/struct-numpy-cxx/pystructmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_HPP
 #define PYSTRUCTMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/struct-py-c/pystructmodule.h
+++ b/regression/reference/struct-py-c/pystructmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_H
 #define PYSTRUCTMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/struct-py-cxx/pystructmodule.hpp
+++ b/regression/reference/struct-py-cxx/pystructmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_HPP
 #define PYSTRUCTMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/structlist/pystructmodule.h
+++ b/regression/reference/structlist/pystructmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYSTRUCTMODULE_H
 #define PYSTRUCTMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/templates/pytemplatesmodule.hpp
+++ b/regression/reference/templates/pytemplatesmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTEMPLATESMODULE_HPP
 #define PYTEMPLATESMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/tutorial/pyTutorialmodule.hpp
+++ b/regression/reference/tutorial/pyTutorialmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTUTORIALMODULE_HPP
 #define PYTUTORIALMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/typedefs-c/pytypedefsmodule.h
+++ b/regression/reference/typedefs-c/pytypedefsmodule.h
@@ -7,6 +7,7 @@
 #ifndef PYTYPEDEFSMODULE_H
 #define PYTYPEDEFSMODULE_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/typedefs-cxx/pytypedefsmodule.hpp
+++ b/regression/reference/typedefs-cxx/pytypedefsmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTYPEDEFSMODULE_HPP
 #define PYTYPEDEFSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/types/pytypesmodule.hpp
+++ b/regression/reference/types/pytypesmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYTYPESMODULE_HPP
 #define PYTYPESMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/vectors-list/pyvectorsmodule.hpp
+++ b/regression/reference/vectors-list/pyvectorsmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYVECTORSMODULE_HPP
 #define PYVECTORSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/reference/vectors-numpy/pyvectorsmodule.hpp
+++ b/regression/reference/vectors-numpy/pyvectorsmodule.hpp
@@ -7,6 +7,7 @@
 #ifndef PYVECTORSMODULE_HPP
 #define PYVECTORSMODULE_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // cxx_header

--- a/regression/run/defaults.mk
+++ b/regression/run/defaults.mk
@@ -218,10 +218,12 @@ python.libs    = $(eval python.libs := $$(call shell,$(python.exe) \
   -c $(call sf_01,LIBS) 2>&1))$(python.libs)
 python.ldflags = $(eval python.ldflags := $$(call shell,$(python.exe) \
   -c $(call sf_01,LDFLAGS) 2>&1))$(python.ldflags)
-python.bldlibrary  = $(eval python.bldlibrary := $$(call shell,$(python.exe) \
-  -c $(call sf_01,BLDLIBRARY) 2>&1))$(python.bldlibrary)
+#python.bldlibrary  = $(eval python.bldlibrary := $$(call shell,$(python.exe) \
+#  -c $(call sf_01,BLDLIBRARY) 2>&1))$(python.bldlibrary)
 python.incdir   = $(eval python.incdir := $$(call shell,$(python.exe) \
   -c $(call sf_01,INCLUDEPY) 2>&1))$(python.incdir)
+python.ldversion = $(eval python.incdir := $$(call shell,$(python.exe) \
+  -c $(call sf_01,LDVERSION) 2>&1))$(python.incdir)
 
 # python 2.7
 # libpl      - .../lib/python2.7/config
@@ -232,6 +234,9 @@ python.incdir   = $(eval python.incdir := $$(call shell,$(python.exe) \
 # libpl      -  .../lib/python3.6/config-3.6m-x86_64-linux-gnu
 # libs       -  -lpthreads -ldl -lutil
 # bldlibrary - -L. -lpython3.6m
+
+# Required with anaconda build which does not have a static library.
+python.bldlibrary = -lpython$(python.ldversion)
 
 PYTHON_VER := $(shell $(PYTHON) -c "import sys;sys.stdout.write('{v[0]}.{v[1]}'.format(v=sys.version_info))")
 PLATFORM := $(shell $(PYTHON) -c "import sys, sysconfig;sys.stdout.write(sysconfig.get_platform())")

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -895,8 +895,7 @@ def default_typemap():
             PY_format="s",
             PY_ctor="PyString_FromStringAndSize({ctor_expr})",
             PY_build_format="s#",
-            # XXX need cast after PY_SSIZE_T_CLEAN
-            PY_build_arg="{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()",
+            PY_build_arg="{cxx_var}{cxx_member}data(),\t (Py_ssize_t) {cxx_var}{cxx_member}size()",
             LUA_type="LUA_TSTRING",
             LUA_pop="lua_tostring({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushstring({LUA_state_var}, {push_arg})",

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -2439,6 +2439,7 @@ return 1;""",
         output.extend(["#ifndef %s" % guard, "#define %s" % guard])
 
         output.append("")
+        output.append("#define PY_SSIZE_T_CLEAN")
         output.append("#include <Python.h>")
         self.header_type_include.write_headers(output)
 


### PR DESCRIPTION
From Python docs:
Note: On Python 3.12 and older, the macro PY_SSIZE_T_CLEAN must be defined before including Python.h to use all # variants of formats (s#, y#, etc.) explained below. This is not necessary on Python 3.13 and later.

Load Python tests with -lpythonx.y instead of pythonx.y.a.  Some installs of Python do not provide the static library, only shared.