### PR TITLE
changed fstrings to work with older versions of python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 top := $(CURDIR)
 
-PYTHONEXE := python3
+PYTHONEXE := python
 
 PYTHON := $(shell which $(PYTHONEXE))
 python.dir := $(dir $(PYTHON))

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -2590,7 +2590,8 @@ def check_deprecated_option(fmtdict):
             msg = f"option {fmt} is deprecated, changed to {info['new']}"
             details = info.get("details")
             if details:
-                msg += f"\n{'\n'.join(details)}"
+                details_str = '\n'.join(details)
+                msg += f"\n{details_str}"
             error.cursor.warning(msg)
 
 deprecated_formats = dict(
@@ -2610,5 +2611,6 @@ def check_deprecated_format(fmtdict):
             msg = f"format {fmt} is deprecated, changed to {info['new']}"
             details = info.get("details")
             if details:
-                msg += f"\n{'\n'.join(details)}"
+                details_str = '\n'.join(details)
+                msg += f"\n{details_str}"
             error.cursor.warning(msg)

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -1374,7 +1374,9 @@ class FormatGen(object):
         fmtshape = []
         for i, dim in enumerate(shape):
             fmtshape.append(f"{c_var_cdesc}->shape[{i}] = {dim};")
-        value = f"\n{'\n'.join(fmtshape)}"
+        
+        value = '\n'.join(fmtshape)
+        value = "\n" + value
         return value
 
     @property

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -987,7 +987,8 @@ rv = .false.
                 arg_f_use = self.sort_module_info(modules, fmt.F_module_name, imports)
                 iface.extend(arg_f_use)
                 if imports:
-                    iface.append(f"import :: {',\t '.join(sorted(imports.keys()))}")
+                    import_str = ',\t '.join(sorted(imports.keys()))
+                    iface.append(f"import :: {import_str}")
                 iface.append("implicit none")
                 iface.extend(dummy_decl_list)
                 iface.append(-1)
@@ -1231,7 +1232,8 @@ rv = .false.
         c_interface.append(1)
         c_interface.extend(arg_f_use)
         if imports:
-            c_interface.append(f"import :: {',\t '.join(sorted(imports.keys()))}")
+            import_str = ',\t '.join(sorted(imports.keys()))
+            c_interface.append(f"import :: {import_str}")
         c_interface.append("implicit none")
         c_interface.extend(dummy_decl_list)
         c_interface.append(-1)


### PR DESCRIPTION
This is a quick fix of the python f-strings for older versions of python3.
Prior to python 3.12 f-strings could not contain backslashes. As a result I was getting errors like this.
```
  File "/Users/janibal/.pyenv/versions/3.9.12/lib/python3.9/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/Users/janibal/.pyenv/versions/3.9.12/lib/python3.9/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/Users/janibal/repos/shroud/tests/__init__.py", line 13, in <module>
    from . import (test_ast, test_declast, test_format, test_generate,
  File "/Users/janibal/repos/shroud/tests/test_ast.py", line 8, in <module>
    from shroud import ast, declast, generate, typemap  # 
  File "/Users/janibal/repos/shroud/shroud/__init__.py", line 9, in <module>
    from .main import create_wrapper
  File "/Users/janibal/repos/shroud/shroud/main.py", line 19, in <module>
    from . import (ast, declast, fcfmt, generate, metaattrs, metadata, splicer,
  File "/Users/janibal/repos/shroud/shroud/wrapf.py", line 990
    iface.append(f"import :: {',\t '.join(sorted(imports.keys()))}")
                                                                   ^
SyntaxError: f-string expression part cannot include a backslash
make: *** [test] Error 1
```
To fix that I just broke up the lines with f-strings and backslashes into two lines.
